### PR TITLE
impl Debug for Device

### DIFF
--- a/src/coreaudio/mod.rs
+++ b/src/coreaudio/mod.rs
@@ -15,6 +15,7 @@ use UnknownTypeInputBuffer;
 use UnknownTypeOutputBuffer;
 
 use std::ffi::CStr;
+use std::fmt;
 use std::mem;
 use std::os::raw::c_char;
 use std::ptr::null;
@@ -299,6 +300,15 @@ impl Device {
 
     pub fn default_output_format(&self) -> Result<Format, DefaultFormatError> {
         self.default_format(kAudioObjectPropertyScopeOutput)
+    }
+}
+
+impl fmt::Debug for Device {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("Device")
+            .field("audio_device_id", &self.audio_device_id)
+            .field("name", &self.name())
+            .finish()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -395,6 +395,12 @@ impl Device {
     }
 }
 
+impl fmt::Debug for Device {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Debug::fmt(&self.0, f)
+    }
+}
+
 impl EventLoop {
     /// Initializes a new events loop.
     #[inline]

--- a/src/wasapi/device.rs
+++ b/src/wasapi/device.rs
@@ -1,5 +1,6 @@
 use std;
 use std::ffi::OsString;
+use std::fmt;
 use std::io::Error as IoError;
 use std::mem;
 use std::ops::{Deref, DerefMut};
@@ -549,6 +550,15 @@ impl Clone for Device {
             device: self.device,
             future_audio_client: self.future_audio_client.clone(),
         }
+    }
+}
+
+impl fmt::Debug for Device {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("Device")
+            .field("device", &self.device)
+            .field("name", &self.name())
+            .finish()
     }
 }
 


### PR DESCRIPTION
The internal alsa, null and emscripten Device implementations already implemented Debug; but the coreaudio and wasapi ones, and therefore also the wrapper, did not.

I decided to eschew the `Device(…)` wrapping in the outer layer (hence a custom implementation rather than `#[derive(Debug)]`), because `Device(Device)`, `Device(Device { … })` and so forth all look better without the extra `Device(…)` wrapping.

On the wasapi and coreaudio implementations I put both the pointer and name. Name because it’s useful, pointer because on Windows at least I believe duplicated names are possible. (e.g. two monitors that include monitors, of the same type; I haven’t strictly confirmed this, because I killed those off harshly on my machine and don’t want to reinstate them.)

I do not have access to a macOS device to confirm that the coreaudio implementation is sane, but I think it is.