### PR TITLE
Fix macos build

### DIFF
--- a/src/coreaudio/mod.rs
+++ b/src/coreaudio/mod.rs
@@ -98,9 +98,9 @@ impl EventLoop {
 
     #[inline]
     pub fn run<F>(&self, mut callback: F) -> !
-        where F: FnMut(VoiceId, UnknownTypeBuffer)
+        where F: FnMut(VoiceId, UnknownTypeBuffer) + Send
     {
-        let callback: &mut FnMut(VoiceId, UnknownTypeBuffer) = &mut callback;
+        let callback: &mut (FnMut(VoiceId, UnknownTypeBuffer) + Send) = &mut callback;
         self.active_callbacks
             .callbacks
             .lock()

--- a/src/coreaudio/mod.rs
+++ b/src/coreaudio/mod.rs
@@ -151,7 +151,7 @@ impl EventLoop {
             Scope::Input,
             Element::Output,
             Some(&asbd)
-        ).map_err(convert_error)?;
+        )?;
 
         // Determine the future ID of the voice.
         let mut voices_lock = self.voices.lock().unwrap();

--- a/src/coreaudio/mod.rs
+++ b/src/coreaudio/mod.rs
@@ -65,7 +65,7 @@ pub struct EventLoop {
 
 struct ActiveCallbacks {
     // Whenever the `run()` method is called with a callback, this callback is put in this list.
-    callbacks: Mutex<Vec<Box<FnMut(VoiceId, UnknownTypeBuffer) + Send>>>,
+    callbacks: Mutex<Vec<&'static mut (FnMut(VoiceId, UnknownTypeBuffer) + Send)>>,
 }
 
 struct VoiceInner {

--- a/src/coreaudio/mod.rs
+++ b/src/coreaudio/mod.rs
@@ -56,7 +56,7 @@ pub struct EventLoop {
 
 struct ActiveCallbacks {
     // Whenever the `run()` method is called with a callback, this callback is put in this list.
-    callbacks: Mutex<Vec<&'static mut FnMut(VoiceId, UnknownTypeBuffer)>>,
+    callbacks: Mutex<Vec<Box<FnMut(VoiceId, UnknownTypeBuffer) + Send>>>,
 }
 
 struct VoiceInner {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -374,7 +374,7 @@ impl EventLoop {
     /// You can call the other methods of `EventLoop` without getting a deadlock.
     #[inline]
     pub fn run<F>(&self, mut callback: F) -> !
-        where F: FnMut(VoiceId, UnknownTypeBuffer)
+        where F: FnMut(VoiceId, UnknownTypeBuffer) + Send
     {
         self.0.run(move |id, buf| callback(VoiceId(id), buf))
     }


### PR DESCRIPTION
This PR fixes broken osx build:
1. Fixes tomaka/rodio#145 (callback sync error)
2. Fixes missing `convert_error` caused by most recent PRs. #182 #183 