### PR TITLE
Do not lock inner twice. Fixes bug in osx futures 0.1.1 update.

### DIFF
--- a/src/coreaudio/mod.rs
+++ b/src/coreaudio/mod.rs
@@ -114,7 +114,7 @@ impl Stream for SamplesStream {
         let current_callback = match inner.current_callback.take() {
             Some(c) => c,
             None => {
-                self.inner.lock().unwrap().scheduled_task = Some(task::park());
+                inner.scheduled_task = Some(task::park());
                 return Ok(Async::NotReady);
             }
         };


### PR DESCRIPTION
After applying this, #131 works for me (beep example works fine) :+1: