### PR TITLE
Add SupportedFormat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,5 @@
   and `EventLoop::pause` that can be used to create, destroy, play and pause voices.
 - Added a `VoiceId` struct that is now used to identify a voice owned by an `EventLoop`.
 - Changed `EventLoop::run()` to take a callback that is called whenever a voice requires sound data.
+- Changed `supported_formats()` to produce a list of `SupportedFormat` instead of `Format`. A
+  `SupportedFormat` must then be turned into a `Format` in order to build a voice.

--- a/examples/beep.rs
+++ b/examples/beep.rs
@@ -6,7 +6,8 @@ fn main() {
         .supported_formats()
         .unwrap()
         .next()
-        .expect("Failed to get endpoint format");
+        .expect("Failed to get endpoint format")
+        .with_max_samples_rate();
 
     let event_loop = cpal::EventLoop::new();
     let voice_id = event_loop.build_voice(&endpoint, &format).unwrap();

--- a/src/coreaudio/enumerate.rs
+++ b/src/coreaudio/enumerate.rs
@@ -1,6 +1,7 @@
 use super::Endpoint;
 
 use Format;
+use SupportedFormat;
 
 use std::vec::IntoIter as VecIntoIter;
 
@@ -33,4 +34,4 @@ pub fn default_endpoint() -> Option<Endpoint> {
     Some(Endpoint)
 }
 
-pub type SupportedFormatsIterator = VecIntoIter<Format>;
+pub type SupportedFormatsIterator = VecIntoIter<SupportedFormat>;

--- a/src/coreaudio/mod.rs
+++ b/src/coreaudio/mod.rs
@@ -7,6 +7,7 @@ use FormatsEnumerationError;
 use Sample;
 use SampleFormat;
 use SamplesRate;
+use SupportedFormat;
 use UnknownTypeBuffer;
 
 use std::mem;
@@ -30,9 +31,10 @@ impl Endpoint {
         -> Result<SupportedFormatsIterator, FormatsEnumerationError> {
         Ok(
             vec![
-                Format {
+                SupportedFormat {
                     channels: vec![ChannelPosition::FrontLeft, ChannelPosition::FrontRight],
-                    samples_rate: SamplesRate(44100),
+                    min_samples_rate: SamplesRate(44100),
+                    max_samples_rate: SamplesRate(44100),
                     data_type: SampleFormat::F32,
                 },
             ].into_iter(),

--- a/src/emscripten/mod.rs
+++ b/src/emscripten/mod.rs
@@ -7,6 +7,7 @@ use CreationError;
 use Format;
 use FormatsEnumerationError;
 use Sample;
+use SupportedFormat;
 use UnknownTypeBuffer;
 
 extern {
@@ -182,9 +183,10 @@ impl Endpoint {
         // TODO: right now cpal's API doesn't allow flexibility here
         //       "44100" and "2" (channels) have also been hard-coded in the rest of the code ; if
         //       this ever becomes more flexible, don't forget to change that
-        Ok(vec![Format {
+        Ok(vec![SupportedFormat {
             channels: vec![::ChannelPosition::BackLeft, ::ChannelPosition::BackRight],
-            samples_rate: ::SamplesRate(44100),
+            min_samples_rate: ::SamplesRate(44100),
+            max_samples_rate: ::SamplesRate(44100),
             data_type: ::SampleFormat::F32,
         }].into_iter())
     }
@@ -195,7 +197,7 @@ impl Endpoint {
     }
 }
 
-pub type SupportedFormatsIterator = ::std::vec::IntoIter<Format>;
+pub type SupportedFormatsIterator = ::std::vec::IntoIter<SupportedFormat>;
 
 pub struct Buffer<'a, T: 'a> where T: Sample {
     temporary_buffer: Vec<T>,

--- a/src/null/mod.rs
+++ b/src/null/mod.rs
@@ -5,6 +5,7 @@ use std::marker::PhantomData;
 use CreationError;
 use Format;
 use FormatsEnumerationError;
+use SupportedFormat;
 use UnknownTypeBuffer;
 
 pub struct EventLoop;
@@ -84,10 +85,10 @@ impl Endpoint {
 pub struct SupportedFormatsIterator;
 
 impl Iterator for SupportedFormatsIterator {
-    type Item = Format;
+    type Item = SupportedFormat;
 
     #[inline]
-    fn next(&mut self) -> Option<Format> {
+    fn next(&mut self) -> Option<SupportedFormat> {
         None
     }
 }

--- a/src/wasapi/endpoint.rs
+++ b/src/wasapi/endpoint.rs
@@ -8,17 +8,17 @@ use std::slice;
 use std::sync::{Arc, Mutex, MutexGuard};
 
 use ChannelPosition;
-use Format;
 use FormatsEnumerationError;
 use SampleFormat;
 use SamplesRate;
+use SupportedFormat;
 
 use super::check_result;
 use super::com;
 use super::ole32;
 use super::winapi;
 
-pub type SupportedFormatsIterator = OptionIntoIter<Format>;
+pub type SupportedFormatsIterator = OptionIntoIter<SupportedFormat>;
 
 /// Wrapper because of that stupid decision to remove `Send` and `Sync` from raw pointers.
 #[derive(Copy, Clone)]
@@ -236,9 +236,10 @@ impl Endpoint {
                     f => panic!("Unknown data format returned by GetMixFormat: {:?}", f),
                 };
 
-                Format {
+                SupportedFormat {
                     channels: channels,
-                    samples_rate: SamplesRate((*format_ptr).nSamplesPerSec),
+                    min_samples_rate: SamplesRate((*format_ptr).nSamplesPerSec),
+                    max_samples_rate: SamplesRate((*format_ptr).nSamplesPerSec),
                     data_type: data_type,
                 }
             };


### PR DESCRIPTION
The ALSA API reports that devices support a wide range of samples rate, as it does the conversion to the final rate itself. Right now cpal handles that by returning one `Format` for each possible samples rate, which results in thousands of elements.

This PR fixes this design issue by producing a list of `SupportedFormat` elements, instead of `Format`. The difference between `SupportedFormat` and `Format` is that the former contains a range of samples rate. Building a voice still expects a `Format`, and the user must perform the conversion.