### PR TITLE
Restore CoreAudio support after API overhaul.

### DIFF
--- a/src/coreaudio/enumerate.rs
+++ b/src/coreaudio/enumerate.rs
@@ -1,0 +1,29 @@
+use super::Endpoint;
+
+use ::Format;
+
+use std::vec::IntoIter as VecIntoIter;
+
+pub struct EndpointsIterator(bool);
+
+unsafe impl Send for EndpointsIterator {}
+unsafe impl Sync for EndpointsIterator {}
+
+impl Default for EndpointsIterator {
+    fn default() -> Self {
+        EndpointsIterator(false)
+    }
+}
+
+impl Iterator for EndpointsIterator {
+    type Item = Endpoint;
+    fn next(&mut self) -> Option<Endpoint> {
+        if self.0 { None } else { self.0 = true; Some(Endpoint) }
+    }
+}
+
+pub fn get_default_endpoint() -> Option<Endpoint> {
+    Some(Endpoint)
+}
+
+pub type SupportedFormatsIterator = VecIntoIter<Format>;

--- a/src/coreaudio/mod.rs
+++ b/src/coreaudio/mod.rs
@@ -28,7 +28,7 @@ impl Endpoint {
     {
         Ok(vec!(Format {
             channels: vec![ChannelPosition::FrontLeft, ChannelPosition::FrontRight],
-            samples_rate: SamplesRate(64),
+            samples_rate: SamplesRate(44100),
             data_type: SampleFormat::F32
         }).into_iter())
     }

--- a/src/coreaudio/mod.rs
+++ b/src/coreaudio/mod.rs
@@ -10,6 +10,7 @@ use FormatsEnumerationError;
 use SampleFormat;
 use SamplesRate;
 use ChannelPosition;
+use Sample;
 
 mod enumerate;
 
@@ -26,11 +27,21 @@ impl Endpoint {
     pub fn get_supported_formats_list(&self)
             -> Result<SupportedFormatsIterator, FormatsEnumerationError>
     {
-        Ok(vec!(Format {
-            channels: vec![ChannelPosition::FrontLeft, ChannelPosition::FrontRight],
-            samples_rate: SamplesRate(44100),
-            data_type: SampleFormat::F32
-        }).into_iter())
+        // AUHAL converts internally for simple PCM translations.
+        // However, an additional AudioConverter unit is needed in order to
+        // change sample rate.
+        // TODO support other sample rates.
+        let formats = [SampleFormat::F32, SampleFormat::I16, SampleFormat::U16]
+            .into_iter()
+            .map(|f| {
+                Format {
+                    channels: vec![ChannelPosition::FrontLeft, ChannelPosition::FrontRight],
+                    samples_rate: SamplesRate(44100),
+                    data_type: *f
+                }
+            })
+            .collect::<Vec<_>>();
+        Ok(formats.into_iter())
     }
 
     pub fn get_name(&self) -> String {
@@ -46,7 +57,7 @@ pub struct Buffer<'a, T: 'a> {
     marker: ::std::marker::PhantomData<&'a T>,
 }
 
-impl<'a, T> Buffer<'a, T> {
+impl<'a, T: Sample> Buffer<'a, T> {
     #[inline]
     pub fn get_buffer<'b>(&'b mut self) -> &'b mut [T] {
         &mut self.samples[..]
@@ -62,7 +73,8 @@ impl<'a, T> Buffer<'a, T> {
         let Buffer { samples_sender, samples, num_channels, .. } = self;
         // TODO: At the moment this assumes the Vec<T> is a Vec<f32>.
         // Need to add T: Sample and use Sample::to_vec_f32.
-        let samples = unsafe { mem::transmute(samples) };
+        //let samples = unsafe { mem::transmute(samples) };
+        let samples = samples.into_iter().map(|x| x.as_f32()).collect();
         match samples_sender.send((samples, num_channels)) {
             Err(_) => panic!("Failed to send samples to audio unit callback."),
             Ok(()) => (),

--- a/src/coreaudio/mod.rs
+++ b/src/coreaudio/mod.rs
@@ -28,7 +28,7 @@ impl Endpoint {
     {
         Ok(vec!(Format {
             channels: vec![ChannelPosition::FrontLeft, ChannelPosition::FrontRight],
-            samples_rate: SamplesRate(512),
+            samples_rate: SamplesRate(64),
             data_type: SampleFormat::F32
         }).into_iter())
     }
@@ -78,6 +78,9 @@ pub struct Voice {
     ready_receiver: Receiver<(NumChannels, NumFrames)>,
     samples_sender: Sender<(Vec<f32>, NumChannels)>,
 }
+
+unsafe impl Sync for Voice {}
+unsafe impl Send for Voice {}
 
 impl Voice {
     pub fn new(endpoint: &Endpoint, format: &Format) -> Result<Voice, CreationError> {
@@ -133,7 +136,7 @@ impl Voice {
                     samples: vec![unsafe{ mem::uninitialized() }; buffer_size],
                     num_channels: channels as usize,
                     marker: ::std::marker::PhantomData,
-                    len: 512
+                    len: 64
                 }
             }
         }

--- a/src/coreaudio/mod.rs
+++ b/src/coreaudio/mod.rs
@@ -42,7 +42,6 @@ pub struct Buffer<'a, T: 'a> {
     samples_sender: Sender<(Vec<f32>, NumChannels)>,
     samples: Vec<T>,
     num_channels: NumChannels,
-    len: usize,
     marker: ::std::marker::PhantomData<&'a T>,
 }
 
@@ -54,7 +53,7 @@ impl<'a, T> Buffer<'a, T> {
 
     #[inline]
     pub fn len(&self) -> usize {
-        self.len
+        self.samples.len()
     }
 
     #[inline]
@@ -135,8 +134,7 @@ impl Voice {
                     samples_sender: self.samples_sender.clone(),
                     samples: vec![unsafe{ mem::uninitialized() }; buffer_size],
                     num_channels: channels as usize,
-                    marker: ::std::marker::PhantomData,
-                    len: 64
+                    marker: ::std::marker::PhantomData
                 }
             }
         }
@@ -152,11 +150,13 @@ impl Voice {
         unimplemented!()
     }
 
+    #[inline]
     pub fn get_pending_samples(&self) -> usize {
-        0
+        unimplemented!()
     }
 
+    #[inline]
     pub fn underflowed(&self) -> bool {
-        false
+        unimplemented!()
     }
 }

--- a/src/samples_formats.rs
+++ b/src/samples_formats.rs
@@ -27,7 +27,6 @@ impl SampleFormat {
 pub unsafe trait Sample: Copy + Clone {
     /// Returns the `SampleFormat` corresponding to this data type.
     fn get_format() -> SampleFormat;
-    fn as_f32(&self) -> f32;
 }
 
 unsafe impl Sample for u16 {
@@ -35,8 +34,6 @@ unsafe impl Sample for u16 {
     fn get_format() -> SampleFormat {
         SampleFormat::U16
     }
-
-    fn as_f32(&self) -> f32 { (*self as f32 - 32768.0) / (32768.0) }
 }
 
 unsafe impl Sample for i16 {
@@ -44,8 +41,6 @@ unsafe impl Sample for i16 {
     fn get_format() -> SampleFormat {
         SampleFormat::I16
     }
-
-    fn as_f32(&self) -> f32 { (*self as f32) / (32768.0) }
 }
 
 unsafe impl Sample for f32 {
@@ -53,6 +48,4 @@ unsafe impl Sample for f32 {
     fn get_format() -> SampleFormat {
         SampleFormat::F32
     }
-
-    fn as_f32(&self) -> f32 { *self }
 }

--- a/src/samples_formats.rs
+++ b/src/samples_formats.rs
@@ -27,6 +27,7 @@ impl SampleFormat {
 pub unsafe trait Sample: Copy + Clone {
     /// Returns the `SampleFormat` corresponding to this data type.
     fn get_format() -> SampleFormat;
+    fn as_f32(&self) -> f32;
 }
 
 unsafe impl Sample for u16 {
@@ -34,6 +35,8 @@ unsafe impl Sample for u16 {
     fn get_format() -> SampleFormat {
         SampleFormat::U16
     }
+
+    fn as_f32(&self) -> f32 { (*self as f32 - 32768.0) / (32768.0) }
 }
 
 unsafe impl Sample for i16 {
@@ -41,6 +44,8 @@ unsafe impl Sample for i16 {
     fn get_format() -> SampleFormat {
         SampleFormat::I16
     }
+
+    fn as_f32(&self) -> f32 { (*self as f32) / (32768.0) }
 }
 
 unsafe impl Sample for f32 {
@@ -48,4 +53,6 @@ unsafe impl Sample for f32 {
     fn get_format() -> SampleFormat {
         SampleFormat::F32
     }
+
+    fn as_f32(&self) -> f32 { *self }
 }


### PR DESCRIPTION
Since the API changes, compilation on OSX fails. This restores compilation and the features that the CoreAudio backend was originally capable of (that is to say, only f32 samples and a fixed buffer size).

~~The most recent commit adds support-ish for U16/I16. AUHAL is able to convert between PCM formats internally, but we are doing it Rust-side before sending the buffer to the unit.~~