### PR TITLE
Add coreaudio-rs dependency for i686-apple-darwin

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cpal"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["The CPAL contributors", "Pierre Krieger <pierre.krieger1708@gmail.com>"]
 description = "Low-level cross-platform audio playing library in pure Rust."
 repository = "https://github.com/tomaka/cpal"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,5 +32,8 @@ path = "alsa-sys"
 version = "0.1"
 path = "alsa-sys"
 
+[target.i686-apple-darwin.dependencies]
+coreaudio-rs = "0.6"
+
 [target.x86_64-apple-darwin.dependencies]
 coreaudio-rs = "0.6"


### PR DESCRIPTION
Fixes build for 32-bit mac. Tested locally in both configs, works just fine!

Also, can I request a minor release be published after merge? Would be nice to use this ASAP :) Thanks!