### PR TITLE
Update winapi version from 0.2 to 0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,7 @@ keywords = ["audio", "sound"]
 lazy_static = "0.2"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-winapi = "0.2.8"
-ole32-sys = "0.2"
-kernel32-sys = "0.2"
+winapi = { version = "0.3", features = ["audiosessiontypes", "audioclient", "combaseapi", "debug", "handleapi", "ksmedia", "mmdeviceapi", "objbase", "std", "synchapi", "winuser"] }
 
 [target.'cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "openbsd"))'.dependencies]
 alsa-sys = { version = "0.1", path = "alsa-sys" }

--- a/src/wasapi/com.rs
+++ b/src/wasapi/com.rs
@@ -1,15 +1,16 @@
 //! Handles COM initialization and cleanup.
 
 use super::check_result;
-use super::ole32;
-use super::winapi;
 use std::ptr;
+
+use super::winapi::um::objbase::{COINIT_MULTITHREADED};
+use super::winapi::um::combaseapi::{CoInitializeEx, CoUninitialize};
 
 thread_local!(static COM_INITIALIZED: ComInitialized = {
     unsafe {
         // this call can fail if another library initialized COM in single-threaded mode
         // handling this situation properly would make the API more annoying, so we just don't care
-        check_result(ole32::CoInitializeEx(ptr::null_mut(), winapi::COINIT_MULTITHREADED)).unwrap();
+        check_result(CoInitializeEx(ptr::null_mut(), COINIT_MULTITHREADED)).unwrap();
         ComInitialized(ptr::null_mut())
     }
 });
@@ -23,7 +24,7 @@ struct ComInitialized(*mut ());
 impl Drop for ComInitialized {
     #[inline]
     fn drop(&mut self) {
-        unsafe { ole32::CoUninitialize() };
+        unsafe { CoUninitialize() };
     }
 }
 

--- a/src/wasapi/mod.rs
+++ b/src/wasapi/mod.rs
@@ -1,18 +1,17 @@
 extern crate winapi;
-extern crate ole32;
-extern crate kernel32;
 
 use std::io::Error as IoError;
 
 pub use self::endpoint::{Endpoint, EndpointsIterator, SupportedFormatsIterator, default_endpoint};
 pub use self::voice::{Buffer, EventLoop, VoiceId};
+use self::winapi::um::winnt::HRESULT;
 
 mod com;
 mod endpoint;
 mod voice;
 
 #[inline]
-fn check_result(result: winapi::HRESULT) -> Result<(), IoError> {
+fn check_result(result: HRESULT) -> Result<(), IoError> {
     if result < 0 {
         Err(IoError::from_raw_os_error(result))
     } else {


### PR DESCRIPTION
Adds only the necessary cargo features to reduce compile time and reduce
the chance of linking errors occurring for unused libraries (e.g.
d3d12.dll fails to link on my win10 VM).

I thought I'd try and land this before before working on the wasapi
backend implementation for #201.

Tested both beep.rs and enumerate.rs and they work fine with the update.