### PR TITLE
Fixed alsa: Device not available not returning Err

### DIFF
--- a/src/alsa/mod.rs
+++ b/src/alsa/mod.rs
@@ -92,7 +92,7 @@ impl Device {
         ) {
             -2 |
             -16 /* determined empirically */ => return Err(FormatsEnumerationError::DeviceNotAvailable),
-            e => check_errors(e).expect("device not available")
+            e => if check_errors(e).is_err(){ return Err(FormatsEnumerationError::DeviceNotAvailable) }
         }
 
         let hw_params = HwParams::alloc();


### PR DESCRIPTION
A step towards not crashing when alsa is not running or when I don't have any audio devices plugged in :P

Side note: Rodio is running on cpal 0.6 to which I can't find the source code, so it would need to be updated to the newer cpal to fix the bug we are having with amethyst.