### PR TITLE
Rename `SamplesRate` to `SampleRate` and `ChannelsCount` to `ChannelCount`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Rename ChannelsCount to ChannelCount.
+- Rename SamplesRate to SampleRate.
 - Remove unused ChannelPosition API.
 - Implement Endpoint and Format Enumeration for macos.
 - Implement format handling for macos `build_voice` method.

--- a/examples/beep.rs
+++ b/examples/beep.rs
@@ -7,19 +7,19 @@ fn main() {
         .unwrap()
         .next()
         .expect("Failed to get endpoint format")
-        .with_max_samples_rate();
+        .with_max_sample_rate();
 
     let event_loop = cpal::EventLoop::new();
     let voice_id = event_loop.build_voice(&endpoint, &format).unwrap();
     event_loop.play(voice_id);
 
-    let samples_rate = format.samples_rate.0 as f32;
+    let sample_rate = format.sample_rate.0 as f32;
     let mut sample_clock = 0f32;
 
     // Produce a sinusoid of maximum amplitude.
     let mut next_value = || {
-        sample_clock = (sample_clock + 1.0) % samples_rate;
-        (sample_clock * 440.0 * 2.0 * 3.141592 / samples_rate).sin()
+        sample_clock = (sample_clock + 1.0) % sample_rate;
+        (sample_clock * 440.0 * 2.0 * 3.141592 / sample_rate).sin()
     };
 
     event_loop.run(move |_, buffer| {

--- a/src/alsa/mod.rs
+++ b/src/alsa/mod.rs
@@ -3,7 +3,7 @@ extern crate libc;
 
 pub use self::enumerate::{EndpointsIterator, default_endpoint};
 
-use ChannelsCount;
+use ChannelCount;
 use CreationError;
 use Format;
 use FormatsEnumerationError;
@@ -206,7 +206,7 @@ impl Endpoint {
                     num,
                 ) == 0
                 {
-                    Some(num as ChannelsCount)
+                    Some(num as ChannelCount)
                 } else {
                     None
                 })

--- a/src/alsa/mod.rs
+++ b/src/alsa/mod.rs
@@ -8,7 +8,7 @@ use CreationError;
 use Format;
 use FormatsEnumerationError;
 use SampleFormat;
-use SamplesRate;
+use SampleRate;
 use SupportedFormat;
 use UnknownTypeBuffer;
 
@@ -149,7 +149,7 @@ impl Endpoint {
                                                               ptr::null_mut()))
                 .expect("unable to get maximum supported rate");
 
-            let samples_rates = if min_rate == max_rate {
+            let sample_rates = if min_rate == max_rate {
                 vec![(min_rate, max_rate)]
             } else if alsa::snd_pcm_hw_params_test_rate(playback_handle,
                                                         hw_params.0,
@@ -213,14 +213,14 @@ impl Endpoint {
                 .collect::<Vec<_>>();
 
             let mut output = Vec::with_capacity(supported_formats.len() * supported_channels.len() *
-                                                    samples_rates.len());
+                                                    sample_rates.len());
             for &data_type in supported_formats.iter() {
                 for channels in supported_channels.iter() {
-                    for &(min_rate, max_rate) in samples_rates.iter() {
+                    for &(min_rate, max_rate) in sample_rates.iter() {
                         output.push(SupportedFormat {
                                         channels: channels.clone(),
-                                        min_samples_rate: SamplesRate(min_rate as u32),
-                                        max_samples_rate: SamplesRate(max_rate as u32),
+                                        min_sample_rate: SampleRate(min_rate as u32),
+                                        max_sample_rate: SampleRate(max_rate as u32),
                                         data_type: data_type,
                                     });
                     }
@@ -552,7 +552,7 @@ impl EventLoop {
                 .expect("format could not be set");
             check_errors(alsa::snd_pcm_hw_params_set_rate(playback_handle,
                                                           hw_params.0,
-                                                          format.samples_rate.0 as libc::c_uint,
+                                                          format.sample_rate.0 as libc::c_uint,
                                                           0))
                 .expect("sample rate could not be set");
             check_errors(alsa::snd_pcm_hw_params_set_channels(playback_handle,
@@ -560,7 +560,7 @@ impl EventLoop {
                                                               format.channels as
                                                                   libc::c_uint))
                 .expect("channel count could not be set");
-            let mut max_buffer_size = format.samples_rate.0 as alsa::snd_pcm_uframes_t /
+            let mut max_buffer_size = format.sample_rate.0 as alsa::snd_pcm_uframes_t /
                 format.channels as alsa::snd_pcm_uframes_t /
                 5; // 200ms of buffer
             check_errors(alsa::snd_pcm_hw_params_set_buffer_size_max(playback_handle,

--- a/src/coreaudio/mod.rs
+++ b/src/coreaudio/mod.rs
@@ -7,7 +7,7 @@ use Format;
 use FormatsEnumerationError;
 use Sample;
 use SampleFormat;
-use SamplesRate;
+use SampleRate;
 use SupportedFormat;
 use UnknownTypeBuffer;
 
@@ -152,8 +152,8 @@ impl Endpoint {
             for range in ranges {
                 let fmt = SupportedFormat {
                     channels: n_channels as ChannelsCount,
-                    min_samples_rate: SamplesRate(range.mMinimum as _),
-                    max_samples_rate: SamplesRate(range.mMaximum as _),
+                    min_sample_rate: SampleRate(range.mMinimum as _),
+                    max_sample_rate: SampleRate(range.mMaximum as _),
                     data_type: sample_format,
                 };
                 fmts.push(fmt);
@@ -282,7 +282,7 @@ impl EventLoop {
 
         // Set the stream in interleaved mode.
         let n_channels = format.channels as usize;
-        let sample_rate = format.samples_rate.0;
+        let sample_rate = format.sample_rate.0;
         let bytes_per_channel = format.data_type.sample_size();
         let bits_per_channel = bytes_per_channel * 8;
         let bytes_per_frame = n_channels * bytes_per_channel;

--- a/src/coreaudio/mod.rs
+++ b/src/coreaudio/mod.rs
@@ -1,7 +1,7 @@
 extern crate coreaudio;
 extern crate core_foundation_sys;
 
-use ChannelsCount;
+use ChannelCount;
 use CreationError;
 use Format;
 use FormatsEnumerationError;
@@ -151,7 +151,7 @@ impl Endpoint {
             let mut fmts = vec![];
             for range in ranges {
                 let fmt = SupportedFormat {
-                    channels: n_channels as ChannelsCount,
+                    channels: n_channels as ChannelCount,
                     min_sample_rate: SampleRate(range.mMinimum as _),
                     max_sample_rate: SampleRate(range.mMaximum as _),
                     data_type: sample_format,

--- a/src/emscripten/mod.rs
+++ b/src/emscripten/mod.rs
@@ -184,8 +184,8 @@ impl Endpoint {
             vec![
                 SupportedFormat {
                     channels: 2,
-                    min_samples_rate: ::SamplesRate(44100),
-                    max_samples_rate: ::SamplesRate(44100),
+                    min_sample_rate: ::SampleRate(44100),
+                    max_sample_rate: ::SampleRate(44100),
                     data_type: ::SampleFormat::F32,
                 },
             ].into_iter(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -238,7 +238,7 @@ impl Endpoint {
 }
 
 /// Number of channels.
-pub type ChannelsCount = u16;
+pub type ChannelCount = u16;
 
 ///
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -247,7 +247,7 @@ pub struct SampleRate(pub u32);
 /// Describes a format.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Format {
-    pub channels: ChannelsCount,
+    pub channels: ChannelCount,
     pub sample_rate: SampleRate,
     pub data_type: SampleFormat,
 }
@@ -274,7 +274,7 @@ impl Iterator for SupportedFormatsIterator {
 /// Describes a range of supported formats.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SupportedFormat {
-    pub channels: ChannelsCount,
+    pub channels: ChannelCount,
     /// Minimum value for the samples rate of the supported formats.
     pub min_sample_rate: SampleRate,
     /// Maximum value for the samples rate of the supported formats.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,14 +40,14 @@
 //! let mut supported_formats_range = endpoint.supported_formats()
 //!                                           .expect("error while querying formats");
 //! let format = supported_formats_range.next().expect("no supported format?!")
-//!                                     .with_max_samples_rate();
+//!                                     .with_max_sample_rate();
 //! ```
 //!
 //! Now that we have everything, we can create a voice from that event loop:
 //!
 //! ```no_run
 //! # let endpoint = cpal::default_endpoint().unwrap();
-//! # let format = endpoint.supported_formats().unwrap().next().unwrap().with_max_samples_rate();
+//! # let format = endpoint.supported_formats().unwrap().next().unwrap().with_max_sample_rate();
 //! # let event_loop = cpal::EventLoop::new();
 //! let voice_id = event_loop.build_voice(&endpoint, &format).unwrap();
 //! ```
@@ -242,13 +242,13 @@ pub type ChannelsCount = u16;
 
 ///
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub struct SamplesRate(pub u32);
+pub struct SampleRate(pub u32);
 
 /// Describes a format.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Format {
     pub channels: ChannelsCount,
-    pub samples_rate: SamplesRate,
+    pub sample_rate: SampleRate,
     pub data_type: SampleFormat,
 }
 
@@ -276,9 +276,9 @@ impl Iterator for SupportedFormatsIterator {
 pub struct SupportedFormat {
     pub channels: ChannelsCount,
     /// Minimum value for the samples rate of the supported formats.
-    pub min_samples_rate: SamplesRate,
+    pub min_sample_rate: SampleRate,
     /// Maximum value for the samples rate of the supported formats.
-    pub max_samples_rate: SamplesRate,
+    pub max_sample_rate: SampleRate,
     /// Type of data expected by the endpoint.
     pub data_type: SampleFormat,
 }
@@ -286,10 +286,10 @@ pub struct SupportedFormat {
 impl SupportedFormat {
     /// Turns this `SupportedFormat` into a `Format` corresponding to the maximum samples rate.
     #[inline]
-    pub fn with_max_samples_rate(self) -> Format {
+    pub fn with_max_sample_rate(self) -> Format {
         Format {
             channels: self.channels,
-            samples_rate: self.max_samples_rate,
+            sample_rate: self.max_sample_rate,
             data_type: self.data_type,
         }
     }
@@ -300,8 +300,8 @@ impl From<Format> for SupportedFormat {
     fn from(format: Format) -> SupportedFormat {
         SupportedFormat {
             channels: format.channels,
-            min_samples_rate: format.samples_rate,
-            max_samples_rate: format.samples_rate,
+            min_sample_rate: format.sample_rate,
+            max_sample_rate: format.sample_rate,
             data_type: format.data_type,
         }
     }

--- a/src/wasapi/endpoint.rs
+++ b/src/wasapi/endpoint.rs
@@ -7,7 +7,7 @@ use std::ptr;
 use std::slice;
 use std::sync::{Arc, Mutex, MutexGuard};
 
-use ChannelsCount;
+use ChannelCount;
 use FormatsEnumerationError;
 use SampleFormat;
 use SampleRate;
@@ -144,7 +144,7 @@ impl Endpoint {
                     },
                     winapi::WAVE_FORMAT_EXTENSIBLE => {
                         let format_ptr = format_ptr as *const winapi::WAVEFORMATEXTENSIBLE;
-                        let channels = (*format_ptr).Format.nChannels as ChannelsCount;
+                        let channels = (*format_ptr).Format.nChannels as ChannelCount;
                         let format = {
                             fn cmp_guid(a: &winapi::GUID, b: &winapi::GUID) -> bool {
                                 a.Data1 == b.Data1 && a.Data2 == b.Data2 && a.Data3 == b.Data3 &&

--- a/src/wasapi/endpoint.rs
+++ b/src/wasapi/endpoint.rs
@@ -10,7 +10,7 @@ use std::sync::{Arc, Mutex, MutexGuard};
 use ChannelsCount;
 use FormatsEnumerationError;
 use SampleFormat;
-use SamplesRate;
+use SampleRate;
 use SupportedFormat;
 
 use super::check_result;
@@ -172,8 +172,8 @@ impl Endpoint {
 
                 SupportedFormat {
                     channels: channels,
-                    min_samples_rate: SamplesRate((*format_ptr).nSamplesPerSec),
-                    max_samples_rate: SamplesRate((*format_ptr).nSamplesPerSec),
+                    min_sample_rate: SampleRate((*format_ptr).nSamplesPerSec),
+                    max_sample_rate: SampleRate((*format_ptr).nSamplesPerSec),
                     data_type: data_type,
                 }
             };

--- a/src/wasapi/voice.rs
+++ b/src/wasapi/voice.rs
@@ -472,9 +472,9 @@ fn format_to_waveformatextensible(format: &Format)
                    SampleFormat::U16 => return Err(CreationError::FormatNotSupported),
                },
                nChannels: format.channels as winapi::WORD,
-               nSamplesPerSec: format.samples_rate.0 as winapi::DWORD,
+               nSamplesPerSec: format.sample_rate.0 as winapi::DWORD,
                nAvgBytesPerSec: format.channels as winapi::DWORD *
-                   format.samples_rate.0 as winapi::DWORD *
+                   format.sample_rate.0 as winapi::DWORD *
                    format.data_type.sample_size() as winapi::DWORD,
                nBlockAlign: format.channels as winapi::WORD *
                    format.data_type.sample_size() as winapi::WORD,


### PR DESCRIPTION
Previously mentioned at #29.

This changes the `SamplesRate` and `ChannelsCount` type names to the more idiomatic names `SampleRate` and `ChannelCount`.

The `s` on the end of `Sample` and `Channel` is unnecessary as both `Rate` and `Count` already imply plurality. A quick google will show that the term "sample rate" is ubiquitous throughout existing audio libraries, whereas there are no previous uses of "samples rate" within APIs that I can find.

This also renames the `samples_rate` fields to `sample_rate`.