### PR TITLE
fix(alsa): ALSA template errors during enumeration

### DIFF
--- a/src/host/alsa/mod.rs
+++ b/src/host/alsa/mod.rs
@@ -153,7 +153,7 @@ impl DeviceTrait for Device {
     {
         let stream_inner =
             self.build_stream_inner(conf, sample_format, alsa::Direction::Capture)?;
-        let stream = Stream::new_input(
+        let stream = Self::Stream::new_input(
             Arc::new(stream_inner),
             data_callback,
             error_callback,
@@ -176,7 +176,7 @@ impl DeviceTrait for Device {
     {
         let stream_inner =
             self.build_stream_inner(conf, sample_format, alsa::Direction::Playback)?;
-        let stream = Stream::new_output(
+        let stream = Self::Stream::new_output(
             Arc::new(stream_inner),
             data_callback,
             error_callback,
@@ -237,19 +237,6 @@ struct DeviceHandles {
 }
 
 impl DeviceHandles {
-    /// Create `DeviceHandles` for `name` and try to open a handle for both
-    /// directions. Returns `Ok` if either direction is opened successfully.
-    fn open(pcm_id: &str) -> Result<Self, alsa::Error> {
-        let mut handles = Self::default();
-        let playback_err = handles.try_open(pcm_id, alsa::Direction::Playback).err();
-        let capture_err = handles.try_open(pcm_id, alsa::Direction::Capture).err();
-        if let Some(err) = capture_err.and(playback_err) {
-            Err(err)
-        } else {
-            Ok(handles)
-        }
-    }
-
     /// Get a mutable reference to the `Option` for a specific `stream_type`.
     /// If the `Option` is `None`, the `alsa::PCM` will be opened and placed in
     /// the `Option` before returning. If `handle_mut()` returns `Ok` the contained
@@ -1091,7 +1078,7 @@ impl Stream {
                 );
             })
             .unwrap();
-        Stream {
+        Self {
             thread: Some(thread),
             inner,
             trigger: tx,
@@ -1123,7 +1110,7 @@ impl Stream {
                 );
             })
             .unwrap();
-        Stream {
+        Self {
             thread: Some(thread),
             inner,
             trigger: tx,
@@ -1380,7 +1367,7 @@ impl TryFrom<SampleFormat> for alsa::pcm::Format {
 
 impl From<alsa::Error> for BackendSpecificError {
     fn from(err: alsa::Error) -> Self {
-        BackendSpecificError {
+        Self {
             description: err.to_string(),
         }
     }


### PR DESCRIPTION
Reported on [Discord](https://discord.com/channels/590254806208217089/672897096826748948/1428515185076867212):

> When enumerating devices I get a lot of alsa errors: 

```
[2025-10-16T22:38:51Z INFO  alsa] ALSA lib confmisc.c:855:(parse_card) cannot find card '$CARD'
[2025-10-16T22:38:51Z INFO  alsa] ALSA lib conf.c:5205:(_snd_config_evaluate) function snd_func_card_inum returned error: No such device
[2025-10-16T22:38:51Z INFO  alsa] ALSA lib confmisc.c:422:(snd_func_concat) error evaluating strings
[2025-10-16T22:38:51Z INFO  alsa] ALSA lib conf.c:5205:(_snd_config_evaluate) function snd_func_concat returned error: No such device
[2025-10-16T22:38:51Z INFO  alsa] ALSA lib confmisc.c:1342:(snd_func_refer) error evaluating name
[2025-10-16T22:38:51Z INFO  alsa] ALSA lib conf.c:5205:(_snd_config_evaluate) function snd_func_refer returned error: No such device
[2025-10-16T22:38:51Z INFO  alsa] ALSA lib conf.c:5728:(snd_config_expand) Evaluate error: No such device
[2025-10-16T22:38:51Z INFO  alsa] ALSA lib conf.c:5541:(parse_args) Unknown parameter CARD
[2025-10-16T22:38:51Z INFO  alsa] ALSA lib conf.c:5712:(snd_config_expand) Parse arguments error: No such file or directory
[2025-10-16T22:38:51Z INFO  alsa] ALSA lib conf.c:5541:(parse_args) Unknown parameter CARD
...
```

This is due to trying to open devices that were configured as templates in ALSA. Basically this is an ALSA configuration mistake, however, there's no point to cpal trying to open them either, so that's just removed now.

Cleaned up a little while there.

This PR builds on top of #1033, so review just the last commits to see what's changed on top.