### PR TITLE
Changed getters to match rust convention as pointed out in issue #91

### DIFF
--- a/alsa-sys/build.rs
+++ b/alsa-sys/build.rs
@@ -1,5 +1,7 @@
 extern crate pkg_config;
 
 fn main() {
-    pkg_config::find_library("alsa").unwrap();
+    pkg_config::find_library("alsa")
+        .expect("It seems you have no alsa dev package.\
+On Ubuntu based systems you can install it with 'sudo apt install libasound2-dev'.");
 }

--- a/examples/beep.rs
+++ b/examples/beep.rs
@@ -19,8 +19,8 @@ impl Executor for MyExecutor {
 }
 
 fn main() {
-    let endpoint = cpal::get_default_endpoint().expect("Failed to get default endpoint");
-    let format = endpoint.get_supported_formats_list().unwrap().next().expect("Failed to get endpoint format");
+    let endpoint = cpal::Endpoint::default_endpoint().expect("Failed to get default endpoint");
+    let format = endpoint.supported_formats().unwrap().next().expect("Failed to get endpoint format");
 
     let event_loop = cpal::EventLoop::new();
     let executor = Arc::new(MyExecutor);

--- a/examples/enumerate.rs
+++ b/examples/enumerate.rs
@@ -1,13 +1,13 @@
 extern crate cpal;
 
 fn main() {
-    let endpoints = cpal::get_endpoints_list();
+    let endpoints = cpal::Endpoint::endpoints();
     
     println!("Endpoints: ");
     for (endpoint_index, endpoint) in endpoints.enumerate() {
-        println!("{}. Endpoint \"{}\" Audio formats: ", endpoint_index + 1, endpoint.get_name());
+        println!("{}. Endpoint \"{}\" Audio formats: ", endpoint_index + 1, endpoint.name());
 
-        let formats = match endpoint.get_supported_formats_list() {
+        let formats = match endpoint.supported_formats() {
             Ok(f) => f,
             Err(e) => { println!("Error: {:?}", e); continue; }
         };

--- a/src/alsa/enumerate.rs
+++ b/src/alsa/enumerate.rs
@@ -112,8 +112,3 @@ impl Iterator for EndpointsIterator {
         }
     }
 }
-
-#[inline]
-pub fn get_default_endpoint() -> Option<Endpoint> {
-    Some(Endpoint("default".to_owned()))
-}

--- a/src/alsa/mod.rs
+++ b/src/alsa/mod.rs
@@ -1,7 +1,7 @@
 extern crate alsa_sys as alsa;
 extern crate libc;
 
-pub use self::enumerate::{EndpointsIterator, get_default_endpoint};
+pub use self::enumerate::{EndpointsIterator};
 
 use ChannelPosition;
 use CreationError;
@@ -30,7 +30,12 @@ mod enumerate;
 pub struct Endpoint(String);
 
 impl Endpoint {
-    pub fn get_supported_formats_list(&self)
+    #[inline]
+    pub fn default_endpoint() -> Option<Endpoint> {
+        Some(Endpoint("default".to_owned()))
+    }
+
+    pub fn supported_formats(&self)
             -> Result<SupportedFormatsIterator, FormatsEnumerationError>
     {
         unsafe {
@@ -51,7 +56,7 @@ impl Endpoint {
                 Ok(_) => ()
             };
 
-            // TODO: check endianess
+            // TODO: check endianness
             const FORMATS: [(SampleFormat, alsa::snd_pcm_format_t); 3] = [
                 //SND_PCM_FORMAT_S8,
                 //SND_PCM_FORMAT_U8,
@@ -177,7 +182,7 @@ impl Endpoint {
     }
 
     #[inline]
-    pub fn get_name(&self) -> String {
+    pub fn name(&self) -> String {
         self.0.clone()
     }
 }
@@ -653,7 +658,7 @@ impl Drop for VoiceInner {
 
 impl<T> Buffer<T> {
     #[inline]
-    pub fn get_buffer(&mut self) -> &mut [T] {
+    pub fn buffer(&mut self) -> &mut [T] {
         &mut self.buffer
     }
 
@@ -694,7 +699,7 @@ fn check_errors(err: libc::c_int) -> Result<(), String> {
     if err < 0 {
         unsafe {
             let s = ffi::CStr::from_ptr(alsa::snd_strerror(err)).to_bytes().to_vec();
-            let s = String::from_utf8(s).expect("Streaming error occured");
+            let s = String::from_utf8(s).expect("Streaming error occurred");
             return Err(s);
         }
     }

--- a/src/coreaudio/enumerate.rs
+++ b/src/coreaudio/enumerate.rs
@@ -22,8 +22,4 @@ impl Iterator for EndpointsIterator {
     }
 }
 
-pub fn get_default_endpoint() -> Option<Endpoint> {
-    Some(Endpoint)
-}
-
 pub type SupportedFormatsIterator = VecIntoIter<Format>;

--- a/src/coreaudio/mod.rs
+++ b/src/coreaudio/mod.rs
@@ -23,14 +23,17 @@ use self::coreaudio::audio_unit::render_callback::{self, data};
 mod enumerate;
 
 pub use self::enumerate::{EndpointsIterator,
-                          SupportedFormatsIterator,
-                          get_default_endpoint};
+                          SupportedFormatsIterator};
 
 #[derive(Clone, PartialEq, Eq)]
 pub struct Endpoint;
 
 impl Endpoint {
-    pub fn get_supported_formats_list(&self)
+    pub fn default_endpoint() -> Option<Endpoint> {
+        Some(Endpoint)
+    }
+
+    pub fn supported_formats(&self)
             -> Result<SupportedFormatsIterator, FormatsEnumerationError>
     {
         Ok(vec!(Format {
@@ -40,7 +43,7 @@ impl Endpoint {
         }).into_iter())
     }
 
-    pub fn get_name(&self) -> String {
+    pub fn name(&self) -> String {
         "Default AudioUnit Endpoint".to_string()
     }
 }
@@ -60,7 +63,7 @@ pub struct Buffer<T> {
 
 impl<T> Buffer<T> where T: Sample {
     #[inline]
-    pub fn get_buffer(&mut self) -> &mut [T] {
+    pub fn buffer(&mut self) -> &mut [T] {
         &mut self.buffer[..]
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,13 +5,13 @@ In order to play a sound, first you need to create an `EventLoop` and a `Voice`.
 
 ```no_run
 // getting the default sound output of the system (can return `None` if nothing is supported)
-let endpoint = cpal::get_default_endpoint().unwrap();
+let endpoint = cpal::Endpoint::default_endpoint().unwrap();
 
 // note that the user can at any moment disconnect the device, therefore all operations return
 // a `Result` to handle this situation
 
 // getting a format for the PCM
-let format = endpoint.get_supported_formats_list().unwrap().next().unwrap();
+let format = endpoint.supported_formats().unwrap().next().unwrap();
 
 let event_loop = cpal::EventLoop::new();
 
@@ -118,35 +118,35 @@ impl Iterator for EndpointsIterator {
     }
 }
 
-/// Return an iterator to the list of formats that are supported by the system.
-#[inline]
-pub fn get_endpoints_list() -> EndpointsIterator {
-    EndpointsIterator(Default::default())
-}
-
-/// Return the default endpoint, or `None` if no device is available.
-#[inline]
-pub fn get_default_endpoint() -> Option<Endpoint> {
-    cpal_impl::get_default_endpoint().map(Endpoint)
-}
-
 /// An opaque type that identifies an end point.
 #[derive(Clone, PartialEq, Eq)]
 pub struct Endpoint(cpal_impl::Endpoint);
 
 impl Endpoint {
+    /// Return an iterator to the list of formats that are supported by the system.
+    #[inline]
+    pub fn endpoints() -> EndpointsIterator {
+        EndpointsIterator(Default::default())
+    }
+
+    /// Return the default endpoint, or `None` if no device is available.
+    #[inline]
+    pub fn default_endpoint() -> Option<Endpoint> {
+        cpal_impl::Endpoint::default_endpoint().map(Endpoint)
+    }
+
     /// Returns an iterator that produces the list of formats that are supported by the backend.
     #[inline]
-    pub fn get_supported_formats_list(&self) -> Result<SupportedFormatsIterator,
+    pub fn supported_formats(&self) -> Result<SupportedFormatsIterator,
                                                        FormatsEnumerationError>
     {
-        Ok(SupportedFormatsIterator(try!(self.0.get_supported_formats_list())))
+        Ok(SupportedFormatsIterator(try!(self.0.supported_formats())))
     }
 
     /// Returns the name of the endpoint.
     #[inline]
-    pub fn get_name(&self) -> String {
-        self.0.get_name()
+    pub fn name(&self) -> String {
+        self.0.name()
     }
 }
 
@@ -426,7 +426,7 @@ impl<T> Deref for Buffer<T> where T: Sample {
 impl<T> DerefMut for Buffer<T> where T: Sample {
     #[inline]
     fn deref_mut(&mut self) -> &mut [T] {
-        self.target.as_mut().unwrap().get_buffer()
+        self.target.as_mut().unwrap().buffer()
     }
 }
 

--- a/src/null/mod.rs
+++ b/src/null/mod.rs
@@ -31,24 +31,24 @@ impl Iterator for EndpointsIterator {
     }
 }
 
-#[inline]
-pub fn get_default_endpoint() -> Option<Endpoint> {
-    None
-}
-
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Endpoint;
 
 impl Endpoint {
     #[inline]
-    pub fn get_supported_formats_list(&self)
+    pub fn default_endpoint() -> Option<Endpoint> {
+        None
+    }
+
+    #[inline]
+    pub fn supported_formats(&self)
             -> Result<SupportedFormatsIterator, FormatsEnumerationError>
     {
         unreachable!()
     }
 
     #[inline]
-    pub fn get_name(&self) -> String {
+    pub fn name(&self) -> String {
         "null".to_owned()
     }
 }
@@ -100,7 +100,7 @@ pub struct Buffer<T> {
 
 impl<T> Buffer<T> {
     #[inline]
-    pub fn get_buffer(&mut self) -> &mut [T] {
+    pub fn buffer(&mut self) -> &mut [T] {
         unreachable!()
     }
 

--- a/src/samples_formats.rs
+++ b/src/samples_formats.rs
@@ -14,7 +14,7 @@ pub enum SampleFormat {
 impl SampleFormat {
     /// Returns the size in bytes of a sample of this format.
     #[inline]
-    pub fn get_sample_size(&self) -> usize {
+    pub fn sample_size(&self) -> usize {
         match self {
             &SampleFormat::I16 => mem::size_of::<i16>(),
             &SampleFormat::U16 => mem::size_of::<u16>(),
@@ -26,26 +26,26 @@ impl SampleFormat {
 /// Trait for containers that contain PCM data.
 pub unsafe trait Sample: Copy + Clone {
     /// Returns the `SampleFormat` corresponding to this data type.
-    fn get_format() -> SampleFormat;
+    fn format() -> SampleFormat;
 }
 
 unsafe impl Sample for u16 {
     #[inline]
-    fn get_format() -> SampleFormat {
+    fn format() -> SampleFormat {
         SampleFormat::U16
     }
 }
 
 unsafe impl Sample for i16 {
     #[inline]
-    fn get_format() -> SampleFormat {
+    fn format() -> SampleFormat {
         SampleFormat::I16
     }
 }
 
 unsafe impl Sample for f32 {
     #[inline]
-    fn get_format() -> SampleFormat {
+    fn format() -> SampleFormat {
         SampleFormat::F32
     }
 }

--- a/src/wasapi/enumerate.rs
+++ b/src/wasapi/enumerate.rs
@@ -112,17 +112,3 @@ impl Iterator for EndpointsIterator {
         (num, Some(num))
     }
 }
-
-pub fn get_default_endpoint() -> Option<Endpoint> {
-    unsafe {
-        let mut device = mem::uninitialized();
-        let hres = (*ENUMERATOR.0).GetDefaultAudioEndpoint(winapi::eRender,
-                                                           winapi::eConsole, &mut device);
-
-        if let Err(_err) = check_result(hres) {
-            return None;        // TODO: check specifically for `E_NOTFOUND`, and panic otherwise
-        }
-
-        Some(Endpoint::from_immdevice(device))
-    }
-}

--- a/src/wasapi/enumerate.rs
+++ b/src/wasapi/enumerate.rs
@@ -8,7 +8,7 @@ use std::mem;
 use std::ptr;
 
 lazy_static! {
-    static ref ENUMERATOR: Enumerator = {
+    pub static ref ENUMERATOR: Enumerator = {
         // COM initialization is thread local, but we only need to have COM initialized in the
         // thread we create the objects in
         com::com_initialized();

--- a/src/wasapi/mod.rs
+++ b/src/wasapi/mod.rs
@@ -57,7 +57,7 @@ impl Endpoint {
     pub fn default_endpoint() -> Option<Endpoint> {
         unsafe {
             let mut device = mem::uninitialized();
-            let hres = (*ENUMERATOR.0).GetDefaultAudioEndpoint(winapi::eRender,
+            let hres = (*self::enumerate::ENUMERATOR.0).GetDefaultAudioEndpoint(winapi::eRender,
                                                                winapi::eConsole, &mut device);
 
             if let Err(_err) = check_result(hres) {

--- a/src/wasapi/voice.rs
+++ b/src/wasapi/voice.rs
@@ -454,7 +454,7 @@ unsafe impl<T> Send for Buffer<T> {}
 
 impl<T> Buffer<T> {
     #[inline]
-    pub fn get_buffer(&mut self) -> &mut [T] {
+    pub fn buffer(&mut self) -> &mut [T] {
         unsafe {
             slice::from_raw_parts_mut(self.buffer_data, self.buffer_len)
         }


### PR DESCRIPTION
* Added functions `get_endpoints_list()` and `get_default_endpoint()` to Endpoint structure
* Removed the `get_` part from all getters except from the deprecated ones
