### PR TITLE
Better buffer handling

### DIFF
--- a/src/alsa/mod.rs
+++ b/src/alsa/mod.rs
@@ -15,7 +15,7 @@ use SupportedFormat;
 use UnknownTypeInputBuffer;
 use UnknownTypeOutputBuffer;
 
-use std::{cmp, ffi, iter, mem, ptr};
+use std::{cmp, ffi, mem, ptr};
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::vec::IntoIter as VecIntoIter;
@@ -370,6 +370,11 @@ struct StreamInner {
     // A file descriptor opened with `eventfd`.
     // It is used to wait for resume signal.
     resume_trigger: Trigger,
+
+    // Lazily allocated buffer that is reused inside the loop.
+    // Zero-allocate a new buffer (the fastest way to have zeroed memory) at the first time this is
+    // used.
+    buffer: Option<Vec<u8>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -543,67 +548,78 @@ impl EventLoop {
 
                     let available_frames = available_samples / stream_inner.num_channels as usize;
 
+                    let buffer_size = stream_inner.sample_format.sample_size() * available_samples;
+                    // Could be written with a match with improved borrow checking
+                    if stream_inner.buffer.is_none() {
+                        stream_inner.buffer = Some(vec![0u8; buffer_size]);
+                    } else {
+                        stream_inner.buffer.as_mut().unwrap().resize(buffer_size, 0u8);
+                    }
+                    let buffer = stream_inner.buffer.as_mut().unwrap();
+
                     match stream_type {
                         StreamType::Input => {
-                            // Simplify shared logic across the sample format branches.
-                            macro_rules! read_buffer {
-                                ($T:ty, $Variant:ident) => {{
-                                    // The buffer to read into.
-                                    let mut buffer: Vec<$T> = vec![Default::default(); available_samples];
-                                    let err = alsa::snd_pcm_readi(
-                                        stream_inner.channel,
-                                        buffer.as_mut_ptr() as *mut _,
-                                        available_frames as alsa::snd_pcm_uframes_t,
-                                    );
-                                    check_errors(err as _).expect("snd_pcm_readi error");
-                                    let input_buffer = InputBuffer {
-                                        buffer: &buffer,
-                                    };
-                                    let buffer = UnknownTypeInputBuffer::$Variant(::InputBuffer {
-                                        buffer: Some(input_buffer),
-                                    });
-                                    let stream_data = StreamData::Input { buffer: buffer };
-                                    callback(stream_id, stream_data);
-                                }};
-                            }
+                            let err = alsa::snd_pcm_readi(
+                                stream_inner.channel,
+                                buffer.as_mut_ptr() as *mut _,
+                                available_frames as alsa::snd_pcm_uframes_t,
+                            );
+                            check_errors(err as _).expect("snd_pcm_readi error");
 
-                            match stream_inner.sample_format {
-                                SampleFormat::I16 => read_buffer!(i16, I16),
-                                SampleFormat::U16 => read_buffer!(u16, U16),
-                                SampleFormat::F32 => read_buffer!(f32, F32),
-                            }
+                            let input_buffer = match stream_inner.sample_format {
+                                SampleFormat::I16 => UnknownTypeInputBuffer::I16(::InputBuffer {
+                                    buffer: cast_input_buffer(buffer),
+                                }),
+                                SampleFormat::U16 => UnknownTypeInputBuffer::U16(::InputBuffer {
+                                    buffer: cast_input_buffer(buffer),
+                                }),
+                                SampleFormat::F32 => UnknownTypeInputBuffer::F32(::InputBuffer {
+                                    buffer: cast_input_buffer(buffer),
+                                }),
+                            };
+                            let stream_data = StreamData::Input {
+                                buffer: input_buffer,
+                            };
+                            callback(stream_id, stream_data);
                         },
                         StreamType::Output => {
-                            // We're now sure that we're ready to write data.
-                            let buffer = match stream_inner.sample_format {
-                                SampleFormat::I16 => {
-                                    let buffer = OutputBuffer {
-                                        stream_inner: stream_inner,
-                                        buffer: vec![Default::default(); available_samples],
-                                    };
+                            {
+                                // We're now sure that we're ready to write data.
+                                let output_buffer = match stream_inner.sample_format {
+                                    SampleFormat::I16 => UnknownTypeOutputBuffer::I16(::OutputBuffer {
+                                        buffer: cast_output_buffer(buffer),
+                                    }),
+                                    SampleFormat::U16 => UnknownTypeOutputBuffer::U16(::OutputBuffer {
+                                        buffer: cast_output_buffer(buffer),
+                                    }),
+                                    SampleFormat::F32 => UnknownTypeOutputBuffer::F32(::OutputBuffer {
+                                        buffer: cast_output_buffer(buffer),
+                                    }),
+                                };
 
-                                    UnknownTypeOutputBuffer::I16(::OutputBuffer { target: Some(buffer) })
-                                },
-                                SampleFormat::U16 => {
-                                    let buffer = OutputBuffer {
-                                        stream_inner: stream_inner,
-                                        buffer: vec![Default::default(); available_samples],
-                                    };
+                                let stream_data = StreamData::Output {
+                                    buffer: output_buffer,
+                                };
+                                callback(stream_id, stream_data);
+                            }
+                            loop {
+                                let result = alsa::snd_pcm_writei(
+                                    stream_inner.channel,
+                                    buffer.as_ptr() as *const _,
+                                    available_frames as alsa::snd_pcm_uframes_t,
+                                );
 
-                                    UnknownTypeOutputBuffer::U16(::OutputBuffer { target: Some(buffer) })
-                                },
-                                SampleFormat::F32 => {
-                                    let buffer = OutputBuffer {
-                                        stream_inner: stream_inner,
-                                        buffer: vec![Default::default(); available_samples]
-                                    };
-
-                                    UnknownTypeOutputBuffer::F32(::OutputBuffer { target: Some(buffer) })
-                                },
-                            };
-
-                            let stream_data = StreamData::Output { buffer: buffer };
-                            callback(stream_id, stream_data);
+                                if result == -32 {
+                                    // buffer underrun
+                                    alsa::snd_pcm_prepare(stream_inner.channel);
+                                } else if result < 0 {
+                                    check_errors(result as libc::c_int)
+                                        .expect("could not write pcm");
+                                } else {
+                                    assert_eq!(result as usize, available_frames);
+                                    break;
+                                }
+                            }
                         },
                     }
                 }
@@ -661,6 +677,7 @@ impl EventLoop {
                 can_pause: can_pause,
                 is_paused: false,
                 resume_trigger: Trigger::new(),
+                buffer: None,
             };
 
             check_errors(alsa::snd_pcm_start(capture_handle))
@@ -721,6 +738,7 @@ impl EventLoop {
                 can_pause: can_pause,
                 is_paused: false,
                 resume_trigger: Trigger::new(),
+                buffer: None,
             };
 
             self.push_command(Command::NewStream(stream_inner));
@@ -834,15 +852,6 @@ unsafe fn set_sw_params_from_format(
     (buffer_len, period_len)
 }
 
-pub struct InputBuffer<'a, T: 'a> {
-    buffer: &'a [T],
-}
-
-pub struct OutputBuffer<'a, T: 'a> {
-    stream_inner: &'a mut StreamInner,
-    buffer: Vec<T>,
-}
-
 /// Wrapper around `hw_params`.
 struct HwParams(*mut alsa::snd_pcm_hw_params_t);
 
@@ -874,53 +883,6 @@ impl Drop for StreamInner {
     }
 }
 
-impl<'a, T> InputBuffer<'a, T> {
-    #[inline]
-    pub fn buffer(&self) -> &[T] {
-        &self.buffer
-    }
-
-    #[inline]
-    pub fn finish(self) {
-        // Nothing to be done.
-    }
-}
-
-impl<'a, T> OutputBuffer<'a, T> {
-    #[inline]
-    pub fn buffer(&mut self) -> &mut [T] {
-        &mut self.buffer
-    }
-
-    #[inline]
-    pub fn len(&self) -> usize {
-        self.buffer.len()
-    }
-
-    pub fn finish(self) {
-        let to_write = (self.buffer.len() / self.stream_inner.num_channels as usize) as
-            alsa::snd_pcm_uframes_t;
-
-        unsafe {
-            loop {
-                let result = alsa::snd_pcm_writei(self.stream_inner.channel,
-                                                  self.buffer.as_ptr() as *const _,
-                                                  to_write);
-
-                if result == -32 {
-                    // buffer underrun
-                    alsa::snd_pcm_prepare(self.stream_inner.channel);
-                } else if result < 0 {
-                    check_errors(result as libc::c_int).expect("could not write pcm");
-                } else {
-                    assert_eq!(result as alsa::snd_pcm_uframes_t, to_write);
-                    break;
-                }
-            }
-        }
-    }
-}
-
 #[inline]
 fn check_errors(err: libc::c_int) -> Result<(), String> {
     use std::ffi;
@@ -936,4 +898,18 @@ fn check_errors(err: libc::c_int) -> Result<(), String> {
     }
 
     Ok(())
+}
+
+/// Cast a byte slice into a (immutable) slice of desired type.
+/// Safety: it's up to the caller to ensure that the input slice has valid bit representations.
+unsafe fn cast_input_buffer<T>(v: &[u8]) -> &[T] {
+    debug_assert!(v.len() % std::mem::size_of::<T>() == 0);
+    std::slice::from_raw_parts(v.as_ptr() as *const T, v.len() / std::mem::size_of::<T>())
+}
+
+/// Cast a byte slice into a mutable slice of desired type.
+/// Safety: it's up to the caller to ensure that the input slice has valid bit representations.
+unsafe fn cast_output_buffer<T>(v: &mut [u8]) -> &mut [T] {
+    debug_assert!(v.len() % std::mem::size_of::<T>() == 0);
+    std::slice::from_raw_parts_mut(v.as_mut_ptr() as *mut T, v.len() / std::mem::size_of::<T>())
 }

--- a/src/coreaudio/mod.rs
+++ b/src/coreaudio/mod.rs
@@ -671,8 +671,7 @@ impl EventLoop {
                         Some(cb) => cb,
                         None => return Ok(()),
                     };
-                    let buffer = InputBuffer { buffer: data_slice };
-                    let unknown_type_buffer = UnknownTypeInputBuffer::$SampleFormat(::InputBuffer { buffer: Some(buffer) });
+                    let unknown_type_buffer = UnknownTypeInputBuffer::$SampleFormat(::InputBuffer { buffer: data_slice });
                     let stream_data = StreamData::Input { buffer: unknown_type_buffer };
                     callback(StreamId(stream_id), stream_data);
                 }};
@@ -748,8 +747,7 @@ impl EventLoop {
                             return Ok(());
                         }
                     };
-                    let buffer = OutputBuffer { buffer: data_slice };
-                    let unknown_type_buffer = UnknownTypeOutputBuffer::$SampleFormat(::OutputBuffer { target: Some(buffer) });
+                    let unknown_type_buffer = UnknownTypeOutputBuffer::$SampleFormat(::OutputBuffer { buffer: data_slice });
                     let stream_data = StreamData::Output { buffer: unknown_type_buffer };
                     callback(StreamId(stream_id), stream_data);
                 }};
@@ -796,44 +794,5 @@ impl EventLoop {
             stream.audio_unit.stop().unwrap();
             stream.playing = false;
         }
-    }
-}
-
-pub struct InputBuffer<'a, T: 'a> {
-    buffer: &'a [T],
-}
-
-pub struct OutputBuffer<'a, T: 'a> {
-    buffer: &'a mut [T],
-}
-
-impl<'a, T> InputBuffer<'a, T> {
-    #[inline]
-    pub fn buffer(&self) -> &[T] {
-        &self.buffer
-    }
-
-    #[inline]
-    pub fn finish(self) {
-        // Nothing to be done.
-    }
-}
-
-impl<'a, T> OutputBuffer<'a, T>
-    where T: Sample
-{
-    #[inline]
-    pub fn buffer(&mut self) -> &mut [T] {
-        &mut self.buffer
-    }
-
-    #[inline]
-    pub fn len(&self) -> usize {
-        self.buffer.len()
-    }
-
-    #[inline]
-    pub fn finish(self) {
-        // Do nothing. We wrote directly to the buffer.
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -211,31 +211,27 @@ pub enum StreamData<'a> {
 /// This struct implements the `Deref` trait targeting `[T]`. Therefore this buffer can be read the
 /// same way as reading from a `Vec` or any other kind of Rust array.
 // TODO: explain audio stuff in general
+// TODO: remove the wrapper and just use slices in next major version
 pub struct InputBuffer<'a, T: 'a>
 where
     T: Sample,
 {
-    // Always contains something, taken by `Drop`
-    // TODO: change that
-    buffer: Option<cpal_impl::InputBuffer<'a, T>>,
+    buffer: &'a [T],
 }
 
-/// Represents a buffer that must be filled with audio data.
-///
-/// You should destroy this object as soon as possible. Data is only sent to the audio device when
-/// this object is destroyed.
+/// Represents a buffer that must be filled with audio data. The buffer in unfilled state may
+/// contain garbage values.
 ///
 /// This struct implements the `Deref` and `DerefMut` traits to `[T]`. Therefore writing to this
 /// buffer is done in the same way as writing to a `Vec` or any other kind of Rust array.
 // TODO: explain audio stuff in general
+// TODO: remove the wrapper and just use slices
 #[must_use]
 pub struct OutputBuffer<'a, T: 'a>
 where
     T: Sample,
 {
-    // Always contains something, taken by `Drop`
-    // TODO: change that
-    target: Option<cpal_impl::OutputBuffer<'a, T>>,
+    buffer: &'a mut [T],
 }
 
 /// This is the struct that is provided to you by cpal when you want to read samples from a buffer.
@@ -586,16 +582,7 @@ impl<'a, T> Deref for InputBuffer<'a, T>
 
     #[inline]
     fn deref(&self) -> &[T] {
-        self.buffer.as_ref().unwrap().buffer()
-    }
-}
-
-impl<'a, T> Drop for InputBuffer<'a, T>
-    where T: Sample
-{
-    #[inline]
-    fn drop(&mut self) {
-        self.buffer.take().unwrap().finish();
+        self.buffer
     }
 }
 
@@ -615,16 +602,7 @@ impl<'a, T> DerefMut for OutputBuffer<'a, T>
 {
     #[inline]
     fn deref_mut(&mut self) -> &mut [T] {
-        self.target.as_mut().unwrap().buffer()
-    }
-}
-
-impl<'a, T> Drop for OutputBuffer<'a, T>
-    where T: Sample
-{
-    #[inline]
-    fn drop(&mut self) {
-        self.target.take().unwrap().finish();
+        self.buffer
     }
 }
 
@@ -645,9 +623,9 @@ impl<'a> UnknownTypeOutputBuffer<'a> {
     #[inline]
     pub fn len(&self) -> usize {
         match self {
-            &UnknownTypeOutputBuffer::U16(ref buf) => buf.target.as_ref().unwrap().len(),
-            &UnknownTypeOutputBuffer::I16(ref buf) => buf.target.as_ref().unwrap().len(),
-            &UnknownTypeOutputBuffer::F32(ref buf) => buf.target.as_ref().unwrap().len(),
+            &UnknownTypeOutputBuffer::U16(ref buf) => buf.len(),
+            &UnknownTypeOutputBuffer::I16(ref buf) => buf.len(),
+            &UnknownTypeOutputBuffer::F32(ref buf) => buf.len(),
         }
     }
 }

--- a/src/null/mod.rs
+++ b/src/null/mod.rs
@@ -133,30 +133,3 @@ pub struct InputBuffer<'a, T: 'a> {
 pub struct OutputBuffer<'a, T: 'a> {
     marker: PhantomData<&'a mut T>,
 }
-
-impl<'a, T> InputBuffer<'a, T> {
-    #[inline]
-    pub fn buffer(&self) -> &[T] {
-        unimplemented!()
-    }
-
-    #[inline]
-    pub fn finish(self) {
-    }
-}
-
-impl<'a, T> OutputBuffer<'a, T> {
-    #[inline]
-    pub fn buffer(&mut self) -> &mut [T] {
-        unimplemented!()
-    }
-
-    #[inline]
-    pub fn len(&self) -> usize {
-        0
-    }
-
-    #[inline]
-    pub fn finish(self) {
-    }
-}

--- a/src/wasapi/mod.rs
+++ b/src/wasapi/mod.rs
@@ -3,7 +3,7 @@ extern crate winapi;
 use std::io::Error as IoError;
 
 pub use self::device::{Device, Devices, SupportedInputFormats, SupportedOutputFormats, default_input_device, default_output_device};
-pub use self::stream::{InputBuffer, OutputBuffer, EventLoop, StreamId};
+pub use self::stream::{EventLoop, StreamId};
 use self::winapi::um::winnt::HRESULT;
 
 mod com;


### PR DESCRIPTION
- ALSA backend: reuse the buffers
- Make `InputBuffer` and `OutputBuffer` types just a wrapper of slice
  * Buffer is now submitted at the end of callback