### PR TITLE
Changed integer suffix from 'u' to 'us'

### DIFF
--- a/alsa-sys/src/lib.rs
+++ b/alsa-sys/src/lib.rs
@@ -36,7 +36,7 @@ pub type __off64_t = ::libc::c_long;
 pub type __pid_t = ::libc::c_int;
 #[repr(C)]
 pub struct __fsid_t {
-    pub __val: [::libc::c_int; 2u],
+    pub __val: [::libc::c_int; 2us],
 }
 pub type __clock_t = ::libc::c_long;
 pub type __rlim_t = ::libc::c_ulong;
@@ -381,13 +381,13 @@ pub type FILE = Struct__IO_FILE;
 pub type __FILE = Struct__IO_FILE;
 #[repr(C)]
 pub struct Union_Unnamed4 {
-    pub data: [u32; 1u],
+    pub data: [u32; 1us],
 }
 impl Union_Unnamed4 {
     pub fn __wch(&mut self) -> *mut ::libc::c_uint {
         unsafe { ::std::mem::transmute(self) }
     }
-    pub fn __wchb(&mut self) -> *mut [::libc::c_char; 4u] {
+    pub fn __wchb(&mut self) -> *mut [::libc::c_char; 4us] {
         unsafe { ::std::mem::transmute(self) }
     }
 }
@@ -441,7 +441,7 @@ pub struct Struct__IO_FILE {
     pub _old_offset: __off_t,
     pub _cur_column: ::libc::c_ushort,
     pub _vtable_offset: ::libc::c_char,
-    pub _shortbuf: [::libc::c_char; 1u],
+    pub _shortbuf: [::libc::c_char; 1us],
     pub _lock: *mut _IO_lock_t,
     pub _offset: __off64_t,
     pub __pad1: *mut ::libc::c_void,
@@ -450,7 +450,7 @@ pub struct Struct__IO_FILE {
     pub __pad4: *mut ::libc::c_void,
     pub __pad5: size_t,
     pub _mode: ::libc::c_int,
-    pub _unused2: [::libc::c_char; 20u],
+    pub _unused2: [::libc::c_char; 20us],
 }
 pub type _IO_FILE = Struct__IO_FILE;
 pub enum Struct__IO_FILE_plus { }
@@ -463,7 +463,7 @@ pub type fpos_t = _G_fpos_t;
 pub type wchar_t = ::libc::c_int;
 #[repr(C)]
 pub struct Union_wait {
-    pub data: [u32; 1u],
+    pub data: [u32; 1us],
 }
 impl Union_wait {
     pub fn w_status(&mut self) -> *mut ::libc::c_int {
@@ -491,7 +491,7 @@ pub struct Struct_Unnamed6 {
 }
 #[repr(C)]
 pub struct __WAIT_STATUS {
-    pub data: [u64; 1u],
+    pub data: [u64; 1us],
 }
 impl __WAIT_STATUS {
     pub fn __uptr(&mut self) -> *mut *mut Union_wait {
@@ -551,7 +551,7 @@ pub type register_t = ::libc::c_long;
 pub type __sig_atomic_t = ::libc::c_int;
 #[repr(C)]
 pub struct __sigset_t {
-    pub __val: [::libc::c_ulong; 16u],
+    pub __val: [::libc::c_ulong; 16us],
 }
 pub type sigset_t = __sigset_t;
 #[repr(C)]
@@ -568,7 +568,7 @@ pub type suseconds_t = __suseconds_t;
 pub type __fd_mask = ::libc::c_long;
 #[repr(C)]
 pub struct fd_set {
-    pub __fds_bits: [__fd_mask; 16u],
+    pub __fds_bits: [__fd_mask; 16us],
 }
 pub type fd_mask = __fd_mask;
 pub type blksize_t = __blksize_t;
@@ -578,10 +578,10 @@ pub type fsfilcnt_t = __fsfilcnt_t;
 pub type pthread_t = ::libc::c_ulong;
 #[repr(C)]
 pub struct Union_pthread_attr_t {
-    pub data: [u64; 7u],
+    pub data: [u64; 7us],
 }
 impl Union_pthread_attr_t {
-    pub fn __size(&mut self) -> *mut [::libc::c_char; 56u] {
+    pub fn __size(&mut self) -> *mut [::libc::c_char; 56us] {
         unsafe { ::std::mem::transmute(self) }
     }
     pub fn __align(&mut self) -> *mut ::libc::c_long {
@@ -608,13 +608,13 @@ pub struct Struct___pthread_mutex_s {
 }
 #[repr(C)]
 pub struct pthread_mutex_t {
-    pub data: [u64; 5u],
+    pub data: [u64; 5us],
 }
 impl pthread_mutex_t {
     pub fn __data(&mut self) -> *mut Struct___pthread_mutex_s {
         unsafe { ::std::mem::transmute(self) }
     }
-    pub fn __size(&mut self) -> *mut [::libc::c_char; 40u] {
+    pub fn __size(&mut self) -> *mut [::libc::c_char; 40us] {
         unsafe { ::std::mem::transmute(self) }
     }
     pub fn __align(&mut self) -> *mut ::libc::c_long {
@@ -623,10 +623,10 @@ impl pthread_mutex_t {
 }
 #[repr(C)]
 pub struct pthread_mutexattr_t {
-    pub data: [u32; 1u],
+    pub data: [u32; 1us],
 }
 impl pthread_mutexattr_t {
-    pub fn __size(&mut self) -> *mut [::libc::c_char; 4u] {
+    pub fn __size(&mut self) -> *mut [::libc::c_char; 4us] {
         unsafe { ::std::mem::transmute(self) }
     }
     pub fn __align(&mut self) -> *mut ::libc::c_int {
@@ -646,13 +646,13 @@ pub struct Struct_Unnamed7 {
 }
 #[repr(C)]
 pub struct pthread_cond_t {
-    pub data: [u64; 6u],
+    pub data: [u64; 6us],
 }
 impl pthread_cond_t {
     pub fn __data(&mut self) -> *mut Struct_Unnamed7 {
         unsafe { ::std::mem::transmute(self) }
     }
-    pub fn __size(&mut self) -> *mut [::libc::c_char; 48u] {
+    pub fn __size(&mut self) -> *mut [::libc::c_char; 48us] {
         unsafe { ::std::mem::transmute(self) }
     }
     pub fn __align(&mut self) -> *mut ::libc::c_longlong {
@@ -661,10 +661,10 @@ impl pthread_cond_t {
 }
 #[repr(C)]
 pub struct pthread_condattr_t {
-    pub data: [u32; 1u],
+    pub data: [u32; 1us],
 }
 impl pthread_condattr_t {
-    pub fn __size(&mut self) -> *mut [::libc::c_char; 4u] {
+    pub fn __size(&mut self) -> *mut [::libc::c_char; 4us] {
         unsafe { ::std::mem::transmute(self) }
     }
     pub fn __align(&mut self) -> *mut ::libc::c_int {
@@ -689,13 +689,13 @@ pub struct Struct_Unnamed8 {
 }
 #[repr(C)]
 pub struct pthread_rwlock_t {
-    pub data: [u64; 7u],
+    pub data: [u64; 7us],
 }
 impl pthread_rwlock_t {
     pub fn __data(&mut self) -> *mut Struct_Unnamed8 {
         unsafe { ::std::mem::transmute(self) }
     }
-    pub fn __size(&mut self) -> *mut [::libc::c_char; 56u] {
+    pub fn __size(&mut self) -> *mut [::libc::c_char; 56us] {
         unsafe { ::std::mem::transmute(self) }
     }
     pub fn __align(&mut self) -> *mut ::libc::c_long {
@@ -704,10 +704,10 @@ impl pthread_rwlock_t {
 }
 #[repr(C)]
 pub struct pthread_rwlockattr_t {
-    pub data: [u64; 1u],
+    pub data: [u64; 1us],
 }
 impl pthread_rwlockattr_t {
-    pub fn __size(&mut self) -> *mut [::libc::c_char; 8u] {
+    pub fn __size(&mut self) -> *mut [::libc::c_char; 8us] {
         unsafe { ::std::mem::transmute(self) }
     }
     pub fn __align(&mut self) -> *mut ::libc::c_long {
@@ -717,10 +717,10 @@ impl pthread_rwlockattr_t {
 pub type pthread_spinlock_t = ::libc::c_int;
 #[repr(C)]
 pub struct pthread_barrier_t {
-    pub data: [u64; 4u],
+    pub data: [u64; 4us],
 }
 impl pthread_barrier_t {
-    pub fn __size(&mut self) -> *mut [::libc::c_char; 32u] {
+    pub fn __size(&mut self) -> *mut [::libc::c_char; 32us] {
         unsafe { ::std::mem::transmute(self) }
     }
     pub fn __align(&mut self) -> *mut ::libc::c_long {
@@ -729,10 +729,10 @@ impl pthread_barrier_t {
 }
 #[repr(C)]
 pub struct pthread_barrierattr_t {
-    pub data: [u32; 1u],
+    pub data: [u32; 1us],
 }
 impl pthread_barrierattr_t {
-    pub fn __size(&mut self) -> *mut [::libc::c_char; 4u] {
+    pub fn __size(&mut self) -> *mut [::libc::c_char; 4us] {
         unsafe { ::std::mem::transmute(self) }
     }
     pub fn __align(&mut self) -> *mut ::libc::c_int {
@@ -751,8 +751,8 @@ pub struct Struct_random_data {
 }
 #[repr(C)]
 pub struct Struct_drand48_data {
-    pub __x: [::libc::c_ushort; 3u],
-    pub __old_x: [::libc::c_ushort; 3u],
+    pub __x: [::libc::c_ushort; 3us],
+    pub __old_x: [::libc::c_ushort; 3us],
     pub __c: ::libc::c_ushort,
     pub __init: ::libc::c_ushort,
     pub __a: ::libc::c_ulonglong,
@@ -763,11 +763,11 @@ pub type __compar_fn_t =
                                arg2: *const ::libc::c_void) -> ::libc::c_int>;
 #[repr(C)]
 pub struct Struct___locale_struct {
-    pub __locales: [*mut Struct___locale_data; 13u],
+    pub __locales: [*mut Struct___locale_data; 13us],
     pub __ctype_b: *const ::libc::c_ushort,
     pub __ctype_tolower: *const ::libc::c_int,
     pub __ctype_toupper: *const ::libc::c_int,
-    pub __names: [*const ::libc::c_char; 13u],
+    pub __names: [*const ::libc::c_char; 13us],
 }
 pub enum Struct___locale_data { }
 pub type __locale_t = *mut Struct___locale_struct;
@@ -796,7 +796,7 @@ pub struct Struct_stat {
     pub st_atim: Struct_timespec,
     pub st_mtim: Struct_timespec,
     pub st_ctim: Struct_timespec,
-    pub __glibc_reserved: [__syscall_slong_t; 3u],
+    pub __glibc_reserved: [__syscall_slong_t; 3us],
 }
 pub type nfds_t = ::libc::c_ulong;
 #[repr(C)]
@@ -1060,16 +1060,16 @@ pub struct Struct__snd_pcm_channel_area {
 pub type snd_pcm_channel_area_t = Struct__snd_pcm_channel_area;
 #[repr(C)]
 pub struct Union__snd_pcm_sync_id {
-    pub data: [u32; 4u],
+    pub data: [u32; 4us],
 }
 impl Union__snd_pcm_sync_id {
-    pub fn id(&mut self) -> *mut [::libc::c_uchar; 16u] {
+    pub fn id(&mut self) -> *mut [::libc::c_uchar; 16us] {
         unsafe { ::std::mem::transmute(self) }
     }
-    pub fn id16(&mut self) -> *mut [::libc::c_ushort; 8u] {
+    pub fn id16(&mut self) -> *mut [::libc::c_ushort; 8us] {
         unsafe { ::std::mem::transmute(self) }
     }
-    pub fn id32(&mut self) -> *mut [::libc::c_uint; 4u] {
+    pub fn id32(&mut self) -> *mut [::libc::c_uint; 4us] {
         unsafe { ::std::mem::transmute(self) }
     }
 }
@@ -1124,7 +1124,7 @@ pub static SND_CHMAP_LAST: ::libc::c_uint = 36;
 #[repr(C)]
 pub struct Struct_snd_pcm_chmap {
     pub channels: ::libc::c_uint,
-    pub pos: [::libc::c_uint; 0u],
+    pub pos: [::libc::c_uint; 0us],
 }
 pub type snd_pcm_chmap_t = Struct_snd_pcm_chmap;
 #[repr(C)]
@@ -1297,10 +1297,10 @@ pub enum Struct__snd_hwdep { }
 pub type snd_hwdep_t = Struct__snd_hwdep;
 #[repr(C)]
 pub struct Struct_snd_aes_iec958 {
-    pub status: [::libc::c_uchar; 24u],
-    pub subcode: [::libc::c_uchar; 147u],
+    pub status: [::libc::c_uchar; 24us],
+    pub subcode: [::libc::c_uchar; 147us],
     pub pad: ::libc::c_uchar,
-    pub dig_subframe: [::libc::c_uchar; 4u],
+    pub dig_subframe: [::libc::c_uchar; 4us],
 }
 pub type snd_aes_iec958_t = Struct_snd_aes_iec958;
 pub enum Struct__snd_ctl_card_info { }
@@ -1504,7 +1504,7 @@ pub type snd_seq_real_time_t = Struct_snd_seq_real_time;
 pub type snd_seq_tick_time_t = ::libc::c_uint;
 #[repr(C)]
 pub struct Union_snd_seq_timestamp {
-    pub data: [u32; 2u],
+    pub data: [u32; 2us],
 }
 impl Union_snd_seq_timestamp {
     pub fn tick(&mut self) -> *mut snd_seq_tick_time_t {
@@ -1527,19 +1527,19 @@ pub type snd_seq_ev_note_t = Struct_snd_seq_ev_note;
 #[repr(C)]
 pub struct Struct_snd_seq_ev_ctrl {
     pub channel: ::libc::c_uchar,
-    pub unused: [::libc::c_uchar; 3u],
+    pub unused: [::libc::c_uchar; 3us],
     pub param: ::libc::c_uint,
     pub value: ::libc::c_int,
 }
 pub type snd_seq_ev_ctrl_t = Struct_snd_seq_ev_ctrl;
 #[repr(C)]
 pub struct Struct_snd_seq_ev_raw8 {
-    pub d: [::libc::c_uchar; 12u],
+    pub d: [::libc::c_uchar; 12us],
 }
 pub type snd_seq_ev_raw8_t = Struct_snd_seq_ev_raw8;
 #[repr(C)]
 pub struct Struct_snd_seq_ev_raw32 {
-    pub d: [::libc::c_uint; 3u],
+    pub d: [::libc::c_uint; 3us],
 }
 pub type snd_seq_ev_raw32_t = Struct_snd_seq_ev_raw32;
 #[repr(C)]
@@ -1563,12 +1563,12 @@ pub type snd_seq_queue_skew_t = Struct_snd_seq_queue_skew;
 #[repr(C)]
 pub struct Struct_snd_seq_ev_queue_control {
     pub queue: ::libc::c_uchar,
-    pub unused: [::libc::c_uchar; 3u],
+    pub unused: [::libc::c_uchar; 3us],
     pub param: Union_Unnamed9,
 }
 #[repr(C)]
 pub struct Union_Unnamed9 {
-    pub data: [u32; 2u],
+    pub data: [u32; 2us],
 }
 impl Union_Unnamed9 {
     pub fn value(&mut self) -> *mut ::libc::c_int {
@@ -1583,10 +1583,10 @@ impl Union_Unnamed9 {
     pub fn skew(&mut self) -> *mut snd_seq_queue_skew_t {
         unsafe { ::std::mem::transmute(self) }
     }
-    pub fn d32(&mut self) -> *mut [::libc::c_uint; 2u] {
+    pub fn d32(&mut self) -> *mut [::libc::c_uint; 2us] {
         unsafe { ::std::mem::transmute(self) }
     }
-    pub fn d8(&mut self) -> *mut [::libc::c_uchar; 8u] {
+    pub fn d8(&mut self) -> *mut [::libc::c_uchar; 8us] {
         unsafe { ::std::mem::transmute(self) }
     }
 }
@@ -1604,7 +1604,7 @@ pub struct Struct_snd_seq_event {
 }
 #[repr(C)]
 pub struct Union_Unnamed10 {
-    pub data: [u32; 3u],
+    pub data: [u32; 3us],
 }
 impl Union_Unnamed10 {
     pub fn note(&mut self) -> *mut snd_seq_ev_note_t {
@@ -1720,10 +1720,10 @@ extern "C" {
     pub static mut stderr: *mut Struct__IO_FILE;
     pub static mut sys_nerr: ::libc::c_int;
     pub static mut sys_errlist: *const *const ::libc::c_char;
-    pub static mut __tzname: [*mut ::libc::c_char; 2u];
+    pub static mut __tzname: [*mut ::libc::c_char; 2us];
     pub static mut __daylight: ::libc::c_int;
     pub static mut __timezone: ::libc::c_long;
-    pub static mut tzname: [*mut ::libc::c_char; 2u];
+    pub static mut tzname: [*mut ::libc::c_char; 2us];
     pub static mut daylight: ::libc::c_int;
     pub static mut timezone: ::libc::c_long;
     pub static mut snd_dlsym_start: *mut Struct_snd_dlsym_link;
@@ -1746,7 +1746,7 @@ extern "C" {
                  __nbytes: size_t, __offset: __off_t) -> ssize_t;
     pub fn pwrite(__fd: ::libc::c_int, __buf: *const ::libc::c_void,
                   __n: size_t, __offset: __off_t) -> ssize_t;
-    pub fn pipe(__pipedes: [::libc::c_int; 2u]) -> ::libc::c_int;
+    pub fn pipe(__pipedes: [::libc::c_int; 2us]) -> ::libc::c_int;
     pub fn alarm(__seconds: ::libc::c_uint) -> ::libc::c_uint;
     pub fn sleep(__seconds: ::libc::c_uint) -> ::libc::c_uint;
     pub fn ualarm(__value: __useconds_t, __interval: __useconds_t) ->
@@ -2096,35 +2096,35 @@ extern "C" {
     pub fn srand(__seed: ::libc::c_uint);
     pub fn rand_r(__seed: *mut ::libc::c_uint) -> ::libc::c_int;
     pub fn drand48() -> ::libc::c_double;
-    pub fn erand48(__xsubi: [::libc::c_ushort; 3u]) -> ::libc::c_double;
+    pub fn erand48(__xsubi: [::libc::c_ushort; 3us]) -> ::libc::c_double;
     pub fn lrand48() -> ::libc::c_long;
-    pub fn nrand48(__xsubi: [::libc::c_ushort; 3u]) -> ::libc::c_long;
+    pub fn nrand48(__xsubi: [::libc::c_ushort; 3us]) -> ::libc::c_long;
     pub fn mrand48() -> ::libc::c_long;
-    pub fn jrand48(__xsubi: [::libc::c_ushort; 3u]) -> ::libc::c_long;
+    pub fn jrand48(__xsubi: [::libc::c_ushort; 3us]) -> ::libc::c_long;
     pub fn srand48(__seedval: ::libc::c_long);
-    pub fn seed48(__seed16v: [::libc::c_ushort; 3u]) ->
+    pub fn seed48(__seed16v: [::libc::c_ushort; 3us]) ->
      *mut ::libc::c_ushort;
-    pub fn lcong48(__param: [::libc::c_ushort; 7u]);
+    pub fn lcong48(__param: [::libc::c_ushort; 7us]);
     pub fn drand48_r(__buffer: *mut Struct_drand48_data,
                      __result: *mut ::libc::c_double) -> ::libc::c_int;
-    pub fn erand48_r(__xsubi: [::libc::c_ushort; 3u],
+    pub fn erand48_r(__xsubi: [::libc::c_ushort; 3us],
                      __buffer: *mut Struct_drand48_data,
                      __result: *mut ::libc::c_double) -> ::libc::c_int;
     pub fn lrand48_r(__buffer: *mut Struct_drand48_data,
                      __result: *mut ::libc::c_long) -> ::libc::c_int;
-    pub fn nrand48_r(__xsubi: [::libc::c_ushort; 3u],
+    pub fn nrand48_r(__xsubi: [::libc::c_ushort; 3us],
                      __buffer: *mut Struct_drand48_data,
                      __result: *mut ::libc::c_long) -> ::libc::c_int;
     pub fn mrand48_r(__buffer: *mut Struct_drand48_data,
                      __result: *mut ::libc::c_long) -> ::libc::c_int;
-    pub fn jrand48_r(__xsubi: [::libc::c_ushort; 3u],
+    pub fn jrand48_r(__xsubi: [::libc::c_ushort; 3us],
                      __buffer: *mut Struct_drand48_data,
                      __result: *mut ::libc::c_long) -> ::libc::c_int;
     pub fn srand48_r(__seedval: ::libc::c_long,
                      __buffer: *mut Struct_drand48_data) -> ::libc::c_int;
-    pub fn seed48_r(__seed16v: [::libc::c_ushort; 3u],
+    pub fn seed48_r(__seed16v: [::libc::c_ushort; 3us],
                     __buffer: *mut Struct_drand48_data) -> ::libc::c_int;
-    pub fn lcong48_r(__param: [::libc::c_ushort; 7u],
+    pub fn lcong48_r(__param: [::libc::c_ushort; 7us],
                      __buffer: *mut Struct_drand48_data) -> ::libc::c_int;
     pub fn malloc(__size: size_t) -> *mut ::libc::c_void;
     pub fn calloc(__nmemb: size_t, __size: size_t) -> *mut ::libc::c_void;


### PR DESCRIPTION
I was really happy to find your work on cpal, as I'm interested in using rust for audio programming.

I changed the suffixes on ints in alsa from 'u' to 'us' as per compiler output in Rust alpha. 

Jason