### PR TITLE
Clean up numeric overflow using u128 for product of u64 and 1_000

### DIFF
--- a/src/host/jack/stream.rs
+++ b/src/host/jack/stream.rs
@@ -402,9 +402,9 @@ impl jack::ProcessHandler for LocalProcessHandler {
 }
 
 fn micros_to_stream_instant(micros: u64) -> crate::StreamInstant {
-    let nanos = micros * 1000;
+    let nanos = micros as u128 * 1000;
     let secs = micros / 1_000_000;
-    let subsec_nanos = nanos - secs * 1_000_000_000;
+    let subsec_nanos = nanos - secs as u128 * 1_000_000_000;
     crate::StreamInstant::new(secs as i64, subsec_nanos as u32)
 }
 


### PR DESCRIPTION
I some cases I observed in `host/jack/stream.rs` the function `micros_to_stream_instant` the parameter `micros` when multiplied by 1_000 overflowed u64