### PR TITLE
Remove unnecessary panic! from OutputBuffer Deref impl

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -602,7 +602,7 @@ impl<'a, T> Deref for OutputBuffer<'a, T>
 
     #[inline]
     fn deref(&self) -> &[T] {
-        panic!("It is forbidden to read from the audio buffer");
+        self.buffer
     }
 }
 


### PR DESCRIPTION
Since #269 this `panic!` is certainly unnecessary as `InputBuffer` and
`OutputBuffer` are a thin wrapper around a slice. That said, I'm
struggling to understand exactly why this `panic!` was necessary in the
first place.

This closes #228.