### PR TITLE
Added Result<SupportedI/OConfigs, DeviceError> to handle Errors better

### DIFF
--- a/src/host/wasapi/mod.rs
+++ b/src/host/wasapi/mod.rs
@@ -6,6 +6,7 @@ pub use self::stream::Stream;
 use crate::traits::HostTrait;
 use crate::BackendSpecificError;
 use crate::DevicesError;
+use crate::SupportedStreamConfigsError;
 use std::io::Error as IoError;
 use windows::Win32::Media::Audio;
 
@@ -25,15 +26,20 @@ impl Host {
     pub fn new() -> Result<Self, crate::HostUnavailable> {
         Ok(Host)
     }
-    
-    fn supported_output_configs(&self, device: &Device) -> Result<SupportedOutputConfigs, DevicesError> {
-        Ok(device.supported_output_configs()?)
-    }
-    
-    fn supported_input_configs(&self, device: &Device) -> Result<SupportedInputConfigs, DevicesError> {
+
+    fn supported_input_configs(
+        &self,
+        device: &Device,
+    ) -> Result<SupportedInputConfigs, DevicesError> {
         Ok(device.supported_input_configs()?)
     }
-    
+
+    fn supported_output_configs(
+        &self,
+        device: &Device,
+    ) -> Result<SupportedInputConfigs, DevicesError> {
+        Ok(device.supported_input_configs()?)
+    }
 }
 
 impl From<SupportedStreamConfigsError> for DevicesError {
@@ -58,7 +64,7 @@ impl HostTrait for Host {
     fn devices(&self) -> Result<Self::Devices, DevicesError> {
         Devices::new()
     }
-    
+
     fn default_input_device(&self) -> Option<Self::Device> {
         default_input_device()
     }
@@ -66,7 +72,6 @@ impl HostTrait for Host {
     fn default_output_device(&self) -> Option<Self::Device> {
         default_output_device()
     }
-    
 }
 
 impl From<windows::core::Error> for BackendSpecificError {


### PR DESCRIPTION
I noticed it because of the compile warning.

Fix WASAPI Host warnings: Added Stream and impl handling of input/output error configs to return 
Result<SupportedI/OConfigs, DeviceError> 
for better user experience and better error handling

Fixes #740 Respect Windows output device selection
By Erroring and finding new I/O Config
(if WASAPI)

Current behavior
I am using rodio to play audio on Windows 11. When I change the output device on Windows, the audio continues to play on the old device.

//////Another Error //////////

FIxes #426 Panic in stream.rs:145:9 (unwrap Err) on Stream drop when device disconnected
On Windows, presumably using WASAPI, since I don't have ASIO installed.
To reproduce:

Create stream.
Disconnect the audio device, and properly get a DeviceNotAvailable error callback (created with device.build_output_stream(...)).
Drop stream.