### PR TITLE
examples: Avoid f32 precision loss in beep example

### DIFF
--- a/examples/beep.rs
+++ b/examples/beep.rs
@@ -12,19 +12,20 @@ fn main() {
     let voice_id = event_loop.build_voice(&endpoint, &format).unwrap();
     event_loop.play(voice_id);
 
-    // Produce a sinusoid of maximum amplitude.
     let samples_rate = format.samples_rate.0 as f32;
-    let mut data_source = (0u64..).map(move |t| t as f32 * 440.0 * 2.0 * 3.141592 / samples_rate)     // 440 Hz
-                                  .map(move |t| t.sin());
+    let mut sample_clock = 0f32;
+
+    // Produce a sinusoid of maximum amplitude.
+    let mut next_value = || {
+        sample_clock = (sample_clock + 1.0) % samples_rate;
+        (sample_clock * 440.0 * 2.0 * 3.141592 / samples_rate).sin()
+    };
 
     event_loop.run(move |_, buffer| {
         match buffer {
             cpal::UnknownTypeBuffer::U16(mut buffer) => {
-                for (sample, value) in buffer
-                    .chunks_mut(format.channels.len())
-                    .zip(&mut data_source)
-                {
-                    let value = ((value * 0.5 + 0.5) * std::u16::MAX as f32) as u16;
+                for sample in buffer.chunks_mut(format.channels.len()) {
+                    let value = ((next_value() * 0.5 + 0.5) * std::u16::MAX as f32) as u16;
                     for out in sample.iter_mut() {
                         *out = value;
                     }
@@ -32,11 +33,8 @@ fn main() {
             },
 
             cpal::UnknownTypeBuffer::I16(mut buffer) => {
-                for (sample, value) in buffer
-                    .chunks_mut(format.channels.len())
-                    .zip(&mut data_source)
-                {
-                    let value = (value * std::i16::MAX as f32) as i16;
+                for sample in buffer.chunks_mut(format.channels.len()) {
+                    let value = (next_value() * std::i16::MAX as f32) as i16;
                     for out in sample.iter_mut() {
                         *out = value;
                     }
@@ -44,10 +42,8 @@ fn main() {
             },
 
             cpal::UnknownTypeBuffer::F32(mut buffer) => {
-                for (sample, value) in buffer
-                    .chunks_mut(format.channels.len())
-                    .zip(&mut data_source)
-                {
+                for sample in buffer.chunks_mut(format.channels.len()) {
+                    let value = next_value();
                     for out in sample.iter_mut() {
                         *out = value;
                     }


### PR DESCRIPTION
Closes #157