### PR TITLE
Fix underflow detection for alsa

### DIFF
--- a/src/alsa/mod.rs
+++ b/src/alsa/mod.rs
@@ -317,8 +317,8 @@ impl Voice {
     pub fn underflowed(&self) -> bool {
         let channel = self.channel.lock().expect("channel underflow");
 
-        let state = unsafe { alsa::snd_pcm_state(*channel) };
-        state == alsa::SND_PCM_STATE_XRUN
+        let available = unsafe { alsa::snd_pcm_avail(*channel) };
+        available == -32
     }
 }
 


### PR DESCRIPTION
The old method always returned _RUNNING on some machines.
This new method seems to produce the expected behaviour.

Note: -32 is probably -EPIPE, but the appropriate constant was not
available at this time.