### PR TITLE
[asio-sys] Use case-insensitive comparison for discovering downloaded asio sdk

### DIFF
--- a/asio-sys/build.rs
+++ b/asio-sys/build.rs
@@ -290,7 +290,13 @@ fn get_asio_dir() -> PathBuf {
     // Move the contents of the inner directory to asio_dir
     for entry in walkdir::WalkDir::new(&temp_dir).min_depth(1).max_depth(1) {
         let entry = entry.unwrap();
-        if entry.file_type().is_dir() && entry.file_name().to_string_lossy().starts_with("asio") {
+        if entry.file_type().is_dir()
+            && entry
+                .file_name()
+                .to_string_lossy()
+                .to_lowercase()
+                .starts_with("asio")
+        {
             std::fs::rename(entry.path(), &asio_dir).expect("Failed to rename directory");
             break;
         }


### PR DESCRIPTION
This fixed the build of asio-sys on my windows machine. I thought all windows filesystems were case-insensitive but apparently not 😅 