### PR TITLE
Fix aaudio device name in `device.description().name()`

### DIFF
--- a/src/host/aaudio/mod.rs
+++ b/src/host/aaudio/mod.rs
@@ -405,7 +405,7 @@ impl DeviceTrait for Device {
         match &self.0 {
             None => Ok(DeviceDescriptionBuilder::new("Default Device".to_string()).build()),
             Some(info) => {
-                let mut builder = DeviceDescriptionBuilder::new(info.product_name.clone())
+                let mut builder = DeviceDescriptionBuilder::new(self.name()?)
                     .device_type(info.device_type.into())
                     .interface_type(info.device_type.into())
                     .direction(info.direction);

--- a/src/host/aaudio/mod.rs
+++ b/src/host/aaudio/mod.rs
@@ -405,7 +405,15 @@ impl DeviceTrait for Device {
         match &self.0 {
             None => Ok(DeviceDescriptionBuilder::new("Default Device".to_string()).build()),
             Some(info) => {
-                let mut builder = DeviceDescriptionBuilder::new(self.name()?)
+                let name = if info.address.is_empty() {
+                    format!("{}:{:?}", info.product_name, info.device_type)
+                } else {
+                    format!(
+                        "{}:{:?}:{}",
+                        info.product_name, info.device_type, info.address
+                    )
+                };
+                let mut builder = DeviceDescriptionBuilder::new(name)
                     .device_type(info.device_type.into())
                     .interface_type(info.device_type.into())
                     .direction(info.direction);


### PR DESCRIPTION
#965 fixed this for `device.name()`, which is now a deprecated method. I let `.description().name()` return the same name.