### PR TITLE
WASAPI: Handle AUDCLNT_E_DEVICE_IN_USE 

### DIFF
--- a/src/host/wasapi/mod.rs
+++ b/src/host/wasapi/mod.rs
@@ -96,12 +96,8 @@ fn windows_err_to_cpal_err_message<E: ErrDeviceNotAvailable>(
     message: &str,
 ) -> E {
     match e.code() {
-        Audio::AUDCLNT_E_DEVICE_INVALIDATED => E::device_not_available(),
-        Audio::AUDCLNT_E_DEVICE_IN_USE => {
-            let err = BackendSpecificError {
-                description: "The device is already in use.".to_string(),
-            };
-            err.into()
+        Audio::AUDCLNT_E_DEVICE_INVALIDATED | Audio::AUDCLNT_E_DEVICE_IN_USE => {
+            E::device_not_available()
         }
         _ => {
             let description = format!("{}{}", message, e);


### PR DESCRIPTION
Small fix: changes the backend-specific error from a cryptic "0x8889000A" to "The device is already in use.".