### PR TITLE
Update CPAL to version 0.10.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Unreleased
 
+# Version 0.10.0 (2019-07-05)
+
+- core-foundation-sys and coreaudio-rs version bumps.
+- Add an ASIO host, available under Windows.
+- Introduce a new Host API, adding support for alternative audio APIs.
+- Remove sleep loop on macOS in favour of using a `Condvar`.
+- Allow users to handle stream callback errors with a new `StreamEvent` type.
+- Overhaul error handling throughout the crate.
+- Remove unnecessary Mutex from ALSA and WASAPI backends in favour of channels.
+- Remove `panic!` from OutputBuffer Deref impl as it is no longer necessary.
+
 # Version 0.9.0 (2019-06-06)
 
 - Better buffer handling

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "cpal"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["The CPAL contributors", "Pierre Krieger <pierre.krieger1708@gmail.com>"]
-description = "Low-level cross-platform audio playing library in pure Rust."
+description = "Low-level cross-platform audio I/O library in pure Rust."
 repository = "https://github.com/tomaka/cpal"
 documentation = "https://docs.rs/cpal"
 license = "Apache-2.0"

--- a/asio-sys/Cargo.toml
+++ b/asio-sys/Cargo.toml
@@ -2,6 +2,11 @@
 name = "asio-sys"
 version = "0.1.0"
 authors = ["Tom Gowan <tomrgowan@gmail.com>"]
+description = "Low-level interface and binding generation for the steinberg ASIO SDK."
+repository = "https://github.com/tomaka/cpal"
+documentation = "https://docs.rs/asio-sys"
+license = "Apache-2.0"
+keywords = ["audio", "sound", "asio", "steinberg"]
 build = "build.rs"
 
 [target.'cfg(any(target_os = "windows"))'.build-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,8 +150,8 @@ extern crate lazy_static;
 extern crate stdweb;
 
 pub use platform::{
-    ALL_HOSTS, Device, EventLoop, Host, HostId, StreamId, available_hosts,
-    default_host, host_from_id,
+    ALL_HOSTS, Device, Devices, EventLoop, Host, HostId, SupportedInputFormats,
+    SupportedOutputFormats, StreamId, available_hosts, default_host, host_from_id,
 };
 pub use samples_formats::{Sample, SampleFormat};
 

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -64,7 +64,7 @@ macro_rules! impl_platform_host {
 
         /// The **StreamId** implementation associated with the platform's dynamically dispatched
         /// **Host** type.
-        #[derive(Clone, Debug, Eq, PartialEq)]
+        #[derive(Clone, Debug, Eq, Hash, PartialEq)]
         pub struct StreamId(StreamIdInner);
 
         /// The **SupportedInputFormats** iterator associated with the platform's dynamically
@@ -107,7 +107,7 @@ macro_rules! impl_platform_host {
             )*
         }
 
-        #[derive(Clone, Debug, Eq, PartialEq)]
+        #[derive(Clone, Debug, Eq, Hash, PartialEq)]
         enum StreamIdInner {
             $(
                 $HostVariant(crate::host::$host_mod::StreamId),

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -195,4 +195,4 @@ pub trait EventLoopTrait {
 }
 
 /// The set of required bounds for host `StreamId` types.
-pub trait StreamIdTrait: Clone + std::fmt::Debug + PartialEq + Eq {}
+pub trait StreamIdTrait: Clone + std::fmt::Debug + std::hash::Hash + PartialEq + Eq {}


### PR DESCRIPTION
This is quite a significant update for CPAL, including a number of
breaking changes. Here is a list of the major changes along with
links to where you can find more information:

- A `Host` API has been introduced in #289 along with a follow-up
  refactor in #295. Please see the examples for a demonstration of how
  to update your code. The necessary changes should hopefully be
  minimal. If this has caused you any major difficulty please let us
  know in an issue!
- An ASIO host has been introduced in #292. This adds support for
  Steinberg's ASIO audio driver API on Windows. Please see the ASIO
  section of the README for more information on how to setup CPAL with
  ASIO support for your project.
- The user callback API has been overhauled to emit `StreamEvent`s
  rather than buffers in order to support handling stream errors. #288.
- Error handling in general was overhauled in #286. This meant taking
  advantage of the `failure` crate and adding support for
  backend-specific errors with custom messages. Many unnecessary
  `panic!`s have been removed, but a few remain that would indicate bugs
  in CPAL.

In general, checking out the updated examples will be the easiest way to
get a quick overview on how you can update your own code for these
changes.

The CHANGELOG.md has been updated to include these changes.

This PR also includes a few small changes that managed to slip through
the cracks in #289 and #295. Namely, `Devices`, `SupportedInputFormats`
and `SupportedOutputFormats` have been re-exported in the crate root.
The `Hash` implementation has also been re-added to the `StreamId` type
to avoid some potentially frustrating downstream breakage.