### PR TITLE
fix: share ASIO instance across Host instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - ASIO: Fix linker flags for MinGW cross-compilation.
 - ASIO: Add packed(4) to representation of ASIO time structs in bindings.
 - ASIO: Add handling for `kAsioResetRequest` message to prevent driver UI becoming unresponsive.
+- ASIO: Share `sys::Asio` instance across all `Host` instances.
 - CI: Added native ARM64 Linux support in GitHub Actions.
 - CI: Fix cargo publish to trigger on GitHub releases instead of every master commit.
 - CI: Replace cargo install commands with cached tool installation for faster builds.

--- a/src/host/asio/mod.rs
+++ b/src/host/asio/mod.rs
@@ -15,11 +15,17 @@ use crate::{
 
 pub use self::device::{Device, Devices, SupportedInputConfigs, SupportedOutputConfigs};
 pub use self::stream::Stream;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 
 mod device;
 mod stream;
+
+/// Global ASIO instance shared across all Host instances.
+///
+/// ASIO only supports loading a single driver at a time globally, so all Host instances
+/// must share the same underlying sys::Asio wrapper to properly coordinate driver access.
+static GLOBAL_ASIO: OnceLock<Arc<sys::Asio>> = OnceLock::new();
 
 /// The host for ASIO.
 #[derive(Debug)]
@@ -29,7 +35,9 @@ pub struct Host {
 
 impl Host {
     pub fn new() -> Result<Self, crate::HostUnavailable> {
-        let asio = Arc::new(sys::Asio::new());
+        let asio = GLOBAL_ASIO
+            .get_or_init(|| Arc::new(sys::Asio::new()))
+            .clone();
         let host = Host { asio };
         Ok(host)
     }


### PR DESCRIPTION
Idea by @Sin-tel:
> to prevent you from creating multiple asio instances, should we do something like: [...]
> currently it happily lets you make new ASIO hosts even if that is not supposed to happen