### PR TITLE
Fix #227 by handling EINVAL

### DIFF
--- a/src/alsa/mod.rs
+++ b/src/alsa/mod.rs
@@ -91,8 +91,11 @@ impl Device {
             alsa::SND_PCM_NONBLOCK,
         ) {
             -2 |
-            -16 /* determined empirically */ => return Err(FormatsEnumerationError::DeviceNotAvailable),
-            e => check_errors(e).expect("device not available")
+            -16 | /* determined empirically */ 
+            -22 /* Common error in Alsa */ => return Err(FormatsEnumerationError::DeviceNotAvailable),
+            e => {
+                check_errors(e).expect("device not available")
+            }
         }
 
         let hw_params = HwParams::alloc();


### PR DESCRIPTION
 - When iterating a list of formats on a device, gracefully error
   if/when we receive EINVAL from alsa's snd_pcm_open.