### PR TITLE
Add more detailed message to panic

### DIFF
--- a/src/wasapi/mod.rs
+++ b/src/wasapi/mod.rs
@@ -41,7 +41,7 @@ impl Voice {
     pub fn get_samples_format(&self) -> ::SampleFormat {
         match self.bits_per_sample {
             16 => ::SampleFormat::I16,
-            _ => unimplemented!(),
+            _ => panic!("{}-bit format not yet supported", self.bits_per_sample),
         }
     }
 


### PR DESCRIPTION
When samples format is not supported, cpal panics with "not yet implemented" message, which is not useful in bug reports.
This adds samples format to the message.

Signed-off-by: Mariusz Ceier <mceier+cpal@gmail.com>