### PR TITLE
WASPI - Fix stream start after destroy

### DIFF
--- a/src/wasapi/stream.rs
+++ b/src/wasapi/stream.rs
@@ -449,21 +449,27 @@ impl EventLoop {
                             }
                         },
                         Command::PlayStream(stream_id) => {
-                            if let Some(v) = run_context.streams.get_mut(stream_id.0) {
-                                if !v.playing {
-                                    let hresult = (*v.audio_client).Start();
-                                    check_result(hresult).unwrap();
-                                    v.playing = true;
+                            match run_context.streams.iter_mut().find(|v| v.id == stream_id) {
+                                None => continue,
+                                Some(stream) => {
+                                    if !stream.playing {
+                                        let hresult = (*stream.audio_client).Start();
+                                        check_result(hresult).unwrap();
+                                        stream.playing = true;
+                                    }
                                 }
                             }
                         },
                         Command::PauseStream(stream_id) => {
-                            if let Some(v) = run_context.streams.get_mut(stream_id.0) {
-                                if v.playing {
-                                    let hresult = (*v.audio_client).Stop();
-                                    check_result(hresult).unwrap();
-                                    v.playing = false;
-                                }
+                            match run_context.streams.iter_mut().find(|v| v.id == stream_id) {
+                                None => continue,
+                                Some(stream) => {
+                                    if stream.playing {
+                                        let hresult = (*v.audio_client).Stop();
+                                        check_result(hresult).unwrap();
+                                        stream.playing = false;
+                                    }
+                                },
                             }
                         },
                     }

--- a/src/wasapi/stream.rs
+++ b/src/wasapi/stream.rs
@@ -465,7 +465,7 @@ impl EventLoop {
                                 None => continue,
                                 Some(stream) => {
                                     if stream.playing {
-                                        let hresult = (*v.audio_client).Stop();
+                                        let hresult = (*stream.audio_client).Stop();
                                         check_result(hresult).unwrap();
                                         stream.playing = false;
                                     }


### PR DESCRIPTION
On Windows, creating a stream, destroying it and then trying to re-create one was not working. The issue was that the index used by the PlayStream command to find the stream & handle was the StreamId, which keeps incrementing. The second stream had stream id 1, but its index was 0. 

This fixes the issue by making sure we're not using the stream id as an offset, but always finding the right stream by its id. It may not be as performant as a direct access, but we should rarely have more than a few streams. 