### PR TITLE
Allow creation of OutputCallbackInfo and InputCallbackInfo objects (for test purposes)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -363,14 +363,14 @@ pub struct OutputStreamTimestamp {
 /// Information relevant to a single call to the user's input stream data callback.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InputCallbackInfo {
-    timestamp: InputStreamTimestamp,
+    pub timestamp: InputStreamTimestamp,
 }
 
 /// Information relevant to a single call to the user's output stream data callback.
 #[cfg_attr(target_os = "emscripten", wasm_bindgen)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct OutputCallbackInfo {
-    timestamp: OutputStreamTimestamp,
+    pub timestamp: OutputStreamTimestamp,
 }
 
 impl SupportedStreamConfig {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@
 //! ```
 //!
 //! Before we can create a stream, we must decide what the configuration of the audio stream is
-//! going to be.    
+//! going to be.
 //! You can query all the supported configurations with the
 //! [`supported_input_configs()`] and [`supported_output_configs()`] methods.
 //! These produce a list of [`SupportedStreamConfigRange`] structs which can later be turned into
@@ -225,7 +225,7 @@ pub type FrameCount = u32;
 /// behavior of the given host. Note, the default buffer size may be surprisingly
 /// large, leading to latency issues. If low latency is desired, [`Fixed(FrameCount)`]
 /// should be used in accordance with the [`SupportedBufferSize`] range produced by
-/// the [`SupportedStreamConfig`] API.  
+/// the [`SupportedStreamConfig`] API.
 ///
 /// [`Default`]: BufferSize::Default
 /// [`Fixed(FrameCount)`]: BufferSize::Fixed
@@ -334,8 +334,8 @@ pub struct Data {
 /// | emscripten | `AudioContext.getOutputTimestamp` |
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 pub struct StreamInstant {
-    secs: i64,
-    nanos: u32,
+    pub secs: i64,
+    pub nanos: u32,
 }
 
 /// A timestamp associated with a call to an input stream's data callback.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -332,6 +332,7 @@ pub struct Data {
 /// | wasapi | `QueryPerformanceCounter` |
 /// | asio | `timeGetTime` |
 /// | emscripten | `AudioContext.getOutputTimestamp` |
+#[cfg_attr(target_os = "emscripten", wasm_bindgen)]
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 pub struct StreamInstant {
     pub secs: i64,
@@ -339,6 +340,7 @@ pub struct StreamInstant {
 }
 
 /// A timestamp associated with a call to an input stream's data callback.
+#[cfg_attr(target_os = "emscripten", wasm_bindgen)]
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
 pub struct InputStreamTimestamp {
     /// The instant the stream's data callback was invoked.
@@ -350,6 +352,7 @@ pub struct InputStreamTimestamp {
 }
 
 /// A timestamp associated with a call to an output stream's data callback.
+#[cfg_attr(target_os = "emscripten", wasm_bindgen)]
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
 pub struct OutputStreamTimestamp {
     /// The instant the stream's data callback was invoked.
@@ -361,6 +364,7 @@ pub struct OutputStreamTimestamp {
 }
 
 /// Information relevant to a single call to the user's input stream data callback.
+#[cfg_attr(target_os = "emscripten", wasm_bindgen)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InputCallbackInfo {
     pub timestamp: InputStreamTimestamp,


### PR DESCRIPTION
This change makes the fields of `StreamInstant`, `OutputCallbackInfo` and `InputCallbackInfo` pub.

The intent is to allow `OutputCallbackInfo` instances to be created, which then allows unit testing the data callback function. Because it is a self-contained function that simply fills data in a buffer, it is, in principle, very unit-testable -- but it's very difficult to do so today because the test code cannot create an `OutputCallbackInfo` for it.

I don't believe there's any good reason for these fields to not be pub. In particular, I noticed the fields of `OutputStreamTimestamp` _are_ public, so the "middle" layer is already creatable, just not `StreamInstant` and `OutputCallbackInfo`. Also, the structures are pretty plain data objects with no special logic or anything like that, so there really is no harm in allowing them to be created.