### PR TITLE
Publish v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 # Unreleased
 
+# Version 0.6.0 (2017-12-11)
+
 - Changed the emscripten backend to consume less CPU.
 - Added improvements to the crate documentation.
 - Implement `pause` and `play` for ALSA backend.
 - Reduced the number of allocations in the CoreAudio backend.
+- Fixes for macos build (#186, #189).
 
 # Version 0.5.1 (2017-10-21)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cpal"
-version = "0.5.1"
+version = "0.6.0"
 authors = ["The CPAL contributors", "Pierre Krieger <pierre.krieger1708@gmail.com>"]
 description = "Low-level cross-platform audio playing library in pure Rust."
 repository = "https://github.com/tomaka/cpal"


### PR DESCRIPTION
There does not seem to be any major API breakage, however the emscripten
and macos backends have been pretty heavily refactored so I thought it
best to bump to 0.6 (rather than 0.5.2) just in case there is any subtle
behavioural breakage. Happy to change this to 0.5.2 though if someone
can confirm there will be no downstream breakage.