### PR TITLE
Fix the PauseStream handler to flip the `playing` bit.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Unreleased
 
+- Fix resuming a paused stream on Windows (wasapi).
+
 # Version 0.8.1 (2018-03-18)
 
 - Fix the handling of non-default sample rates for coreaudio input streams.
-- Fix resuming a paused stream on Windows (wasapi).
 
 # Version 0.8.0 (2018-02-15)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 # Version 0.8.1 (2018-03-18)
 
 - Fix the handling of non-default sample rates for coreaudio input streams.
+- Fix resuming a paused stream on Windows (wasapi).
 
 # Version 0.8.0 (2018-02-15)
 

--- a/src/wasapi/stream.rs
+++ b/src/wasapi/stream.rs
@@ -462,7 +462,7 @@ impl EventLoop {
                                 if v.playing {
                                     let hresult = (*v.audio_client).Stop();
                                     check_result(hresult).unwrap();
-                                    v.playing = true;
+                                    v.playing = false;
                                 }
                             }
                         },


### PR DESCRIPTION
The `playing` variable was miscarried in wasapi, resulting in it rejecting to resume a stream.