### PR TITLE
allow for building for mipsel targets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,10 @@ lazy_static = "0.1"
 winapi = "0.2.5"
 ole32-sys = "0.1"
 
+[target.mipsel-unknown-linux-gnu.dependencies.alsa-sys]
+version = "0"
+path = "alsa-sys"
+
 [target.i686-unknown-linux-gnu.dependencies.alsa-sys]
 version = "0"
 path = "alsa-sys"


### PR DESCRIPTION
mipsel is mostly used on embedded multimedia devices like settop bockes for eg.
This change will allow building cpal for those platforms aswell