### PR TITLE
update to futures 0.1.1: alsa wasapi

### DIFF
--- a/src/null/mod.rs
+++ b/src/null/mod.rs
@@ -3,8 +3,8 @@
 use std::marker::PhantomData;
 
 use futures::Poll;
-use futures::Task;
 use futures::stream::Stream;
+use futures::Async;
 
 use CreationError;
 use Format;
@@ -89,12 +89,8 @@ impl Stream for SamplesStream {
     type Error = ();
 
     #[inline]
-    fn poll(&mut self, _: &mut Task) -> Poll<Option<Self::Item>, Self::Error> {
-        Poll::NotReady
-    }
-
-    #[inline]
-    fn schedule(&mut self, _: &mut Task) {
+    fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
+        Ok(Async::NotReady)
     }
 }
 


### PR DESCRIPTION
here is a try to update cpal to use futures 0.1.1 instead of yanked futures 0.1.0, it is related to issue 129

change is made on streams: when poll return not ready, the function schedule the task on the event loop.

also there is change for users: in beep example the user spawn a task for the stream and use its own executor to handle its execution.

current state of this branch:
* alsa is OK for me: beep example works.
* wasapi compile but the execution on wine of beep.exe sounds crap
* coreaudio nothing has been made