### PR TITLE
Catch another 'device not found' error code with ALSA

### DIFF
--- a/src/alsa/mod.rs
+++ b/src/alsa/mod.rs
@@ -32,6 +32,7 @@ impl Endpoint {
             match alsa::snd_pcm_open(&mut playback_handle, device_name.as_ptr() as *const _,
                                      alsa::SND_PCM_STREAM_PLAYBACK, alsa::SND_PCM_NONBLOCK)
             {   
+                -2 |
                 -16 /* determined empirically */ => return Err(FormatsEnumerationError::DeviceNotAvailable),
                 e => check_errors(e).unwrap()
             }


### PR DESCRIPTION
On a device with no sound (such as [Travis-CI][travis]) I could get a default endpoint but enumerating the formats would then panic. This patch adds the error code that my case returned, and which I believe should be caught instead of panic.

Looking at the code, I think a more rigorous change would be nice, but in the meantime I propose merging this fix.

[travis]: https://travis-ci.org/mvdnes/rboy/builds/85080893