### PR TITLE
Update coreaudio backend to new futures-rs oriented design introduced in #121. Take 2.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ version = "0"
 path = "alsa-sys"
 
 [target.x86_64-apple-darwin.dependencies]
-coreaudio-rs = "~0.5.0"
+coreaudio-rs = "0.6"
 
 [dev-dependencies]
 vorbis = "0"


### PR DESCRIPTION
This is a follow up to (and is based upon) the changes introduced in #121.

The beep example runs fine for me and `cargo test` passes on my machine.

Tested on OS X 10.10.5.

Closes #104.