### PR TITLE
Mark alsa-sys as linking to alsa

### DIFF
--- a/alsa-sys/Cargo.toml
+++ b/alsa-sys/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Pierre Krieger <pierre.krieger1708@gmail.com>"]
 build = "build.rs"
 description = "Bindings for the ALSA project (Advanced Linux Sound Architecture)"
 license = "MIT"
+links = "alsa"
 
 [dependencies]
 libc = "0.2.7"


### PR DESCRIPTION
The build script requires pkg-config, which isn't available when cross compiling.
Mark alsa-sys as linking to alsa allows cargo configuration to bypass the build script.

cf http://doc.crates.io/build-script.html#the-links-manifest-key