### PR TITLE
alsa: Pass period instead of buffer to snd_pcm_sw_params_set_avail_min

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cpal"
-version = "0.4.3"
+version = "0.4.4"
 authors = ["The CPAL contributors", "Pierre Krieger <pierre.krieger1708@gmail.com>"]
 description = "Low-level cross-platform audio playing library in pure Rust."
 repository = "https://github.com/tomaka/cpal"

--- a/src/alsa/mod.rs
+++ b/src/alsa/mod.rs
@@ -586,7 +586,7 @@ impl Voice {
                 let mut period = mem::uninitialized();
                 check_errors(alsa::snd_pcm_get_params(playback_handle, &mut buffer, &mut period)).expect("could not initialize buffer");
                 assert!(buffer != 0);
-                check_errors(alsa::snd_pcm_sw_params_set_avail_min(playback_handle, sw_params, buffer)).unwrap();
+                check_errors(alsa::snd_pcm_sw_params_set_avail_min(playback_handle, sw_params, period)).unwrap();
                 let buffer = buffer as usize * format.channels.len();
                 let period = period as usize * format.channels.len();
                 (buffer, period)


### PR DESCRIPTION
#145 Fixed the stalling (#142), but there still was a stuttering problem.
Passing `period` instead of `buffer` to `snd_pcm_sw_params_set_avail_min` fixes the stuttering.
Also crate version is bumped to ~`0.4.3`~ `0.4.4`in this PR.