### PR TITLE
Safe join on Drop

### DIFF
--- a/src/host/wasapi/device.rs
+++ b/src/host/wasapi/device.rs
@@ -511,7 +511,7 @@ impl Device {
         // Retrieve the `IAudioClient`.
         let lock = match self.ensure_future_audio_client() {
             Ok(lock) => lock,
-            Err(ref e) if e.code() == Audio::AUDCLNT_E_DEVICE_INVALIDATED.into() => {
+            Err(ref e) if e.code() == Audio::AUDCLNT_E_DEVICE_INVALIDATED => {
                 return Err(SupportedStreamConfigsError::DeviceNotAvailable)
             }
             Err(e) => {
@@ -625,7 +625,7 @@ impl Device {
 
         let lock = match self.ensure_future_audio_client() {
             Ok(lock) => lock,
-            Err(ref e) if e.code() == Audio::AUDCLNT_E_DEVICE_INVALIDATED.into() => {
+            Err(ref e) if e.code() == Audio::AUDCLNT_E_DEVICE_INVALIDATED => {
                 return Err(DefaultStreamConfigError::DeviceNotAvailable)
             }
             Err(e) => {
@@ -682,7 +682,7 @@ impl Device {
             // Obtaining a `IAudioClient`.
             let audio_client = match self.build_audioclient() {
                 Ok(client) => client,
-                Err(ref e) if e.code() == Audio::AUDCLNT_E_DEVICE_INVALIDATED.into() => {
+                Err(ref e) if e.code() == Audio::AUDCLNT_E_DEVICE_INVALIDATED => {
                     return Err(BuildStreamError::DeviceNotAvailable)
                 }
                 Err(e) => {
@@ -725,7 +725,7 @@ impl Device {
                     None,
                 );
                 match hresult {
-                    Err(ref e) if e.code() == Audio::AUDCLNT_E_DEVICE_INVALIDATED.into() => {
+                    Err(ref e) if e.code() == Audio::AUDCLNT_E_DEVICE_INVALIDATED => {
                         return Err(BuildStreamError::DeviceNotAvailable);
                     }
                     Err(e) => {

--- a/src/host/wasapi/stream.rs
+++ b/src/host/wasapi/stream.rs
@@ -442,7 +442,7 @@ fn process_input(
 
             match result {
                 // TODO: Can this happen?
-                Err(e) if e.code() == Audio::AUDCLNT_S_BUFFER_EMPTY.into() => continue,
+                Err(e) if e.code() == Audio::AUDCLNT_S_BUFFER_EMPTY => continue,
                 Err(e) => {
                     error_callback(windows_err_to_cpal_err(e));
                     return ControlFlow::Break;


### PR DESCRIPTION
This PR refactor thread `join` on `Drop` to avoid `unwrap`.

While it's probably unnecessary in most contexts, I depend on `cpal` through [kira](https://github.com/tesselode/kira) in [audioware](https://github.com/cyb3rpsych0s1s/audioware) which runs in a video game plugin context.

In this particular context, the game can reclaim plugin's resource anytime (e.g. when player kill game in Windows taskbar), which, at times, causes race condition leading to CTD like this:
<img width="1909" height="381" alt="Screenshot 2026-01-27 174944" src="https://github.com/user-attachments/assets/de7b0e9e-6b86-4171-9385-ca0d85d8fdc9" />
