### PR TITLE
Use failure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,8 @@ keywords = ["audio", "sound"]
 
 [dependencies]
 lazy_static = "0.2"
+failure = "0.1"
+failure_derive = "0.1"
 
 [dev-dependencies]
 hound = "3.0"

--- a/src/emscripten/mod.rs
+++ b/src/emscripten/mod.rs
@@ -8,10 +8,8 @@ use stdweb::unstable::TryInto;
 use stdweb::web::TypedArray;
 use stdweb::web::set_timeout;
 
-use CreationError;
-use DefaultFormatError;
+use Result;
 use Format;
-use FormatsEnumerationError;
 use Sample;
 use StreamData;
 use SupportedFormat;
@@ -87,12 +85,12 @@ impl EventLoop {
     }
 
     #[inline]
-    pub fn build_input_stream(&self, _: &Device, _format: &Format) -> Result<StreamId, CreationError> {
+    pub fn build_input_stream(&self, _: &Device, _format: &Format) -> Result<StreamId> {
         unimplemented!();
     }
 
     #[inline]
-    pub fn build_output_stream(&self, _: &Device, _format: &Format) -> Result<StreamId, CreationError> {
+    pub fn build_output_stream(&self, _: &Device, _format: &Format) -> Result<StreamId> {
         let stream = js!(return new AudioContext()).into_reference().unwrap();
 
         let mut streams = self.streams.lock().unwrap();
@@ -195,12 +193,12 @@ impl Device {
     }
 
     #[inline]
-    pub fn supported_input_formats(&self) -> Result<SupportedInputFormats, FormatsEnumerationError> {
+    pub fn supported_input_formats(&self) -> Result<SupportedInputFormats> {
         unimplemented!();
     }
 
     #[inline]
-    pub fn supported_output_formats(&self) -> Result<SupportedOutputFormats, FormatsEnumerationError> {
+    pub fn supported_output_formats(&self) -> Result<SupportedOutputFormats> {
         // TODO: right now cpal's API doesn't allow flexibility here
         //       "44100" and "2" (channels) have also been hard-coded in the rest of the code ; if
         //       this ever becomes more flexible, don't forget to change that
@@ -216,11 +214,11 @@ impl Device {
         )
     }
 
-    pub fn default_input_format(&self) -> Result<Format, DefaultFormatError> {
+    pub fn default_input_format(&self) -> Result<Format> {
         unimplemented!();
     }
 
-    pub fn default_output_format(&self) -> Result<Format, DefaultFormatError> {
+    pub fn default_output_format(&self) -> Result<Format> {
         unimplemented!();
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,70 @@
+use failure::{Context, Fail, Backtrace};
+use std::fmt::{self, Display};
+use std::result::Result as StdResult;
+
+/// The type of all errors in this library.
+#[derive(Debug)]
+pub struct Error {
+    inner: Context<ErrorKind>
+}
+
+/// The possible kinds of errors that functions in this library can return
+#[derive(Copy, Clone, Eq, PartialEq, Debug, Fail)]
+pub enum ErrorKind {
+    /// The device no longer exists. This can happen if the device is disconnected while the
+    /// program is running.
+    #[fail(display="device not available")]
+    DeviceNotAvailable,
+    /// Returned if e.g. the default input format was requested on an output-only audio device.
+    #[fail(display="stream type not supported")]
+    StreamTypeNotSupported,
+    /// The required format is not supported.
+    #[fail(display="format not supported")]
+    FormatNotSupported,
+    /// There was an error getting the minimum supported sample rate.
+    #[fail(display="error getting minimum supported rate")]
+    CannotGetMinimumSupportedRate,
+    /// There was an error getting the maximum supported sample rate.
+    #[fail(display="error getting maximum supported rate")]
+    CannotGetMaximumSupportedRate,
+    /// Tried to create a C string from a rust String with a null byte (`\0`).
+    #[fail(display="tried to create a C style string from a string with a null byte")]
+    NullInString,
+}
+
+impl Error {
+    /// Get the kind of this error
+    pub fn kind(&self) -> &ErrorKind {
+        self.inner.get_context()
+    }
+}
+
+impl From<ErrorKind> for Error {
+    fn from(kind: ErrorKind) -> Self {
+        Error { inner: Context::new(kind) }
+    }
+}
+
+impl From<Context<ErrorKind>> for Error {
+    fn from(inner: Context<ErrorKind>) -> Self {
+        Error { inner }
+    }
+}
+
+impl Fail for Error {
+    fn cause(&self) -> Option<&Fail> {
+        self.inner.cause()
+    }
+
+    fn backtrace(&self) -> Option<&Backtrace> {
+        self.inner.backtrace()
+    }
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        Display::fmt(&self.inner, f)
+    }
+}
+
+pub type Result<T> = StdResult<T, Error>;

--- a/src/null/mod.rs
+++ b/src/null/mod.rs
@@ -2,10 +2,9 @@
 
 use std::marker::PhantomData;
 
-use CreationError;
-use DefaultFormatError;
+use Result;
+use ErrorKind;
 use Format;
-use FormatsEnumerationError;
 use StreamData;
 use SupportedFormat;
 
@@ -21,17 +20,21 @@ impl EventLoop {
     pub fn run<F>(&self, _callback: F) -> !
         where F: FnMut(StreamId, StreamData)
     {
-        loop { /* TODO: don't spin */ }
+        use std::sync::mpsc::channel;
+        let (_, rx) = channel::<()>();
+        rx.recv().unwrap();
+        // convince the compiler that we never return
+        loop {}
     }
 
     #[inline]
-    pub fn build_input_stream(&self, _: &Device, _: &Format) -> Result<StreamId, CreationError> {
-        Err(CreationError::DeviceNotAvailable)
+    pub fn build_input_stream(&self, _: &Device, _: &Format) -> Result<StreamId> {
+        Err(ErrorKind::DeviceNotAvailable.into())
     }
 
     #[inline]
-    pub fn build_output_stream(&self, _: &Device, _: &Format) -> Result<StreamId, CreationError> {
-        Err(CreationError::DeviceNotAvailable)
+    pub fn build_output_stream(&self, _: &Device, _: &Format) -> Result<StreamId> {
+        Err(ErrorKind::DeviceNotAvailable.into())
     }
 
     #[inline]
@@ -80,22 +83,22 @@ pub struct Device;
 
 impl Device {
     #[inline]
-    pub fn supported_input_formats(&self) -> Result<SupportedInputFormats, FormatsEnumerationError> {
+    pub fn supported_input_formats(&self) -> Result<SupportedInputFormats> {
         unimplemented!()
     }
 
     #[inline]
-    pub fn supported_output_formats(&self) -> Result<SupportedOutputFormats, FormatsEnumerationError> {
+    pub fn supported_output_formats(&self) -> Result<SupportedOutputFormats> {
         unimplemented!()
     }
 
     #[inline]
-    pub fn default_input_format(&self) -> Result<Format, DefaultFormatError> {
+    pub fn default_input_format(&self) -> Result<Format> {
         unimplemented!()
     }
 
     #[inline]
-    pub fn default_output_format(&self) -> Result<Format, DefaultFormatError> {
+    pub fn default_output_format(&self) -> Result<Format> {
         unimplemented!()
     }
 

--- a/src/wasapi/stream.rs
+++ b/src/wasapi/stream.rs
@@ -512,7 +512,7 @@ impl EventLoop {
                                             == Some(AUDCLNT_E_DEVICE_INVALIDATED)
                                         {
                                             return Err(e).context(DeviceNotAvailable)
-                                        },
+                                        }
                                     };
                                 }};
                             }


### PR DESCRIPTION
I had an issue with alsa recently where I had updated my computer but was using an old kernel, so trying to load a `.so` failed, and cpal panicked. I've done an example of how using failure might work with cpal here. If I was using this PR's version of cpal, I would have got info on the specific IO error, and moreover could have chosen to continue without sound (without using catch_unwind).

I hope you'll consider this PR, or another similar one.