### PR TITLE
Switching the headset on and off

### DIFF
--- a/src/wasapi/stream.rs
+++ b/src/wasapi/stream.rs
@@ -494,6 +494,13 @@ impl EventLoop {
                     let mut frames_available = {
                         let mut padding = mem::uninitialized();
                         let hresult = (*stream.audio_client).GetCurrentPadding(&mut padding);
+                        // Happens when a bluetooth headset was turned off, for example.
+                        if hresult == AUDCLNT_E_DEVICE_INVALIDATED {
+                            // The client code should switch to a different device eventually.
+                            // For now let's just skip the invalidated device.
+                            // Would be nice to inform the client code about the invalidation,
+                            // but throwing a panic isn't the most ergonomic way to do so.
+                            continue}
                         check_result(hresult).unwrap();
                         stream.max_frames_in_buffer - padding
                     };


### PR DESCRIPTION
CPAL was panicking when I was switching my headset off.

Also, it was impossible to detect default device changes by comparing the current default device with the previously obtained one.

The patch fixes these problems on Windows, I can now keep streaming an audio across the changes of the default device.