### PR TITLE
fix(windows): bump minimum windows crate version to 0.59

### DIFF
--- a/.github/workflows/platforms.yml
+++ b/.github/workflows/platforms.yml
@@ -319,7 +319,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ["0.58.0", "0.59.0", "0.60.0", "0.61.3"]
+        version: ["0.59.0", "0.60.0", "0.61.3"]
 
     name: windows-crate-v${{ matrix.version }}
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 - CI: Fix cargo publish to trigger on GitHub releases instead of every master commit.
 - CI: Replace cargo install commands with cached tool installation for faster builds.
 - CI: Update actions to latest versions (checkout@v5, rust-cache@v2).
-- CI: Verify compatibility with windows crates since v0.58.
+- CI: Verify compatibility with windows crates since v0.59.
 - CoreAudio: Change `Device::supported_configs` to return a single element containing the available sample rate range when all elements have the same `mMinimum` and `mMaximum` values.
 - CoreAudio: Change default audio device detection to be lazy when building a stream, instead of during device enumeration.
 - CoreAudio: Add `i8`, `i32` and `I24` sample format support (24-bit samples stored in 4 bytes).
@@ -45,7 +45,7 @@
 - JACK: Add `BufferSize::Fixed` validation to reject requests that don't match server buffer size.
 - WASAPI: Expose `IMMDevice` from WASAPI host Device.
 - WASAPI: Add `I24` and `U24` sample format support (24-bit samples stored in 4 bytes).
-- WASAPI: Update `windows` to >= 0.58, <= 0.62.
+- WASAPI: Update `windows` to >= 0.59, <= 0.62.
 - WASAPI: Make `Stream` implement `Send` and `Sync`.
 - Wasm: Removed optional `wee-alloc` feature for security reasons.
 - Wasm: Make `Stream` implement `Send` and `Sync`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ clap = { version = "4.5", features = ["derive"] }
 # versions when bumping to a new release, and only increase the minimum when absolutely necessary.
 # When updating this, also update the "windows-version" matrix in the CI workflow.
 [target.'cfg(target_os = "windows")'.dependencies]
-windows = { version = ">=0.58, <=0.62", features = [
+windows = { version = ">=0.59, <=0.62", features = [
     "Win32_Media_Audio",
     "Win32_Foundation",
     "Win32_Devices_Properties",


### PR DESCRIPTION
Reported on Discord during final v0.17 shakedown testing: windows v0.58 wasn't tested in the CI.