### PR TITLE
Asio support for int24

### DIFF
--- a/examples/android.rs
+++ b/examples/android.rs
@@ -5,7 +5,7 @@ extern crate cpal;
 
 use cpal::{
     traits::{DeviceTrait, HostTrait, StreamTrait},
-    SizedSample,
+    SizedSample, I24,
 };
 use cpal::{FromSample, Sample};
 
@@ -22,7 +22,7 @@ fn main() {
     match config.sample_format() {
         cpal::SampleFormat::I8 => run::<i8>(&device, &config.into()).unwrap(),
         cpal::SampleFormat::I16 => run::<i16>(&device, &config.into()).unwrap(),
-        // cpal::SampleFormat::I24 => run::<I24>(&device, &config.into()).unwrap(),
+        cpal::SampleFormat::I24 => run::<I24>(&device, &config.into()).unwrap(),
         cpal::SampleFormat::I32 => run::<i32>(&device, &config.into()).unwrap(),
         // cpal::SampleFormat::I48 => run::<I48>(&device, &config.into()).unwrap(),
         cpal::SampleFormat::I64 => run::<i64>(&device, &config.into()).unwrap(),

--- a/examples/beep.rs
+++ b/examples/beep.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 use cpal::{
     traits::{DeviceTrait, HostTrait, StreamTrait},
-    FromSample, Sample, SizedSample,
+    FromSample, Sample, SizedSample, I24,
 };
 
 #[derive(Parser, Debug)]
@@ -78,7 +78,7 @@ fn main() -> anyhow::Result<()> {
     match config.sample_format() {
         cpal::SampleFormat::I8 => run::<i8>(&device, &config.into()),
         cpal::SampleFormat::I16 => run::<i16>(&device, &config.into()),
-        // cpal::SampleFormat::I24 => run::<I24>(&device, &config.into()),
+        cpal::SampleFormat::I24 => run::<I24>(&device, &config.into()),
         cpal::SampleFormat::I32 => run::<i32>(&device, &config.into()),
         // cpal::SampleFormat::I48 => run::<I48>(&device, &config.into()),
         cpal::SampleFormat::I64 => run::<i64>(&device, &config.into()),

--- a/examples/synth_tones.rs
+++ b/examples/synth_tones.rs
@@ -8,7 +8,7 @@ extern crate cpal;
 
 use cpal::{
     traits::{DeviceTrait, HostTrait, StreamTrait},
-    SizedSample,
+    SizedSample, I24,
 };
 use cpal::{FromSample, Sample};
 
@@ -98,6 +98,7 @@ where
     match config.sample_format() {
         cpal::SampleFormat::I8 => make_stream::<i8>(&device, &config.into()),
         cpal::SampleFormat::I16 => make_stream::<i16>(&device, &config.into()),
+        cpal::SampleFormat::I24 => make_stream::<I24>(&device, &config.into()),
         cpal::SampleFormat::I32 => make_stream::<i32>(&device, &config.into()),
         cpal::SampleFormat::I64 => make_stream::<i64>(&device, &config.into()),
         cpal::SampleFormat::U8 => make_stream::<u8>(&device, &config.into()),

--- a/src/host/asio/device.rs
+++ b/src/host/asio/device.rs
@@ -209,10 +209,14 @@ pub(crate) fn convert_data_type(ty: &sys::AsioSampleType) -> Option<SampleFormat
     let fmt = match *ty {
         sys::AsioSampleType::ASIOSTInt16MSB => SampleFormat::I16,
         sys::AsioSampleType::ASIOSTInt16LSB => SampleFormat::I16,
-        sys::AsioSampleType::ASIOSTFloat32MSB => SampleFormat::F32,
-        sys::AsioSampleType::ASIOSTFloat32LSB => SampleFormat::F32,
+        sys::AsioSampleType::ASIOSTInt24MSB => SampleFormat::I24,
+        sys::AsioSampleType::ASIOSTInt24LSB => SampleFormat::I24,
         sys::AsioSampleType::ASIOSTInt32MSB => SampleFormat::I32,
         sys::AsioSampleType::ASIOSTInt32LSB => SampleFormat::I32,
+        sys::AsioSampleType::ASIOSTFloat32MSB => SampleFormat::F32,
+        sys::AsioSampleType::ASIOSTFloat32LSB => SampleFormat::F32,
+        sys::AsioSampleType::ASIOSTFloat64MSB => SampleFormat::F64,
+        sys::AsioSampleType::ASIOSTFloat64LSB => SampleFormat::F64,
         _ => return None,
     };
     Some(fmt)

--- a/src/samples_formats.rs
+++ b/src/samples_formats.rs
@@ -75,12 +75,12 @@ impl SampleFormat {
         match *self {
             SampleFormat::I8 | SampleFormat::U8 => mem::size_of::<i8>(),
             SampleFormat::I16 | SampleFormat::U16 => mem::size_of::<i16>(),
-            SampleFormat::I24 => mem::size_of::<i32>(), // Use internal size of i32
-            // SampleFormat::U24 => 3,
+            SampleFormat::I24 => mem::size_of::<i32>(),
+            // SampleFormat::U24 => mem::size_of::<i32>(),
             SampleFormat::I32 | SampleFormat::U32 => mem::size_of::<i32>(),
 
-            // SampleFormat::I48 => 6,
-            // SampleFormat::U48 => 6,
+            // SampleFormat::I48 => mem::size_of::<i64>(),
+            // SampleFormat::U48 => mem::size_of::<i64>(),
             SampleFormat::I64 | SampleFormat::U64 => mem::size_of::<i64>(),
             SampleFormat::F32 => mem::size_of::<f32>(),
             SampleFormat::F64 => mem::size_of::<f64>(),

--- a/src/samples_formats.rs
+++ b/src/samples_formats.rs
@@ -29,12 +29,13 @@ pub enum SampleFormat {
     /// `i16` with a valid range of `i16::MIN..=i16::MAX` with `0` being the origin.
     I16,
 
-    // /// `I24` with a valid range of '-(1 << 23)..(1 << 23)' with `0` being the origin
-    // I24,
+    /// `I24` with a valid range of '-(1 << 23)..(1 << 23)' with `0` being the origin
+    I24,
+
     /// `i32` with a valid range of `i32::MIN..=i32::MAX` with `0` being the origin.
     I32,
 
-    // /// `I24` with a valid range of '-(1 << 47)..(1 << 47)' with `0` being the origin
+    // /// `I48` with a valid range of '-(1 << 47)..(1 << 47)' with `0` being the origin
     // I48,
     /// `i64` with a valid range of `i64::MIN..=i64::MAX` with `0` being the origin.
     I64,
@@ -45,13 +46,15 @@ pub enum SampleFormat {
     /// `u16` with a valid range of `u16::MIN..=u16::MAX` with `1 << 15 == 32768` being the origin.
     U16,
 
-    // /// `U24` with a valid range of '0..16777216' with `1 << 23 == 8388608` being the origin
+    /// `U24` with a valid range of '0..16777216' with `1 << 23 == 8388608` being the origin
     // U24,
+
     /// `u32` with a valid range of `u32::MIN..=u32::MAX` with `1 << 31` being the origin.
     U32,
 
-    // /// `U48` with a valid range of '0..(1 << 48)' with `1 << 47` being the origin
+    /// `U48` with a valid range of '0..(1 << 48)' with `1 << 47` being the origin
     // U48,
+
     /// `u64` with a valid range of `u64::MIN..=u64::MAX` with `1 << 63` being the origin.
     U64,
 
@@ -63,16 +66,21 @@ pub enum SampleFormat {
 }
 
 impl SampleFormat {
-    /// Returns the size in bytes of a sample of this format.
+    /// Returns the size in bytes of a sample of this format. This corresponds to
+    /// the internal size of the rust primitives that are used to represent this
+    /// sample format (e.g., i24 has size of i32).
     #[inline]
     #[must_use]
     pub fn sample_size(&self) -> usize {
         match *self {
             SampleFormat::I8 | SampleFormat::U8 => mem::size_of::<i8>(),
             SampleFormat::I16 | SampleFormat::U16 => mem::size_of::<i16>(),
-            // SampleFormat::I24 | SampleFormat::U24 => 3,
+            SampleFormat::I24 => mem::size_of::<i32>(), // Use internal size of i32
+            // SampleFormat::U24 => 3,
             SampleFormat::I32 | SampleFormat::U32 => mem::size_of::<i32>(),
-            // SampleFormat::I48 | SampleFormat::U48 => 6,
+
+            // SampleFormat::I48 => 6,
+            // SampleFormat::U48 => 6,
             SampleFormat::I64 | SampleFormat::U64 => mem::size_of::<i64>(),
             SampleFormat::F32 => mem::size_of::<f32>(),
             SampleFormat::F64 => mem::size_of::<f64>(),
@@ -82,20 +90,28 @@ impl SampleFormat {
     #[inline]
     #[must_use]
     pub fn is_int(&self) -> bool {
-        //matches!(*self, SampleFormat::I8 | SampleFormat::I16 | SampleFormat::I24 | SampleFormat::I32 | SampleFormat::I48 | SampleFormat::I64)
         matches!(
             *self,
-            SampleFormat::I8 | SampleFormat::I16 | SampleFormat::I32 | SampleFormat::I64
+            SampleFormat::I8
+                | SampleFormat::I16
+                | SampleFormat::I24
+                | SampleFormat::I32
+                // | SampleFormat::I48
+                | SampleFormat::I64
         )
     }
 
     #[inline]
     #[must_use]
     pub fn is_uint(&self) -> bool {
-        //matches!(*self, SampleFormat::U8 | SampleFormat::U16 | SampleFormat::U24 | SampleFormat::U32 | SampleFormat::U48 | SampleFormat::U64)
         matches!(
             *self,
-            SampleFormat::U8 | SampleFormat::U16 | SampleFormat::U32 | SampleFormat::U64
+            SampleFormat::U8
+                | SampleFormat::U16
+                // | SampleFormat::U24
+                | SampleFormat::U32
+                // | SampleFormat::U48
+                | SampleFormat::U64
         )
     }
 
@@ -111,7 +127,7 @@ impl Display for SampleFormat {
         match *self {
             SampleFormat::I8 => "i8",
             SampleFormat::I16 => "i16",
-            // SampleFormat::I24 => "i24",
+            SampleFormat::I24 => "i24",
             SampleFormat::I32 => "i32",
             // SampleFormat::I48 => "i48",
             SampleFormat::I64 => "i64",
@@ -140,13 +156,17 @@ impl SizedSample for i16 {
     const FORMAT: SampleFormat = SampleFormat::I16;
 }
 
-// impl SizedSample for I24 { const FORMAT: SampleFormat = SampleFormat::I24; }
+impl SizedSample for I24 {
+    const FORMAT: SampleFormat = SampleFormat::I24;
+}
 
 impl SizedSample for i32 {
     const FORMAT: SampleFormat = SampleFormat::I32;
 }
 
-// impl SizedSample for I48 { const FORMAT: SampleFormat = SampleFormat::I48; }
+// impl SizedSample for I48 {
+//     const FORMAT: SampleFormat = SampleFormat::I48;
+// }
 
 impl SizedSample for i64 {
     const FORMAT: SampleFormat = SampleFormat::I64;
@@ -160,13 +180,17 @@ impl SizedSample for u16 {
     const FORMAT: SampleFormat = SampleFormat::U16;
 }
 
-// impl SizedSample for U24 { const FORMAT: SampleFormat = SampleFormat::U24; }
+// impl SizedSample for U24 {
+//     const FORMAT: SampleFormat = SampleFormat::U24;
+// }
 
 impl SizedSample for u32 {
     const FORMAT: SampleFormat = SampleFormat::U32;
 }
 
-// impl SizedSample for U48 { const FORMAT: SampleFormat = SampleFormat::U48; }
+// impl SizedSample for U48 {
+//     const FORMAT: SampleFormat = SampleFormat::U48;
+// }
 
 impl SizedSample for u64 {
     const FORMAT: SampleFormat = SampleFormat::U64;


### PR DESCRIPTION
The ASIO API supports the sample formats int24 (3 bytes long) in little and big endian variants (see [documentation](https://dspace.tul.cz/server/api/core/bitstreams/39cee442-acf3-4ba4-8a9f-7b9988a8abe4/content) page 33 and 34). Some professional audio interfaces make use of this part of the API. Currently, the ASIO host does not allow for this, so these devices are left unsupported altogether.

This PR introduces support for these sample formats without changing much of the external API. The only change is the fact that the sample format I24 is uncommented. This is not a breaking change because the enum is marked as non-exhaustive.

## Regarding this implementation
Current implementation uses a single function with generics which allows to parse the SampleFormats from/to the ASIO types. Since int24 has no direct representation with rust primitive types, and is in fact represented internally using a i32, this implementation reads/writes bytes directly from/to the ASIO buffers.

ASIO does not support the other sample types such as U24, I48 and U48. Therefore, I decided to implemented a single function for this special case, without refactoring much of the already working one. This part of the ASIO API will likely not change in the future, so I see no benefit in writing a general function to support the aforementioned types.

The existing function could be rewritten completely to support all types (including int24) simultaneously if it would write the raw bytes directly instead of using rust primitive types for every case. It might be somewhat more concise, but it does require refactoring of working code, which in this case, I personally see as a waste of resources.

## Examples
Some examples were extended to the use of I24. I honestly never use anything else than ASIO or CoreAudio, so I'm not certain, that everything will just work for the other hosts.

## Tests
I did manual tests with a [professional audio interface](https://www.merging.com/products/interfaces/merging+anubis) which utilizes ASIO int24 as its default sample type. Both callbacks worked as expected. No unit tests were added here.