### PR TITLE
Error Handling Overhaul

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ license = "Apache-2.0"
 keywords = ["audio", "sound"]
 
 [dependencies]
+failure = "0.1.5"
 lazy_static = "1.3"
 
 [dev-dependencies]

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,9 +7,6 @@ environment:
       target: x86_64-pc-windows-msvc
     - channel: nightly
       target: x86_64-pc-windows-msvc
-    # GNU
-    - channel: stable
-      target: x86_64-pc-windows-gnu
 
 matrix:
   allow_failures:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,21 +5,11 @@ environment:
     # MSVC
     - channel: stable
       target: x86_64-pc-windows-msvc
-    - channel: stable
-      target: i686-pc-windows-msvc
     - channel: nightly
       target: x86_64-pc-windows-msvc
-    - channel: nightly
-      target: i686-pc-windows-msvc
     # GNU
     - channel: stable
       target: x86_64-pc-windows-gnu
-    - channel: stable
-      target: i686-pc-windows-gnu
-    - channel: nightly
-      target: x86_64-pc-windows-gnu
-    - channel: nightly
-      target: i686-pc-windows-gnu
 
 matrix:
   allow_failures:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,16 +1,38 @@
+os: Visual Studio 2015
+
+environment:
+  matrix:
+    # MSVC
+    - channel: stable
+      target: x86_64-pc-windows-msvc
+    - channel: stable
+      target: i686-pc-windows-msvc
+    - channel: nightly
+      target: x86_64-pc-windows-msvc
+    - channel: nightly
+      target: i686-pc-windows-msvc
+    # GNU
+    - channel: stable
+      target: x86_64-pc-windows-gnu
+    - channel: stable
+      target: i686-pc-windows-gnu
+    - channel: nightly
+      target: x86_64-pc-windows-gnu
+    - channel: nightly
+      target: i686-pc-windows-gnu
+
+matrix:
+  allow_failures:
+    - channel: nightly
+
 install:
-  - ps: Start-FileDownload 'https://static.rust-lang.org/dist/rust-nightly-i686-pc-windows-gnu.exe'
-  - ps: Start-FileDownload 'https://static.rust-lang.org/cargo-dist/cargo-nightly-i686-pc-windows-gnu.tar.gz'
-  - rust-nightly-i686-pc-windows-gnu.exe /VERYSILENT /NORESTART /DIR="C:\Program Files (x86)\Rust"
-  - 7z e cargo-nightly-i686-pc-windows-gnu.tar.gz
-  - 7z x cargo-nightly-i686-pc-windows-gnu.tar
-  - SET PATH=%PATH%;C:\Program Files (x86)\Rust\bin
-  - SET PATH=%PATH%;%CD%\cargo-nightly-i686-pc-windows-gnu\bin
-  - rustc -V
-  - cargo -V
+  - appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
+  - rustup-init -yv --default-toolchain %channel% --default-host %target%
+  - set PATH=%PATH%;%USERPROFILE%\.cargo\bin
+  - rustc -vV
+  - cargo -vV
 
 build: false
 
 test_script:
-  - cargo build --verbose
-#  - cargo test --verbose
+- cargo test --verbose %cargoflags%

--- a/examples/beep.rs
+++ b/examples/beep.rs
@@ -1,11 +1,12 @@
 extern crate cpal;
+extern crate failure;
 
-fn main() {
-    let device = cpal::default_output_device().expect("Failed to get default output device");
-    let format = device.default_output_format().expect("Failed to get default output format");
+fn main() -> Result<(), failure::Error> {
+    let device = cpal::default_output_device().expect("failed to find a default output device");
+    let format = device.default_output_format()?;
     let event_loop = cpal::EventLoop::new();
-    let stream_id = event_loop.build_output_stream(&device, &format).unwrap();
-    event_loop.play_stream(stream_id.clone()).unwrap();
+    let stream_id = event_loop.build_output_stream(&device, &format)?;
+    event_loop.play_stream(stream_id.clone())?;
 
     let sample_rate = format.sample_rate.0 as f32;
     let mut sample_clock = 0f32;

--- a/examples/beep.rs
+++ b/examples/beep.rs
@@ -5,7 +5,7 @@ fn main() {
     let format = device.default_output_format().expect("Failed to get default output format");
     let event_loop = cpal::EventLoop::new();
     let stream_id = event_loop.build_output_stream(&device, &format).unwrap();
-    event_loop.play_stream(stream_id.clone());
+    event_loop.play_stream(stream_id.clone()).unwrap();
 
     let sample_rate = format.sample_rate.0 as f32;
     let mut sample_clock = 0f32;

--- a/examples/enumerate.rs
+++ b/examples/enumerate.rs
@@ -1,15 +1,16 @@
 extern crate cpal;
+extern crate failure;
 
-fn main() {
-    println!("Default Input Device:\n  {:?}", cpal::default_input_device().map(|e| e.name().unwrap()));
-    println!("Default Output Device:\n  {:?}", cpal::default_output_device().map(|e| e.name().unwrap()));
+fn main() -> Result<(), failure::Error> {
+    let default_in = cpal::default_input_device().map(|e| e.name().unwrap());
+    let default_out = cpal::default_output_device().map(|e| e.name().unwrap());
+    println!("Default Input Device:\n  {:?}", default_in);
+    println!("Default Output Device:\n  {:?}", default_out);
 
-    let devices = cpal::devices().expect("failed to enumerate devices");
+    let devices = cpal::devices()?;
     println!("Devices: ");
     for (device_index, device) in devices.enumerate() {
-        println!("{}. \"{}\"",
-                 device_index + 1,
-                 device.name().unwrap());
+        println!("{}. \"{}\"", device_index + 1, device.name()?);
 
         // Input formats
         if let Ok(fmt) = device.default_input_format() {
@@ -47,4 +48,6 @@ fn main() {
             }
         }
     }
+
+    Ok(())
 }

--- a/examples/enumerate.rs
+++ b/examples/enumerate.rs
@@ -1,15 +1,15 @@
 extern crate cpal;
 
 fn main() {
-    println!("Default Input Device:\n  {:?}", cpal::default_input_device().map(|e| e.name()));
-    println!("Default Output Device:\n  {:?}", cpal::default_output_device().map(|e| e.name()));
+    println!("Default Input Device:\n  {:?}", cpal::default_input_device().map(|e| e.name().unwrap()));
+    println!("Default Output Device:\n  {:?}", cpal::default_output_device().map(|e| e.name().unwrap()));
 
     let devices = cpal::devices().expect("failed to enumerate devices");
     println!("Devices: ");
     for (device_index, device) in devices.enumerate() {
         println!("{}. \"{}\"",
                  device_index + 1,
-                 device.name());
+                 device.name().unwrap());
 
         // Input formats
         if let Ok(fmt) = device.default_input_format() {

--- a/examples/enumerate.rs
+++ b/examples/enumerate.rs
@@ -4,7 +4,7 @@ fn main() {
     println!("Default Input Device:\n  {:?}", cpal::default_input_device().map(|e| e.name()));
     println!("Default Output Device:\n  {:?}", cpal::default_output_device().map(|e| e.name()));
 
-    let devices = cpal::devices();
+    let devices = cpal::devices().expect("failed to enumerate devices");
     println!("Devices: ");
     for (device_index, device) in devices.enumerate() {
         println!("{}. \"{}\"",

--- a/examples/feedback.rs
+++ b/examples/feedback.rs
@@ -16,8 +16,8 @@ fn main() {
     // Default devices.
     let input_device = cpal::default_input_device().expect("Failed to get default input device");
     let output_device = cpal::default_output_device().expect("Failed to get default output device");
-    println!("Using default input device: \"{}\"", input_device.name());
-    println!("Using default output device: \"{}\"", output_device.name());
+    println!("Using default input device: \"{}\"", input_device.name().unwrap());
+    println!("Using default output device: \"{}\"", output_device.name().unwrap());
 
     // We'll try and use the same format between streams to keep it simple
     let mut format = input_device.default_input_format().expect("Failed to get default format");

--- a/examples/feedback.rs
+++ b/examples/feedback.rs
@@ -43,8 +43,8 @@ fn main() {
 
     // Play the streams.
     println!("Starting the input and output streams with `{}` milliseconds of latency.", LATENCY_MS);
-    event_loop.play_stream(input_stream_id.clone());
-    event_loop.play_stream(output_stream_id.clone());
+    event_loop.play_stream(input_stream_id.clone()).unwrap();
+    event_loop.play_stream(output_stream_id.clone()).unwrap();
 
     // Run the event loop on a separate thread.
     std::thread::spawn(move || {

--- a/examples/feedback.rs
+++ b/examples/feedback.rs
@@ -7,26 +7,27 @@
 //! precisely synchronised.
 
 extern crate cpal;
+extern crate failure;
 
 const LATENCY_MS: f32 = 150.0;
 
-fn main() {
+fn main() -> Result<(), failure::Error> {
     let event_loop = cpal::EventLoop::new();
 
     // Default devices.
-    let input_device = cpal::default_input_device().expect("Failed to get default input device");
-    let output_device = cpal::default_output_device().expect("Failed to get default output device");
-    println!("Using default input device: \"{}\"", input_device.name().unwrap());
-    println!("Using default output device: \"{}\"", output_device.name().unwrap());
+    let input_device = cpal::default_input_device().expect("failed to get default input device");
+    let output_device = cpal::default_output_device().expect("failed to get default output device");
+    println!("Using default input device: \"{}\"", input_device.name()?);
+    println!("Using default output device: \"{}\"", output_device.name()?);
 
     // We'll try and use the same format between streams to keep it simple
-    let mut format = input_device.default_input_format().expect("Failed to get default format");
+    let mut format = input_device.default_input_format()?;
     format.data_type = cpal::SampleFormat::F32;
 
     // Build streams.
     println!("Attempting to build both streams with `{:?}`.", format);
-    let input_stream_id = event_loop.build_input_stream(&input_device, &format).unwrap();
-    let output_stream_id = event_loop.build_output_stream(&output_device, &format).unwrap();
+    let input_stream_id = event_loop.build_input_stream(&input_device, &format)?;
+    let output_stream_id = event_loop.build_output_stream(&output_device, &format)?;
     println!("Successfully built streams.");
 
     // Create a delay in case the input and output devices aren't synced.
@@ -38,13 +39,13 @@ fn main() {
 
     // Fill the samples with 0.0 equal to the length of the delay.
     for _ in 0..latency_samples {
-        tx.send(0.0).unwrap();
+        tx.send(0.0)?;
     }
 
     // Play the streams.
     println!("Starting the input and output streams with `{}` milliseconds of latency.", LATENCY_MS);
-    event_loop.play_stream(input_stream_id.clone()).unwrap();
-    event_loop.play_stream(output_stream_id.clone()).unwrap();
+    event_loop.play_stream(input_stream_id.clone())?;
+    event_loop.play_stream(output_stream_id.clone())?;
 
     // Run the event loop on a separate thread.
     std::thread::spawn(move || {
@@ -87,4 +88,5 @@ fn main() {
     println!("Playing for 3 seconds... ");
     std::thread::sleep(std::time::Duration::from_secs(3));
     println!("Done!");
+    Ok(())
 }

--- a/examples/record_wav.rs
+++ b/examples/record_wav.rs
@@ -14,7 +14,7 @@ fn main() {
     let event_loop = cpal::EventLoop::new();
     let stream_id = event_loop.build_input_stream(&device, &format)
         .expect("Failed to build input stream");
-    event_loop.play_stream(stream_id);
+    event_loop.play_stream(stream_id).unwrap();
 
     // The WAV file we're recording to.
     const PATH: &'static str = concat!(env!("CARGO_MANIFEST_DIR"), "/recorded.wav");

--- a/examples/record_wav.rs
+++ b/examples/record_wav.rs
@@ -3,23 +3,23 @@
 //! The input data is recorded to "$CARGO_MANIFEST_DIR/recorded.wav".
 
 extern crate cpal;
+extern crate failure;
 extern crate hound;
 
-fn main() {
+fn main() -> Result<(), failure::Error> {
     // Setup the default input device and stream with the default input format.
     let device = cpal::default_input_device().expect("Failed to get default input device");
-    println!("Default input device: {}", device.name().unwrap());
+    println!("Default input device: {}", device.name()?);
     let format = device.default_input_format().expect("Failed to get default input format");
     println!("Default input format: {:?}", format);
     let event_loop = cpal::EventLoop::new();
-    let stream_id = event_loop.build_input_stream(&device, &format)
-        .expect("Failed to build input stream");
-    event_loop.play_stream(stream_id).unwrap();
+    let stream_id = event_loop.build_input_stream(&device, &format)?;
+    event_loop.play_stream(stream_id)?;
 
     // The WAV file we're recording to.
     const PATH: &'static str = concat!(env!("CARGO_MANIFEST_DIR"), "/recorded.wav");
     let spec = wav_spec_from_format(&format);
-    let writer = hound::WavWriter::create(PATH, spec).unwrap();
+    let writer = hound::WavWriter::create(PATH, spec)?;
     let writer = std::sync::Arc::new(std::sync::Mutex::new(Some(writer)));
 
     // A flag to indicate that recording is in progress.
@@ -73,8 +73,9 @@ fn main() {
     // Let recording go for roughly three seconds.
     std::thread::sleep(std::time::Duration::from_secs(3));
     recording.store(false, std::sync::atomic::Ordering::Relaxed);
-    writer.lock().unwrap().take().unwrap().finalize().unwrap();
+    writer.lock().unwrap().take().unwrap().finalize()?;
     println!("Recording {} complete!", PATH);
+    Ok(())
 }
 
 fn sample_format(format: cpal::SampleFormat) -> hound::SampleFormat {

--- a/examples/record_wav.rs
+++ b/examples/record_wav.rs
@@ -8,7 +8,7 @@ extern crate hound;
 fn main() {
     // Setup the default input device and stream with the default input format.
     let device = cpal::default_input_device().expect("Failed to get default input device");
-    println!("Default input device: {}", device.name());
+    println!("Default input device: {}", device.name().unwrap());
     let format = device.default_input_format().expect("Failed to get default input format");
     println!("Default input format: {:?}", format);
     let event_loop = cpal::EventLoop::new();

--- a/src/alsa/enumerate.rs
+++ b/src/alsa/enumerate.rs
@@ -30,13 +30,13 @@ impl Drop for Devices {
 impl Default for Devices {
     fn default() -> Devices {
         unsafe {
-            let mut hints = mem::uninitialized();
-            // TODO: check in which situation this can fail
-            check_errors(alsa::snd_device_name_hint(-1, b"pcm\0".as_ptr() as *const _, &mut hints))
-                .unwrap();
-
+            // TODO: check in which situation this can fail.
+            let card = -1; // -1 means all cards.
+            let iface = b"pcm\0"; // Interface identification.
+            let mut hints = mem::uninitialized(); // Array of device name hints.
+            let res = alsa::snd_device_name_hint(card, iface.as_ptr() as *const _, &mut hints);
+            check_errors(res).unwrap();
             let hints = hints as *const *const u8;
-
             Devices {
                 global_list: hints,
                 next_str: hints,

--- a/src/alsa/mod.rs
+++ b/src/alsa/mod.rs
@@ -313,8 +313,7 @@ impl Device {
                     return Err(DefaultFormatError::StreamTypeNotSupported);
                 }
                 Err(SupportedFormatsError::BackendSpecific { err }) => {
-                    unimplemented!();
-                    //return Err(err.into());
+                    return Err(err.into());
                 }
                 Ok(fmts) => fmts.collect(),
             }

--- a/src/alsa/mod.rs
+++ b/src/alsa/mod.rs
@@ -7,6 +7,7 @@ use ChannelCount;
 use BackendSpecificError;
 use BuildStreamError;
 use DefaultFormatError;
+use DeviceNameError;
 use Format;
 use SupportedFormatsError;
 use SampleFormat;
@@ -74,8 +75,8 @@ pub struct Device(String);
 
 impl Device {
     #[inline]
-    pub fn name(&self) -> String {
-        self.0.clone()
+    pub fn name(&self) -> Result<String, DeviceNameError> {
+        Ok(self.0.clone())
     }
 
     unsafe fn supported_formats(

--- a/src/alsa/mod.rs
+++ b/src/alsa/mod.rs
@@ -4,7 +4,7 @@ extern crate libc;
 pub use self::enumerate::{Devices, default_input_device, default_output_device};
 
 use ChannelCount;
-use CreationError;
+use BuildStreamError;
 use DefaultFormatError;
 use Format;
 use SupportedFormatsError;
@@ -644,7 +644,7 @@ impl EventLoop {
         &self,
         device: &Device,
         format: &Format,
-    ) -> Result<StreamId, CreationError>
+    ) -> Result<StreamId, BuildStreamError>
     {
         unsafe {
             let name = ffi::CString::new(device.0.clone()).expect("unable to clone device");
@@ -656,10 +656,10 @@ impl EventLoop {
                 alsa::SND_PCM_STREAM_CAPTURE,
                 alsa::SND_PCM_NONBLOCK,
             ) {
-                -16 /* determined empirically */ => return Err(CreationError::DeviceNotAvailable),
-                -22 => return Err(CreationError::InvalidArgument),
+                -16 /* determined empirically */ => return Err(BuildStreamError::DeviceNotAvailable),
+                -22 => return Err(BuildStreamError::InvalidArgument),
                 e => if check_errors(e).is_err() {
-                    return Err(CreationError::Unknown);
+                    return Err(BuildStreamError::Unknown);
                 }
             }
             let hw_params = HwParams::alloc();
@@ -708,7 +708,7 @@ impl EventLoop {
         &self,
         device: &Device,
         format: &Format,
-    ) -> Result<StreamId, CreationError>
+    ) -> Result<StreamId, BuildStreamError>
     {
         unsafe {
             let name = ffi::CString::new(device.0.clone()).expect("unable to clone device");
@@ -720,10 +720,10 @@ impl EventLoop {
                 alsa::SND_PCM_STREAM_PLAYBACK,
                 alsa::SND_PCM_NONBLOCK,
             ) {
-                -16 /* determined empirically */ => return Err(CreationError::DeviceNotAvailable),
-                -22 => return Err(CreationError::InvalidArgument),
+                -16 /* determined empirically */ => return Err(BuildStreamError::DeviceNotAvailable),
+                -22 => return Err(BuildStreamError::InvalidArgument),
                 e => if check_errors(e).is_err() {
-                    return Err(CreationError::Unknown);
+                    return Err(BuildStreamError::Unknown);
                 }
             }
             let hw_params = HwParams::alloc();

--- a/src/alsa/mod.rs
+++ b/src/alsa/mod.rs
@@ -9,6 +9,8 @@ use BuildStreamError;
 use DefaultFormatError;
 use DeviceNameError;
 use Format;
+use PauseStreamError;
+use PlayStreamError;
 use SupportedFormatsError;
 use SampleFormat;
 use SampleRate;
@@ -837,13 +839,15 @@ impl EventLoop {
     }
 
     #[inline]
-    pub fn play_stream(&self, stream_id: StreamId) {
+    pub fn play_stream(&self, stream_id: StreamId) -> Result<(), PlayStreamError> {
         self.push_command(Command::PlayStream(stream_id));
+        Ok(())
     }
 
     #[inline]
-    pub fn pause_stream(&self, stream_id: StreamId) {
+    pub fn pause_stream(&self, stream_id: StreamId) -> Result<(), PauseStreamError> {
         self.push_command(Command::PauseStream(stream_id));
+        Ok(())
     }
 }
 

--- a/src/coreaudio/mod.rs
+++ b/src/coreaudio/mod.rs
@@ -10,7 +10,6 @@ use Format;
 use PauseStreamError;
 use PlayStreamError;
 use SupportedFormatsError;
-use Sample;
 use SampleFormat;
 use SampleRate;
 use StreamData;
@@ -55,7 +54,6 @@ use self::coreaudio::sys::{
     kAudioFormatFlagIsFloat,
     kAudioFormatFlagIsPacked,
     kAudioFormatLinearPCM,
-    kAudioHardwareNoError,
     kAudioObjectPropertyElementMaster,
     kAudioObjectPropertyScopeOutput,
     kAudioOutputUnitProperty_CurrentDevice,
@@ -790,7 +788,7 @@ impl EventLoop {
 
         if !stream.playing {
             if let Err(e) = stream.audio_unit.start() {
-                let description = format!("{}", std::error::Error::description(e));
+                let description = format!("{}", std::error::Error::description(&e));
                 let err = BackendSpecificError { description };
                 return Err(err.into());
             }
@@ -805,7 +803,7 @@ impl EventLoop {
 
         if stream.playing {
             if let Err(e) = stream.audio_unit.stop() {
-                let description = format!("{}", std::error::Error::description(e));
+                let description = format!("{}", std::error::Error::description(&e));
                 let err = BackendSpecificError { description };
                 return Err(err.into());
             }

--- a/src/coreaudio/mod.rs
+++ b/src/coreaudio/mod.rs
@@ -2,7 +2,7 @@ extern crate coreaudio;
 extern crate core_foundation_sys;
 
 use ChannelCount;
-use CreationError;
+use BuildStreamError;
 use DefaultFormatError;
 use Format;
 use SupportedFormatsError;
@@ -338,15 +338,15 @@ struct StreamInner {
 }
 
 // TODO need stronger error identification
-impl From<coreaudio::Error> for CreationError {
-    fn from(err: coreaudio::Error) -> CreationError {
+impl From<coreaudio::Error> for BuildStreamError {
+    fn from(err: coreaudio::Error) -> BuildStreamError {
         match err {
             coreaudio::Error::RenderCallbackBufferFormatDoesNotMatchAudioUnitStreamFormat |
             coreaudio::Error::NoKnownSubtype |
             coreaudio::Error::AudioUnit(coreaudio::error::AudioUnitError::FormatNotSupported) |
             coreaudio::Error::AudioCodec(_) |
-            coreaudio::Error::AudioFormat(_) => CreationError::FormatNotSupported,
-            _ => CreationError::DeviceNotAvailable,
+            coreaudio::Error::AudioFormat(_) => BuildStreamError::FormatNotSupported,
+            _ => BuildStreamError::DeviceNotAvailable,
         }
     }
 }
@@ -483,7 +483,7 @@ impl EventLoop {
         &self,
         device: &Device,
         format: &Format,
-    ) -> Result<StreamId, CreationError>
+    ) -> Result<StreamId, BuildStreamError>
     {
         // The scope and element for working with a device's input stream.
         let scope = Scope::Output;
@@ -555,7 +555,7 @@ impl EventLoop {
                     .iter()
                     .position(|r| r.mMinimum as u32 == sample_rate && r.mMaximum as u32 == sample_rate);
                 let range_index = match maybe_index {
-                    None => return Err(CreationError::FormatNotSupported),
+                    None => return Err(BuildStreamError::FormatNotSupported),
                     Some(i) => i,
                 };
 
@@ -700,7 +700,7 @@ impl EventLoop {
         &self,
         device: &Device,
         format: &Format,
-    ) -> Result<StreamId, CreationError>
+    ) -> Result<StreamId, BuildStreamError>
     {
         let mut audio_unit = audio_unit_from_device(device, false)?;
 

--- a/src/coreaudio/mod.rs
+++ b/src/coreaudio/mod.rs
@@ -5,7 +5,7 @@ use ChannelCount;
 use CreationError;
 use DefaultFormatError;
 use Format;
-use FormatsEnumerationError;
+use SupportedFormatsError;
 use Sample;
 use SampleFormat;
 use SampleRate;
@@ -108,7 +108,7 @@ impl Device {
     fn supported_formats(
         &self,
         scope: AudioObjectPropertyScope,
-    ) -> Result<SupportedOutputFormats, FormatsEnumerationError>
+    ) -> Result<SupportedOutputFormats, SupportedFormatsError>
     {
         let mut property_address = AudioObjectPropertyAddress {
             mSelector: kAudioDevicePropertyStreamConfiguration,
@@ -212,11 +212,11 @@ impl Device {
         }
     }
 
-    pub fn supported_input_formats(&self) -> Result<SupportedOutputFormats, FormatsEnumerationError> {
+    pub fn supported_input_formats(&self) -> Result<SupportedOutputFormats, SupportedFormatsError> {
         self.supported_formats(kAudioObjectPropertyScopeInput)
     }
 
-    pub fn supported_output_formats(&self) -> Result<SupportedOutputFormats, FormatsEnumerationError> {
+    pub fn supported_output_formats(&self) -> Result<SupportedOutputFormats, SupportedFormatsError> {
         self.supported_formats(kAudioObjectPropertyScopeOutput)
     }
 

--- a/src/emscripten/mod.rs
+++ b/src/emscripten/mod.rs
@@ -13,6 +13,8 @@ use DefaultFormatError;
 use DeviceNameError;
 use DevicesError;
 use Format;
+use PauseStreamError;
+use PlayStreamError;
 use SupportedFormatsError;
 use StreamData;
 use SupportedFormat;
@@ -147,23 +149,25 @@ impl EventLoop {
     }
 
     #[inline]
-    pub fn play_stream(&self, stream_id: StreamId) {
+    pub fn play_stream(&self, stream_id: StreamId) -> Result<(), PlayStreamError> {
         let streams = self.streams.lock().unwrap();
         let stream = streams
             .get(stream_id.0)
             .and_then(|v| v.as_ref())
             .expect("invalid stream ID");
         js!(@{stream}.resume());
+        Ok(())
     }
 
     #[inline]
-    pub fn pause_stream(&self, stream_id: StreamId) {
+    pub fn pause_stream(&self, stream_id: StreamId) -> Result<(), PauseStreamError> {
         let streams = self.streams.lock().unwrap();
         let stream = streams
             .get(stream_id.0)
             .and_then(|v| v.as_ref())
             .expect("invalid stream ID");
         js!(@{stream}.suspend());
+        Ok(())
     }
 }
 

--- a/src/emscripten/mod.rs
+++ b/src/emscripten/mod.rs
@@ -8,7 +8,7 @@ use stdweb::unstable::TryInto;
 use stdweb::web::TypedArray;
 use stdweb::web::set_timeout;
 
-use CreationError;
+use BuildStreamError;
 use DefaultFormatError;
 use Format;
 use SupportedFormatsError;
@@ -118,12 +118,12 @@ impl EventLoop {
     }
 
     #[inline]
-    pub fn build_input_stream(&self, _: &Device, _format: &Format) -> Result<StreamId, CreationError> {
+    pub fn build_input_stream(&self, _: &Device, _format: &Format) -> Result<StreamId, BuildStreamError> {
         unimplemented!();
     }
 
     #[inline]
-    pub fn build_output_stream(&self, _: &Device, _format: &Format) -> Result<StreamId, CreationError> {
+    pub fn build_output_stream(&self, _: &Device, _format: &Format) -> Result<StreamId, BuildStreamError> {
         let stream = js!(return new AudioContext()).into_reference().unwrap();
 
         let mut streams = self.streams.lock().unwrap();

--- a/src/emscripten/mod.rs
+++ b/src/emscripten/mod.rs
@@ -10,6 +10,7 @@ use stdweb::web::set_timeout;
 
 use BuildStreamError;
 use DefaultFormatError;
+use DevicesError;
 use Format;
 use SupportedFormatsError;
 use StreamData;
@@ -183,6 +184,13 @@ fn is_webaudio_available() -> bool {
 
 // Content is false if the iterator is empty.
 pub struct Devices(bool);
+
+impl Devices {
+    pub fn new() -> Result<Self, DevicesError> {
+        Ok(Self::default())
+    }
+}
+
 impl Default for Devices {
     fn default() -> Devices {
         // We produce an empty iterator if the WebAudio API isn't available.

--- a/src/emscripten/mod.rs
+++ b/src/emscripten/mod.rs
@@ -10,6 +10,7 @@ use stdweb::web::set_timeout;
 
 use BuildStreamError;
 use DefaultFormatError;
+use DeviceNameError;
 use DevicesError;
 use Format;
 use SupportedFormatsError;
@@ -229,8 +230,8 @@ pub struct Device;
 
 impl Device {
     #[inline]
-    pub fn name(&self) -> String {
-        "Default Device".to_owned()
+    pub fn name(&self) -> Result<String, DeviceNameError> {
+        Ok("Default Device".to_owned())
     }
 
     #[inline]

--- a/src/emscripten/mod.rs
+++ b/src/emscripten/mod.rs
@@ -11,7 +11,7 @@ use stdweb::web::set_timeout;
 use CreationError;
 use DefaultFormatError;
 use Format;
-use FormatsEnumerationError;
+use SupportedFormatsError;
 use StreamData;
 use SupportedFormat;
 use UnknownTypeOutputBuffer;
@@ -226,12 +226,12 @@ impl Device {
     }
 
     #[inline]
-    pub fn supported_input_formats(&self) -> Result<SupportedInputFormats, FormatsEnumerationError> {
+    pub fn supported_input_formats(&self) -> Result<SupportedInputFormats, SupportedFormatsError> {
         unimplemented!();
     }
 
     #[inline]
-    pub fn supported_output_formats(&self) -> Result<SupportedOutputFormats, FormatsEnumerationError> {
+    pub fn supported_output_formats(&self) -> Result<SupportedOutputFormats, SupportedFormatsError> {
         // TODO: right now cpal's API doesn't allow flexibility here
         //       "44100" and "2" (channels) have also been hard-coded in the rest of the code ; if
         //       this ever becomes more flexible, don't forget to change that

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@
 //! `default_*_device()` functions return an `Option` in case no device is available for that
 //! stream type on the system.
 //!
-//! ```
+//! ```no_run
 //! let device = cpal::default_output_device().expect("no output device available");
 //! ```
 //!
@@ -60,10 +60,10 @@
 //!
 //! Now we must start the stream. This is done with the `play_stream()` method on the event loop.
 //!
-//! ```
+//! ```no_run
 //! # let event_loop: cpal::EventLoop = return;
 //! # let stream_id: cpal::StreamId = return;
-//! event_loop.play_stream(stream_id);
+//! event_loop.play_stream(stream_id).expect("failed to play_stream");
 //! ```
 //!
 //! Now everything is ready! We call `run()` on the `event_loop` to begin processing.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -160,7 +160,7 @@ mod cpal_impl;
 #[derive(Clone, PartialEq, Eq)]
 pub struct Device(cpal_impl::Device);
 
-/// Collection of voices managed together.
+/// Collection of streams managed together.
 ///
 /// Created with the [`new`](struct.EventLoop.html#method.new) method.
 pub struct EventLoop(cpal_impl::EventLoop);
@@ -306,9 +306,9 @@ pub enum DefaultFormatError {
     StreamTypeNotSupported,
 }
 
-/// Error that can happen when creating a `Voice`.
+/// Error that can happen when creating a `Stream`.
 #[derive(Debug, Fail)]
-pub enum CreationError {
+pub enum BuildStreamError {
     /// The device no longer exists. This can happen if the device is disconnected while the
     /// program is running.
     #[fail(display = "The requested device is no longer available. For example, it has been unplugged.")]
@@ -435,7 +435,7 @@ impl EventLoop {
         &self,
         device: &Device,
         format: &Format,
-    ) -> Result<StreamId, CreationError>
+    ) -> Result<StreamId, BuildStreamError>
     {
         self.0.build_input_stream(&device.0, format).map(StreamId)
     }
@@ -451,7 +451,7 @@ impl EventLoop {
         &self,
         device: &Device,
         format: &Format,
-    ) -> Result<StreamId, CreationError>
+    ) -> Result<StreamId, BuildStreamError>
     {
         self.0.build_output_stream(&device.0, format).map(StreamId)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -308,6 +308,17 @@ pub enum DevicesError {
     }
 }
 
+/// An error that may occur while attempting to retrieve a device name.
+#[derive(Debug, Fail)]
+pub enum DeviceNameError {
+    /// See the `BackendSpecificError` docs for more information about this error variant.
+    #[fail(display = "{}", err)]
+    BackendSpecific {
+        #[fail(cause)]
+        err: BackendSpecificError,
+    }
+}
+
 /// Error that can happen when enumerating the list of supported formats.
 #[derive(Debug, Fail)]
 pub enum SupportedFormatsError {
@@ -410,7 +421,7 @@ pub fn default_output_device() -> Option<Device> {
 impl Device {
     /// The human-readable name of the device.
     #[inline]
-    pub fn name(&self) -> String {
+    pub fn name(&self) -> Result<String, DeviceNameError> {
         self.0.name()
     }
 
@@ -739,6 +750,12 @@ impl Iterator for SupportedOutputFormats {
 impl From<BackendSpecificError> for DevicesError {
     fn from(err: BackendSpecificError) -> Self {
         DevicesError::BackendSpecific { err }
+    }
+}
+
+impl From<BackendSpecificError> for DeviceNameError {
+    fn from(err: BackendSpecificError) -> Self {
+        DeviceNameError::BackendSpecific { err }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -382,6 +382,36 @@ pub enum BuildStreamError {
     }
 }
 
+/// Errors that might occur when calling `play_stream`.
+///
+/// As of writing this, only macOS may immediately return an error while calling this method. This
+/// is because both the alsa and wasapi backends only enqueue these commands and do not process
+/// them immediately.
+#[derive(Debug, Fail)]
+pub enum PlayStreamError {
+    /// See the `BackendSpecificError` docs for more information about this error variant.
+    #[fail(display = "{}", err)]
+    BackendSpecific {
+        #[fail(cause)]
+        err: BackendSpecificError,
+    }
+}
+
+/// Errors that might occur when calling `pause_stream`.
+///
+/// As of writing this, only macOS may immediately return an error while calling this method. This
+/// is because both the alsa and wasapi backends only enqueue these commands and do not process
+/// them immediately.
+#[derive(Debug, Fail)]
+pub enum PauseStreamError {
+    /// See the `BackendSpecificError` docs for more information about this error variant.
+    #[fail(display = "{}", err)]
+    BackendSpecific {
+        #[fail(cause)]
+        err: BackendSpecificError,
+    }
+}
+
 /// An iterator yielding all `Device`s currently available to the system.
 ///
 /// Can be empty if the system does not support audio in general.
@@ -522,7 +552,7 @@ impl EventLoop {
     /// If the stream does not exist, this function can either panic or be a no-op.
     ///
     #[inline]
-    pub fn play_stream(&self, stream: StreamId) {
+    pub fn play_stream(&self, stream: StreamId) -> Result<(), PlayStreamError> {
         self.0.play_stream(stream.0)
     }
 
@@ -537,7 +567,7 @@ impl EventLoop {
     /// If the stream does not exist, this function can either panic or be a no-op.
     ///
     #[inline]
-    pub fn pause_stream(&self, stream: StreamId) {
+    pub fn pause_stream(&self, stream: StreamId) -> Result<(), PauseStreamError> {
         self.0.pause_stream(stream.0)
     }
 
@@ -786,6 +816,18 @@ impl From<BackendSpecificError> for DefaultFormatError {
 impl From<BackendSpecificError> for BuildStreamError {
     fn from(err: BackendSpecificError) -> Self {
         BuildStreamError::BackendSpecific { err }
+    }
+}
+
+impl From<BackendSpecificError> for PlayStreamError {
+    fn from(err: BackendSpecificError) -> Self {
+        PlayStreamError::BackendSpecific { err }
+    }
+}
+
+impl From<BackendSpecificError> for PauseStreamError {
+    fn from(err: BackendSpecificError) -> Self {
+        PauseStreamError::BackendSpecific { err }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -281,7 +281,7 @@ pub struct SupportedOutputFormats(cpal_impl::SupportedOutputFormats);
 
 /// Error that can happen when enumerating the list of supported formats.
 #[derive(Debug, Fail)]
-pub enum FormatsEnumerationError {
+pub enum SupportedFormatsError {
     /// The device no longer exists. This can happen if the device is disconnected while the
     /// program is running.
     #[fail(display = "The requested device is no longer available. For example, it has been unplugged.")]
@@ -386,7 +386,7 @@ impl Device {
     ///
     /// Can return an error if the device is no longer valid (eg. it has been disconnected).
     #[inline]
-    pub fn supported_input_formats(&self) -> Result<SupportedInputFormats, FormatsEnumerationError> {
+    pub fn supported_input_formats(&self) -> Result<SupportedInputFormats, SupportedFormatsError> {
         Ok(SupportedInputFormats(self.0.supported_input_formats()?))
     }
 
@@ -394,7 +394,7 @@ impl Device {
     ///
     /// Can return an error if the device is no longer valid (eg. it has been disconnected).
     #[inline]
-    pub fn supported_output_formats(&self) -> Result<SupportedOutputFormats, FormatsEnumerationError> {
+    pub fn supported_output_formats(&self) -> Result<SupportedOutputFormats, SupportedFormatsError> {
         Ok(SupportedOutputFormats(self.0.supported_output_formats()?))
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -347,6 +347,12 @@ pub enum DefaultFormatError {
     /// Returned if e.g. the default input format was requested on an output-only audio device.
     #[fail(display = "The requested stream type is not supported by the device.")]
     StreamTypeNotSupported,
+    /// See the `BackendSpecificError` docs for more information about this error variant.
+    #[fail(display = "{}", err)]
+    BackendSpecific {
+        #[fail(cause)]
+        err: BackendSpecificError,
+    }
 }
 
 /// Error that can happen when creating a `Stream`.
@@ -762,6 +768,12 @@ impl From<BackendSpecificError> for DeviceNameError {
 impl From<BackendSpecificError> for SupportedFormatsError {
     fn from(err: BackendSpecificError) -> Self {
         SupportedFormatsError::BackendSpecific { err }
+    }
+}
+
+impl From<BackendSpecificError> for DefaultFormatError {
+    fn from(err: BackendSpecificError) -> Self {
+        DefaultFormatError::BackendSpecific { err }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -300,9 +300,7 @@ pub struct BackendSpecificError {
 /// An error that might occur while attempting to enumerate the available devices on a system.
 #[derive(Debug, Fail)]
 pub enum DevicesError {
-    /// Some error that is specific to the backend from which it was produced.
-    ///
-    /// Note: This error is often used when
+    /// See the `BackendSpecificError` docs for more information about this error variant.
     #[fail(display = "{}", err)]
     BackendSpecific {
         #[fail(cause)]
@@ -320,9 +318,12 @@ pub enum SupportedFormatsError {
     /// We called something the C-Layer did not understand
     #[fail(display = "Invalid argument passed to the backend. For example, this happens when trying to read capture capabilities when the device does not support it.")]
     InvalidArgument,
-    /// The C-Layer returned an error we don't know about
-    #[fail(display = "An unknown error in the backend occured.")]
-    Unknown
+    /// See the `BackendSpecificError` docs for more information about this error variant.
+    #[fail(display = "{}", err)]
+    BackendSpecific {
+        #[fail(cause)]
+        err: BackendSpecificError,
+    }
 }
 
 /// May occur when attempting to request the default input or output stream format from a `Device`.
@@ -738,6 +739,12 @@ impl Iterator for SupportedOutputFormats {
 impl From<BackendSpecificError> for DevicesError {
     fn from(err: BackendSpecificError) -> Self {
         DevicesError::BackendSpecific { err }
+    }
+}
+
+impl From<BackendSpecificError> for SupportedFormatsError {
+    fn from(err: BackendSpecificError) -> Self {
+        SupportedFormatsError::BackendSpecific { err }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -371,9 +371,15 @@ pub enum BuildStreamError {
     /// Trying to use capture capabilities on an output only format yields this.
     #[fail(display = "The requested device does not support this capability (invalid argument)")]
     InvalidArgument,
-    /// The C-Layer returned an error we don't know about
-    #[fail(display = "An unknown error in the Backend occured")]
-    Unknown,
+    /// Occurs if adding a new Stream ID would cause an integer overflow.
+    #[fail(display = "Adding a new stream ID would cause an overflow")]
+    StreamIdOverflow,
+    /// See the `BackendSpecificError` docs for more information about this error variant.
+    #[fail(display = "{}", err)]
+    BackendSpecific {
+        #[fail(cause)]
+        err: BackendSpecificError,
+    }
 }
 
 /// An iterator yielding all `Device`s currently available to the system.
@@ -774,6 +780,12 @@ impl From<BackendSpecificError> for SupportedFormatsError {
 impl From<BackendSpecificError> for DefaultFormatError {
     fn from(err: BackendSpecificError) -> Self {
         DefaultFormatError::BackendSpecific { err }
+    }
+}
+
+impl From<BackendSpecificError> for BuildStreamError {
+    fn from(err: BackendSpecificError) -> Self {
+        BuildStreamError::BackendSpecific { err }
     }
 }
 

--- a/src/null/mod.rs
+++ b/src/null/mod.rs
@@ -5,7 +5,7 @@ use std::marker::PhantomData;
 use CreationError;
 use DefaultFormatError;
 use Format;
-use FormatsEnumerationError;
+use SupportedFormatsError;
 use StreamData;
 use SupportedFormat;
 
@@ -80,12 +80,12 @@ pub struct Device;
 
 impl Device {
     #[inline]
-    pub fn supported_input_formats(&self) -> Result<SupportedInputFormats, FormatsEnumerationError> {
+    pub fn supported_input_formats(&self) -> Result<SupportedInputFormats, SupportedFormatsError> {
         unimplemented!()
     }
 
     #[inline]
-    pub fn supported_output_formats(&self) -> Result<SupportedOutputFormats, FormatsEnumerationError> {
+    pub fn supported_output_formats(&self) -> Result<SupportedOutputFormats, SupportedFormatsError> {
         unimplemented!()
     }
 

--- a/src/null/mod.rs
+++ b/src/null/mod.rs
@@ -2,7 +2,7 @@
 
 use std::marker::PhantomData;
 
-use CreationError;
+use BuildStreamError;
 use DefaultFormatError;
 use Format;
 use SupportedFormatsError;
@@ -25,13 +25,13 @@ impl EventLoop {
     }
 
     #[inline]
-    pub fn build_input_stream(&self, _: &Device, _: &Format) -> Result<StreamId, CreationError> {
-        Err(CreationError::DeviceNotAvailable)
+    pub fn build_input_stream(&self, _: &Device, _: &Format) -> Result<StreamId, BuildStreamError> {
+        Err(BuildStreamError::DeviceNotAvailable)
     }
 
     #[inline]
-    pub fn build_output_stream(&self, _: &Device, _: &Format) -> Result<StreamId, CreationError> {
-        Err(CreationError::DeviceNotAvailable)
+    pub fn build_output_stream(&self, _: &Device, _: &Format) -> Result<StreamId, BuildStreamError> {
+        Err(BuildStreamError::DeviceNotAvailable)
     }
 
     #[inline]

--- a/src/null/mod.rs
+++ b/src/null/mod.rs
@@ -4,6 +4,7 @@ use std::marker::PhantomData;
 
 use BuildStreamError;
 use DefaultFormatError;
+use DevicesError;
 use Format;
 use SupportedFormatsError;
 use StreamData;
@@ -55,6 +56,12 @@ pub struct StreamId;
 
 #[derive(Default)]
 pub struct Devices;
+
+impl Devices {
+    pub fn new() -> Result<Self, DevicesError> {
+        Ok(Devices)
+    }
+}
 
 impl Iterator for Devices {
     type Item = Device;

--- a/src/null/mod.rs
+++ b/src/null/mod.rs
@@ -5,6 +5,7 @@ use std::marker::PhantomData;
 use BuildStreamError;
 use DefaultFormatError;
 use DevicesError;
+use DeviceNameError;
 use Format;
 use SupportedFormatsError;
 use StreamData;
@@ -107,8 +108,8 @@ impl Device {
     }
 
     #[inline]
-    pub fn name(&self) -> String {
-        "null".to_owned()
+    pub fn name(&self) -> Result<String, DeviceNameError> {
+        Ok("null".to_owned())
     }
 }
 

--- a/src/null/mod.rs
+++ b/src/null/mod.rs
@@ -7,6 +7,8 @@ use DefaultFormatError;
 use DevicesError;
 use DeviceNameError;
 use Format;
+use PauseStreamError;
+use PlayStreamError;
 use SupportedFormatsError;
 use StreamData;
 use SupportedFormat;
@@ -42,12 +44,12 @@ impl EventLoop {
     }
 
     #[inline]
-    pub fn play_stream(&self, _: StreamId) {
+    pub fn play_stream(&self, _: StreamId) -> Result<(), PlayStreamError> {
         panic!()
     }
 
     #[inline]
-    pub fn pause_stream(&self, _: StreamId) {
+    pub fn pause_stream(&self, _: StreamId) -> Result<(), PauseStreamError> {
         panic!()
     }
 }

--- a/src/wasapi/device.rs
+++ b/src/wasapi/device.rs
@@ -409,7 +409,7 @@ impl Device {
         // Retrieve the `IAudioClient`.
         let lock = match self.ensure_future_audio_client() {
             Ok(lock) => lock,
-            Err(e) if e.raw_os_error() == Some(AUDCLNT_E_DEVICE_INVALIDATED) => {
+            Err(ref e) if e.raw_os_error() == Some(AUDCLNT_E_DEVICE_INVALIDATED) => {
                 return Err(SupportedFormatsError::DeviceNotAvailable)
             }
             Err(e) => {
@@ -748,11 +748,11 @@ impl Devices {
             // can fail if the parameter is null, which should never happen
             check_result_backend_specific((*collection).GetCount(&mut count))?;
 
-            Devices {
+            Ok(Devices {
                 collection: collection,
                 total_count: count,
                 next_item: 0,
-            }
+            })
         }
     }
 }

--- a/src/wasapi/device.rs
+++ b/src/wasapi/device.rs
@@ -187,7 +187,7 @@ pub unsafe fn is_format_supported(
         (_, Err(ref e))
             if e.raw_os_error() == Some(AUDCLNT_E_DEVICE_INVALIDATED) => {
             (*audio_client).Release();
-            return Err(CreationError::DeviceNotAvailable);
+            return Err(BuildStreamError::DeviceNotAvailable);
         },
         (_, Err(e)) => {
             (*audio_client).Release();
@@ -195,7 +195,7 @@ pub unsafe fn is_format_supported(
         },
         (winerror::S_FALSE, _) => {
             (*audio_client).Release();
-            return Err(CreationError::FormatNotSupported);
+            return Err(BuildStreamError::FormatNotSupported);
         },
         (_, Ok(())) => (),
     };

--- a/src/wasapi/mod.rs
+++ b/src/wasapi/mod.rs
@@ -1,10 +1,10 @@
 extern crate winapi;
 
+use BackendSpecificError;
+use self::winapi::um::winnt::HRESULT;
 use std::io::Error as IoError;
-
 pub use self::device::{Device, Devices, SupportedInputFormats, SupportedOutputFormats, default_input_device, default_output_device};
 pub use self::stream::{EventLoop, StreamId};
-use self::winapi::um::winnt::HRESULT;
 
 mod com;
 mod device;
@@ -16,5 +16,15 @@ fn check_result(result: HRESULT) -> Result<(), IoError> {
         Err(IoError::from_raw_os_error(result))
     } else {
         Ok(())
+    }
+}
+
+fn check_result_backend_specific(result: HRESULT) -> Result<(), BackendSpecificError> {
+    match check_result(result) {
+        Ok(()) => Ok(())
+        Err(err) => {
+            let description = format!("{}", err);
+            return BackendSpecificError { description }
+        }
     }
 }

--- a/src/wasapi/mod.rs
+++ b/src/wasapi/mod.rs
@@ -21,10 +21,10 @@ fn check_result(result: HRESULT) -> Result<(), IoError> {
 
 fn check_result_backend_specific(result: HRESULT) -> Result<(), BackendSpecificError> {
     match check_result(result) {
-        Ok(()) => Ok(())
+        Ok(()) => Ok(()),
         Err(err) => {
             let description = format!("{}", err);
-            return BackendSpecificError { description }
+            return Err(BackendSpecificError { description });
         }
     }
 }

--- a/src/wasapi/stream.rs
+++ b/src/wasapi/stream.rs
@@ -23,6 +23,8 @@ use std::sync::atomic::Ordering;
 use BackendSpecificError;
 use BuildStreamError;
 use Format;
+use PauseStreamError;
+use PlayStreamError;
 use SampleFormat;
 use StreamData;
 use UnknownTypeOutputBuffer;
@@ -642,13 +644,15 @@ impl EventLoop {
     }
 
     #[inline]
-    pub fn play_stream(&self, stream: StreamId) {
+    pub fn play_stream(&self, stream: StreamId) -> Result<(), PlayStreamError> {
         self.push_command(Command::PlayStream(stream));
+        Ok(())
     }
 
     #[inline]
-    pub fn pause_stream(&self, stream: StreamId) {
+    pub fn pause_stream(&self, stream: StreamId) -> Result<(), PauseStreamError> {
         self.push_command(Command::PauseStream(stream));
+        Ok(())
     }
 
     #[inline]

--- a/src/wasapi/stream.rs
+++ b/src/wasapi/stream.rs
@@ -20,7 +20,7 @@ use std::sync::mpsc::{channel, Sender, Receiver};
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 
-use CreationError;
+use BuildStreamError;
 use Format;
 use SampleFormat;
 use StreamData;
@@ -114,7 +114,7 @@ impl EventLoop {
         &self,
         device: &Device,
         format: &Format,
-    ) -> Result<StreamId, CreationError>
+    ) -> Result<StreamId, BuildStreamError>
     {
         unsafe {
             // Making sure that COM is initialized.
@@ -124,20 +124,20 @@ impl EventLoop {
             // Obtaining a `IAudioClient`.
             let audio_client = match device.build_audioclient() {
                 Err(ref e) if e.raw_os_error() == Some(AUDCLNT_E_DEVICE_INVALIDATED) =>
-                    return Err(CreationError::DeviceNotAvailable),
+                    return Err(BuildStreamError::DeviceNotAvailable),
                 e => e.unwrap(),
             };
 
             // Computing the format and initializing the device.
             let waveformatex = {
                 let format_attempt = format_to_waveformatextensible(format)
-                    .ok_or(CreationError::FormatNotSupported)?;
+                    .ok_or(BuildStreamError::FormatNotSupported)?;
                 let share_mode = AUDCLNT_SHAREMODE_SHARED;
 
                 // Ensure the format is supported.
                 match super::device::is_format_supported(audio_client, &format_attempt.Format) {
-                    Ok(false) => return Err(CreationError::FormatNotSupported),
-                    Err(_) => return Err(CreationError::DeviceNotAvailable),
+                    Ok(false) => return Err(BuildStreamError::FormatNotSupported),
+                    Err(_) => return Err(BuildStreamError::DeviceNotAvailable),
                     _ => (),
                 }
 
@@ -154,7 +154,7 @@ impl EventLoop {
                     Err(ref e)
                         if e.raw_os_error() == Some(AUDCLNT_E_DEVICE_INVALIDATED) => {
                         (*audio_client).Release();
-                        return Err(CreationError::DeviceNotAvailable);
+                        return Err(BuildStreamError::DeviceNotAvailable);
                     },
                     Err(e) => {
                         (*audio_client).Release();
@@ -175,7 +175,7 @@ impl EventLoop {
                     Err(ref e)
                         if e.raw_os_error() == Some(AUDCLNT_E_DEVICE_INVALIDATED) => {
                         (*audio_client).Release();
-                        return Err(CreationError::DeviceNotAvailable);
+                        return Err(BuildStreamError::DeviceNotAvailable);
                     },
                     Err(e) => {
                         (*audio_client).Release();
@@ -218,7 +218,7 @@ impl EventLoop {
                     Err(ref e)
                         if e.raw_os_error() == Some(AUDCLNT_E_DEVICE_INVALIDATED) => {
                         (*audio_client).Release();
-                        return Err(CreationError::DeviceNotAvailable);
+                        return Err(BuildStreamError::DeviceNotAvailable);
                     },
                     Err(e) => {
                         (*audio_client).Release();
@@ -261,7 +261,7 @@ impl EventLoop {
         &self,
         device: &Device,
         format: &Format,
-    ) -> Result<StreamId, CreationError>
+    ) -> Result<StreamId, BuildStreamError>
     {
         unsafe {
             // Making sure that COM is initialized.
@@ -271,20 +271,20 @@ impl EventLoop {
             // Obtaining a `IAudioClient`.
             let audio_client = match device.build_audioclient() {
                 Err(ref e) if e.raw_os_error() == Some(AUDCLNT_E_DEVICE_INVALIDATED) =>
-                    return Err(CreationError::DeviceNotAvailable),
+                    return Err(BuildStreamError::DeviceNotAvailable),
                 e => e.unwrap(),
             };
 
             // Computing the format and initializing the device.
             let waveformatex = {
                 let format_attempt = format_to_waveformatextensible(format)
-                    .ok_or(CreationError::FormatNotSupported)?;
+                    .ok_or(BuildStreamError::FormatNotSupported)?;
                 let share_mode = AUDCLNT_SHAREMODE_SHARED;
 
                 // Ensure the format is supported.
                 match super::device::is_format_supported(audio_client, &format_attempt.Format) {
-                    Ok(false) => return Err(CreationError::FormatNotSupported),
-                    Err(_) => return Err(CreationError::DeviceNotAvailable),
+                    Ok(false) => return Err(BuildStreamError::FormatNotSupported),
+                    Err(_) => return Err(BuildStreamError::DeviceNotAvailable),
                     _ => (),
                 }
 
@@ -299,7 +299,7 @@ impl EventLoop {
                     Err(ref e)
                         if e.raw_os_error() == Some(AUDCLNT_E_DEVICE_INVALIDATED) => {
                         (*audio_client).Release();
-                        return Err(CreationError::DeviceNotAvailable);
+                        return Err(BuildStreamError::DeviceNotAvailable);
                     },
                     Err(e) => {
                         (*audio_client).Release();
@@ -339,7 +339,7 @@ impl EventLoop {
                     Err(ref e)
                         if e.raw_os_error() == Some(AUDCLNT_E_DEVICE_INVALIDATED) => {
                         (*audio_client).Release();
-                        return Err(CreationError::DeviceNotAvailable);
+                        return Err(BuildStreamError::DeviceNotAvailable);
                     },
                     Err(e) => {
                         (*audio_client).Release();
@@ -363,7 +363,7 @@ impl EventLoop {
                     Err(ref e)
                         if e.raw_os_error() == Some(AUDCLNT_E_DEVICE_INVALIDATED) => {
                         (*audio_client).Release();
-                        return Err(CreationError::DeviceNotAvailable);
+                        return Err(BuildStreamError::DeviceNotAvailable);
                     },
                     Err(e) => {
                         (*audio_client).Release();
@@ -529,7 +529,7 @@ impl EventLoop {
                             if hresult == AUDCLNT_S_BUFFER_EMPTY { continue; }
 
                             debug_assert!(!buffer.is_null());
-                            let buffer_len = frames_available as usize 
+                            let buffer_len = frames_available as usize
                                 * stream.bytes_per_frame as usize / sample_size;
 
                             // Simplify the capture callback sample format branches.
@@ -568,9 +568,9 @@ impl EventLoop {
                                 &mut buffer as *mut *mut _,
                             );
                             // FIXME: can return `AUDCLNT_E_DEVICE_INVALIDATED`
-                            check_result(hresult).unwrap(); 
+                            check_result(hresult).unwrap();
                             debug_assert!(!buffer.is_null());
-                            let buffer_len = frames_available as usize 
+                            let buffer_len = frames_available as usize
                                 * stream.bytes_per_frame as usize / sample_size;
 
                             // Simplify the render callback sample format branches.
@@ -594,7 +594,7 @@ impl EventLoop {
                                         Err(ref e) if e.raw_os_error() == Some(AUDCLNT_E_DEVICE_INVALIDATED) => (),
                                         e => e.unwrap(),
                                     };
-                                }} 
+                                }}
                             }
 
                             match stream.sample_format {


### PR DESCRIPTION
The aim of this PR is to overhaul the way that errors are handled throughout the crate as discussed within #268.

I will continue to update the following list and commit to this PR as I make progress. Feel free to comment at any stage!

## TODO:

- [x] Integrate the `failure` crate to make error implementation and propagation more ergonomic.
- [x] Rename existing error types to more closely match the methods from which they may be returned. Carry this on going forward as a general convention.
- [x] Review every function of the synchronous API and their implementations within each of the different backends. Remove `panic!`s and improve error handling where necessary, which may include adding new error types or new variants to existing error types.

## Follow-up PR:

- [ ] Change the user callback to emit an `Event` enum as described [here](https://github.com/tomaka/cpal/issues/268#issuecomment-499887735).