### PR TITLE
set audioworklet example toolchain to nightly

### DIFF
--- a/examples/audioworklet-beep/rust-toolchain.toml
+++ b/examples/audioworklet-beep/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"


### PR DESCRIPTION
the `audioworklet-beep` example requires nightly, this PR enforces this via `rust-toolchain.toml`.

nb: currently I can't fully build this example on my machine (pop!os 24.04), presumably because `wasm-bindgen` has some issues with nightly, at least recent commits in their repo look like it. Sadly updating to a git version of `wasm-bindgen` isn't trivial because of dependency hell.

So just for completeness' sake, if anyone feels like investigating (`--release` does not fix it):

```
❯ RUST_BACKTRACE=1 trunk serve --open   
2025-12-12T23:24:35.404978Z  INFO 🚀 Starting trunk 0.21.7
2025-12-12T23:24:35.405600Z  INFO ⏫ Found an update of trunk: 0.21.7 -> 0.21.14
2025-12-12T23:24:35.408453Z  INFO 📦 starting build
warning: unstable feature specified for `-Ctarget-feature`: `atomics`
  │
  ╰ note: this feature is not stably supported; its behavior can change in the future

warning: `cpal` (lib) generated 1 warning
warning: `audioworklet-beep` (lib) generated 1 warning (1 duplicate)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.08s

thread 'main' (1145075) panicked at crates/cli-support/src/descriptor.rs:200:15:
index out of bounds: the len is 0 but the index is 0
stack backtrace:
   0: __rustc::rust_begin_unwind
   1: core::panicking::panic_fmt
   2: core::panicking::panic_bounds_check
   3: wasm_bindgen_cli_support::descriptor::Descriptor::_decode
   4: wasm_bindgen_cli_support::descriptors::execute
   5: wasm_bindgen_cli_support::Bindgen::generate_output
   6: wasm_bindgen_cli::wasm_bindgen::rmain
   7: wasm_bindgen_cli::wasm_bindgen::run_cli_with_args
   8: wasm_bindgen::main
```