### PR TITLE
Endpoints and formats enumeration for ALSA backend

### DIFF
--- a/examples/enumerate.rs
+++ b/examples/enumerate.rs
@@ -1,0 +1,18 @@
+
+extern crate cpal;
+
+use cpal::*;
+
+fn main() {
+    let endpoints = cpal::get_endpoints_list();
+    
+    println!("Endpoints: ");
+    for (endpoint_index, endpoint) in endpoints.enumerate() {
+        println!("{}. Endpoint \"{}\" Audio formats: ", endpoint_index + 1, endpoint.get_name());
+        let formats = endpoint.get_supported_formats_list().unwrap();
+        for (format_index, format) in formats.enumerate() {
+            println!("{}.{}. {:?}", endpoint_index+1, format_index+1, format);
+        }
+    }
+}
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,6 +96,11 @@ pub fn get_default_endpoint() -> Option<Endpoint> {
 pub struct Endpoint(cpal_impl::Endpoint);
 
 impl Endpoint {
+    /// Returns name of the endpoint
+    pub fn get_name(&self) -> String {
+        self.0.get_name()
+    }
+
     /// Returns an iterator that produces the list of formats that are supported by the backend.
     pub fn get_supported_formats_list(&self) -> Result<SupportedFormatsIterator,
                                                        FormatsEnumerationError>

--- a/src/null/mod.rs
+++ b/src/null/mod.rs
@@ -25,6 +25,11 @@ pub fn get_default_endpoint() -> Option<Endpoint> {
 pub struct Endpoint;
 
 impl Endpoint {
+    
+    pub fn get_name(&self) -> String {
+        String::from("null")
+    }
+
     pub fn get_supported_formats_list(&self)
             -> Result<SupportedFormatsIterator, FormatsEnumerationError>
     {

--- a/src/wasapi/mod.rs
+++ b/src/wasapi/mod.rs
@@ -71,6 +71,11 @@ unsafe impl Send for Endpoint {}
 unsafe impl Sync for Endpoint {}
 
 impl Endpoint {
+
+    pub fn get_name(&self) -> String {
+        String::from("wasapi") // FIXME: placeholder,  self.device.GetId()
+    }
+
     #[inline]
     fn from_immdevice(device: *mut winapi::IMMDevice) -> Endpoint {
         Endpoint {


### PR DESCRIPTION
Includes changes from alsa-formats branch; default endpoint is not default, but the first found; and there's some memory leak according to valgrind.
