### PR TITLE
User Callback API `StreamEvent` Overhaul

### DIFF
--- a/examples/beep.rs
+++ b/examples/beep.rs
@@ -17,7 +17,16 @@ fn main() -> Result<(), failure::Error> {
         (sample_clock * 440.0 * 2.0 * 3.141592 / sample_rate).sin()
     };
 
-    event_loop.run(move |_, data| {
+    event_loop.run(move |id, event| {
+        let data = match event {
+            cpal::StreamEvent::Data(data) => data,
+            cpal::StreamEvent::Close(cpal::StreamCloseCause::Error(err)) => {
+                eprintln!("stream {:?} closed due to an error: {}", id, err);
+                return;
+            }
+            _ => return,
+        };
+
         match data {
             cpal::StreamData::Output { buffer: cpal::UnknownTypeOutputBuffer::U16(mut buffer) } => {
                 for sample in buffer.chunks_mut(format.channels as usize) {

--- a/examples/beep.rs
+++ b/examples/beep.rs
@@ -17,14 +17,13 @@ fn main() -> Result<(), failure::Error> {
         (sample_clock * 440.0 * 2.0 * 3.141592 / sample_rate).sin()
     };
 
-    event_loop.run(move |id, event| {
-        let data = match event {
-            cpal::StreamEvent::Data(data) => data,
-            cpal::StreamEvent::Close(cpal::StreamCloseCause::Error(err)) => {
+    event_loop.run(move |id, result| {
+        let data = match result {
+            Ok(data) => data,
+            Err(err) => {
                 eprintln!("stream {:?} closed due to an error: {}", id, err);
                 return;
             }
-            _ => return,
         };
 
         match data {

--- a/examples/beep.rs
+++ b/examples/beep.rs
@@ -21,7 +21,7 @@ fn main() -> Result<(), failure::Error> {
         let data = match result {
             Ok(data) => data,
             Err(err) => {
-                eprintln!("stream {:?} closed due to an error: {}", id, err);
+                eprintln!("an error occurred on stream {:?}: {}", id, err);
                 return;
             }
         };

--- a/examples/feedback.rs
+++ b/examples/feedback.rs
@@ -49,14 +49,13 @@ fn main() -> Result<(), failure::Error> {
 
     // Run the event loop on a separate thread.
     std::thread::spawn(move || {
-        event_loop.run(move |id, event| {
-            let data = match event {
-                cpal::StreamEvent::Data(data) => data,
-                cpal::StreamEvent::Close(cpal::StreamCloseCause::Error(err)) => {
+        event_loop.run(move |id, result| {
+            let data = match result {
+                Ok(data) => data,
+                Err(err) => {
                     eprintln!("stream {:?} closed due to an error: {}", id, err);
                     return;
                 }
-                _ => return,
             };
 
             match data {

--- a/examples/feedback.rs
+++ b/examples/feedback.rs
@@ -53,7 +53,7 @@ fn main() -> Result<(), failure::Error> {
             let data = match result {
                 Ok(data) => data,
                 Err(err) => {
-                    eprintln!("stream {:?} closed due to an error: {}", id, err);
+                    eprintln!("an error occurred on stream {:?}: {}", id, err);
                     return;
                 }
             };

--- a/examples/feedback.rs
+++ b/examples/feedback.rs
@@ -49,7 +49,16 @@ fn main() -> Result<(), failure::Error> {
 
     // Run the event loop on a separate thread.
     std::thread::spawn(move || {
-        event_loop.run(move |id, data| {
+        event_loop.run(move |id, event| {
+            let data = match event {
+                cpal::StreamEvent::Data(data) => data,
+                cpal::StreamEvent::Close(cpal::StreamCloseCause::Error(err)) => {
+                    eprintln!("stream {:?} closed due to an error: {}", id, err);
+                    return;
+                }
+                _ => return,
+            };
+
             match data {
                 cpal::StreamData::Input { buffer: cpal::UnknownTypeInputBuffer::F32(buffer) } => {
                     assert_eq!(id, input_stream_id);

--- a/examples/record_wav.rs
+++ b/examples/record_wav.rs
@@ -34,7 +34,7 @@ fn main() -> Result<(), failure::Error> {
             let data = match event {
                 Ok(data) => data,
                 Err(err) => {
-                    eprintln!("stream {:?} closed due to an error: {}", id, err);
+                    eprintln!("an error occurred on stream {:?}: {}", id, err);
                     return;
                 }
             };

--- a/examples/record_wav.rs
+++ b/examples/record_wav.rs
@@ -30,7 +30,16 @@ fn main() -> Result<(), failure::Error> {
     let writer_2 = writer.clone();
     let recording_2 = recording.clone();
     std::thread::spawn(move || {
-        event_loop.run(move |_, data| {
+        event_loop.run(move |id, event| {
+            let data = match event {
+                cpal::StreamEvent::Data(data) => data,
+                cpal::StreamEvent::Close(cpal::StreamCloseCause::Error(err)) => {
+                    eprintln!("stream {:?} closed due to an error: {}", id, err);
+                    return;
+                }
+                _ => return,
+            };
+
             // If we're done recording, return early.
             if !recording_2.load(std::sync::atomic::Ordering::Relaxed) {
                 return;

--- a/examples/record_wav.rs
+++ b/examples/record_wav.rs
@@ -32,12 +32,11 @@ fn main() -> Result<(), failure::Error> {
     std::thread::spawn(move || {
         event_loop.run(move |id, event| {
             let data = match event {
-                cpal::StreamEvent::Data(data) => data,
-                cpal::StreamEvent::Close(cpal::StreamCloseCause::Error(err)) => {
+                Ok(data) => data,
+                Err(err) => {
                     eprintln!("stream {:?} closed due to an error: {}", id, err);
                     return;
                 }
-                _ => return,
             };
 
             // If we're done recording, return early.

--- a/src/emscripten/mod.rs
+++ b/src/emscripten/mod.rs
@@ -17,7 +17,7 @@ use PauseStreamError;
 use PlayStreamError;
 use SupportedFormatsError;
 use StreamData;
-use StreamEvent;
+use StreamDataResult;
 use SupportedFormat;
 use UnknownTypeOutputBuffer;
 
@@ -45,7 +45,7 @@ impl EventLoop {
 
     #[inline]
     pub fn run<F>(&self, callback: F) -> !
-        where F: FnMut(StreamId, StreamEvent) + Send,
+        where F: FnMut(StreamId, StreamDataResult) + Send,
     {
         // The `run` function uses `set_timeout` to invoke a Rust callback repeatidely. The job
         // of this callback is to fill the content of the audio buffers.
@@ -54,7 +54,7 @@ impl EventLoop {
         // and to the `callback` parameter that was passed to `run`.
 
         fn callback_fn<F>(user_data_ptr: *mut c_void)
-            where F: FnMut(StreamId, StreamEvent)
+            where F: FnMut(StreamId, StreamDataResult)
         {
             unsafe {
                 let user_data_ptr2 = user_data_ptr as *mut (&EventLoop, F);
@@ -73,8 +73,7 @@ impl EventLoop {
                     {
                         let buffer = UnknownTypeOutputBuffer::F32(::OutputBuffer { buffer: &mut temporary_buffer });
                         let data = StreamData::Output { buffer: buffer };
-                        let event = StreamEvent::Data(data);
-                        user_cb(StreamId(stream_id), event);
+                        user_cb(StreamId(stream_id), Ok(data));
                         // TODO: directly use a TypedArray<f32> once this is supported by stdweb
                     }
 

--- a/src/emscripten/mod.rs
+++ b/src/emscripten/mod.rs
@@ -45,7 +45,7 @@ impl EventLoop {
 
     #[inline]
     pub fn run<F>(&self, callback: F) -> !
-        where F: FnMut(StreamId, StreamDataResult) + Send,
+        where F: FnMut(StreamId, StreamDataResult),
     {
         // The `run` function uses `set_timeout` to invoke a Rust callback repeatidely. The job
         // of this callback is to fill the content of the audio buffers.

--- a/src/emscripten/mod.rs
+++ b/src/emscripten/mod.rs
@@ -17,6 +17,7 @@ use PauseStreamError;
 use PlayStreamError;
 use SupportedFormatsError;
 use StreamData;
+use StreamEvent;
 use SupportedFormat;
 use UnknownTypeOutputBuffer;
 
@@ -43,7 +44,7 @@ impl EventLoop {
 
     #[inline]
     pub fn run<F>(&self, callback: F) -> !
-        where F: FnMut(StreamId, StreamData)
+        where F: FnMut(StreamId, StreamEvent)
     {
         // The `run` function uses `set_timeout` to invoke a Rust callback repeatidely. The job
         // of this callback is to fill the content of the audio buffers.
@@ -52,7 +53,7 @@ impl EventLoop {
         // and to the `callback` parameter that was passed to `run`.
 
         fn callback_fn<F>(user_data_ptr: *mut c_void)
-            where F: FnMut(StreamId, StreamData)
+            where F: FnMut(StreamId, StreamEvent)
         {
             unsafe {
                 let user_data_ptr2 = user_data_ptr as *mut (&EventLoop, F);
@@ -71,7 +72,8 @@ impl EventLoop {
                     {
                         let buffer = UnknownTypeOutputBuffer::F32(::OutputBuffer { buffer: &mut temporary_buffer });
                         let data = StreamData::Output { buffer: buffer };
-                        user_cb(StreamId(stream_id), data);
+                        let event = StreamEvent::Data(data);
+                        user_cb(StreamId(stream_id), event);
                         // TODO: directly use a TypedArray<f32> once this is supported by stdweb
                     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -219,12 +219,6 @@ pub enum StreamData<'a> {
 pub enum StreamEvent<'a> {
     /// Some data is ready to be processed.
     Data(StreamData<'a>),
-    /// The stream has received a **Play** command.
-    Play,
-    /// The stream has received a **Pause** command.
-    ///
-    /// No **Data** events should occur until a subsequent **Play** command is received.
-    Pause,
     /// The stream was closed, either because the user destroyed it or because of an error.
     ///
     /// The stream event callback will not be called again after this event occurs.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,7 +70,7 @@
 //!
 //! ```no_run
 //! # let event_loop = cpal::EventLoop::new();
-//! event_loop.run(move |_stream_id, _stream_event| {
+//! event_loop.run(move |_stream_id, _stream_result| {
 //!     // react to stream events and read or write stream data here
 //! });
 //! ```
@@ -90,8 +90,8 @@
 //! use cpal::{StreamData, UnknownTypeOutputBuffer};
 //!
 //! # let event_loop = cpal::EventLoop::new();
-//! event_loop.run(move |stream_id, stream_event| {
-//!     let stream_data = match stream_event {
+//! event_loop.run(move |stream_id, stream_result| {
+//!     let stream_data = match stream_result {
 //!         Ok(data) => data,
 //!         Err(err) => {
 //!             eprintln!("an error occurred on stream {:?}: {}", stream_id, err);

--- a/src/null/mod.rs
+++ b/src/null/mod.rs
@@ -9,8 +9,8 @@ use DeviceNameError;
 use Format;
 use PauseStreamError;
 use PlayStreamError;
+use StreamDataResult;
 use SupportedFormatsError;
-use StreamEvent;
 use SupportedFormat;
 
 pub struct EventLoop;
@@ -23,7 +23,7 @@ impl EventLoop {
 
     #[inline]
     pub fn run<F>(&self, _callback: F) -> !
-        where F: FnMut(StreamId, StreamEvent)
+        where F: FnMut(StreamId, StreamDataResult)
     {
         loop { /* TODO: don't spin */ }
     }

--- a/src/null/mod.rs
+++ b/src/null/mod.rs
@@ -10,7 +10,7 @@ use Format;
 use PauseStreamError;
 use PlayStreamError;
 use SupportedFormatsError;
-use StreamData;
+use StreamEvent;
 use SupportedFormat;
 
 pub struct EventLoop;
@@ -23,7 +23,7 @@ impl EventLoop {
 
     #[inline]
     pub fn run<F>(&self, _callback: F) -> !
-        where F: FnMut(StreamId, StreamData)
+        where F: FnMut(StreamId, StreamEvent)
     {
         loop { /* TODO: don't spin */ }
     }

--- a/src/wasapi/stream.rs
+++ b/src/wasapi/stream.rs
@@ -26,7 +26,6 @@ use Format;
 use PauseStreamError;
 use PlayStreamError;
 use SampleFormat;
-use StreamCloseCause;
 use StreamData;
 use StreamError;
 use StreamEvent;
@@ -758,8 +757,6 @@ fn process_commands(
                         run_context.streams.remove(p);
                     },
                 }
-                let event = StreamEvent::Close(StreamCloseCause::UserDestroyed);
-                callback(stream_id, event);
             },
             Command::PlayStream(stream_id) => {
                 match run_context.streams.iter().position(|s| s.id == stream_id) {
@@ -772,8 +769,6 @@ fn process_commands(
                             match stream_error_from_hresult(hresult) {
                                 Ok(()) => {
                                     run_context.streams[p].playing = true;
-                                    let event = StreamEvent::Play;
-                                    callback(stream_id, event);
                                 }
                                 Err(err) => {
                                     let event = StreamEvent::Close(err.into());
@@ -797,8 +792,6 @@ fn process_commands(
                             match stream_error_from_hresult(hresult) {
                                 Ok(()) => {
                                     run_context.streams[p].playing = false;
-                                    let event = StreamEvent::Pause;
-                                    callback(stream_id, event);
                                 }
                                 Err(err) => {
                                     let event = StreamEvent::Close(err.into());


### PR DESCRIPTION
Add new `StreamEvent` type - enables more flexible user callback API.

This adds the following types:

- `StreamEvent`
- `CloseStreamCause`
- `StreamError`

These allow for notifying the user of the following events:

- A stream has been played.
- A stream has been paused.
- A stream has been closed due to the user destroying stream.
- A stream has been closed due to an error.

## TODO

- [x] Add new `StreamEvent` API to top level.
- [x] Update examples for new `StreamEvent` API.
- [x] Update ALSA backend.
- [x] Update WASAPI backend.
- [x] Update CoreAudio backend.
- [x] Update emscripten backend.
- [x] Update null backend.

Closes #268.