### PR TITLE
[coreaudio] Fix handling of non-default sample rates for input streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+# Version 0.8.1 (2018-03-18)
+
+- Fix the handling of non-default sample rates for coreaudio input streams.
+
 # Version 0.8.0 (2018-02-15)
 
 - Add `record_wav.rs` example. Records 3 seconds to

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cpal"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["The CPAL contributors", "Pierre Krieger <pierre.krieger1708@gmail.com>"]
 description = "Low-level cross-platform audio playing library in pure Rust."
 repository = "https://github.com/tomaka/cpal"


### PR DESCRIPTION
Currently when building an input stream the coreaudio backend only
specifies the sample rate for the audio unit, however coreaudio requires
that the audio unit sample rate matches the device sample rate.

This changes the `build_input_stream` behaviour to:

1. Check if the device sample rate differs from the desired one.
2. If so, check that there are no existing audio units using the device
at the current sample rate. If there are, panic with a message
explaining why.
3. Otherwise, change the device sample rate.
4. Continue building the input stream audio unit as normal.

Closes #213.