### PR TITLE
Fix coreaudio build

### DIFF
--- a/src/coreaudio/mod.rs
+++ b/src/coreaudio/mod.rs
@@ -151,7 +151,7 @@ impl EventLoop {
             Scope::Input,
             Element::Output,
             Some(&asbd)
-        ).map_err(convert_error)?;
+        )?;
 
         // Determine the future ID of the voice.
         let mut voices_lock = self.voices.lock().unwrap();


### PR DESCRIPTION
The last commit to coreaudio/mod.rs added a call to convert_error, but
that function was removed earlier. Remove the call to fix the build.