### PR TITLE
cpal's nix dependency to 0.21; resolve build issue

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ lazy_static = "1.4"
 
 [target.'cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd"))'.dependencies]
 alsa = "0.5"
-nix = "0.20"
+nix = "0.21"
 libc = "0.2.65"
 parking_lot = "0.11"
 jack = { version = "0.7.0", optional = true }


### PR DESCRIPTION
Building HEAD was broken with "two different versions of 'nix'".
This fixes it.

See https://github.com/RustAudio/cpal/issues/608

This is also broken in the release version of cpal that rodio 0.14 references.