### PR TITLE
Implement `pause` and `play` for ALSA backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Changed the emscripten backend to consume less CPU.
 - Added improvements to the crate documentation.
+- Implement `pause` and `play` for ALSA backend.
 
 # Version 0.5.1 (2017-10-21)
 

--- a/src/alsa/mod.rs
+++ b/src/alsa/mod.rs
@@ -620,14 +620,6 @@ impl EventLoop {
             let new_voice_id = VoiceId(self.next_voice_id.fetch_add(1, Ordering::Relaxed));
             assert_ne!(new_voice_id.0, usize::max_value()); // check for overflows
 
-            let is_paused = if can_pause {
-                alsa::snd_pcm_pause(playback_handle, 1);
-                true
-            } else {
-                false
-            };
-
-
             let voice_inner = VoiceInner {
                 id: new_voice_id.clone(),
                 channel: playback_handle,
@@ -637,7 +629,7 @@ impl EventLoop {
                 buffer_len: buffer_len,
                 period_len: period_len,
                 can_pause: can_pause,
-                is_paused: AtomicBool::new(is_paused),
+                is_paused: AtomicBool::new(false),
                 resume_trigger: Trigger::new(),
             };
 


### PR DESCRIPTION
This commit also ensures that the Voice is initially paused when returned to remain consistent with the curent state of the rest of the CPAL backends (at least I think they're paused by default at the moment?). Related discussion on this at #175.

The ALSA docs mention that not all hardware supports pause functionality, so we check for this using the `snd_pcm_hw_params_can_pause` function. Currently, `pause` and `play`  only do something if `can_pause` is `true`. I wonder what we should do In the case that  the hardware doesn't support pause functionality? Should we just submit silence and not call the callback? Or just do nothing at all as is currently the case?