### PR TITLE
Fix AudioWorklet example

### DIFF
--- a/examples/audioworklet-beep/.cargo/config.toml
+++ b/examples/audioworklet-beep/.cargo/config.toml
@@ -1,5 +1,22 @@
 [target.wasm32-unknown-unknown]
-rustflags = ["-C", "target-feature=+atomics"]
+rustflags = [
+    "-C",
+    "target-feature=+atomics",
+    "-C",
+    "link-arg=--shared-memory",
+    "-C",
+    "link-arg=--max-memory=1073741824",
+    "-C",
+    "link-arg=--import-memory",
+    "-C",
+    "link-arg=--export=__wasm_init_tls",
+    "-C",
+    "link-arg=--export=__tls_size",
+    "-C",
+    "link-arg=--export=__tls_align",
+    "-C",
+    "link-arg=--export=__tls_base",
+]
 
 [unstable]
 build-std = ["std", "panic_abort"]


### PR DESCRIPTION
This fixes the audioworklet example for the breaking change recently introduced by: https://github.com/rust-lang/rust/pull/147225

Even though many projects are now using workers and threading on web it's still dependent on nightly Rust and so breaking changes can occur. This fixes the example so it doesn't crash when run.