### PR TITLE
fix(pulseaudio): several correctness and accuracy fixes

### DIFF
--- a/src/host/pulseaudio/mod.rs
+++ b/src/host/pulseaudio/mod.rs
@@ -280,7 +280,8 @@ impl DeviceTrait for Device {
 
         let sample_spec = make_sample_spec(config, format);
         let channel_map = make_channel_map(config);
-        let buffer_attr = make_buffer_attr(config, format);
+        let buffer_attr = make_record_buffer_attr(config, format);
+        let adjust_latency = matches!(config.buffer_size, crate::BufferSize::Fixed(_));
 
         let params = protocol::RecordStreamParams {
             sample_spec,
@@ -290,6 +291,9 @@ impl DeviceTrait for Device {
             flags: protocol::stream::StreamFlags {
                 // Start the stream suspended.
                 start_corked: true,
+                // When a fixed buffer size is requested, ask PA to configure
+                // the source hardware to hit the requested latency end-to-end.
+                adjust_latency,
                 ..Default::default()
             },
             ..Default::default()
@@ -320,7 +324,8 @@ impl DeviceTrait for Device {
 
         let sample_spec = make_sample_spec(config, format);
         let channel_map = make_channel_map(config);
-        let buffer_attr = make_buffer_attr(config, format);
+        let buffer_attr = make_playback_buffer_attr(config, format);
+        let adjust_latency = matches!(config.buffer_size, crate::BufferSize::Fixed(_));
 
         let params = protocol::PlaybackStreamParams {
             sink_index: Some(info.index),
@@ -330,6 +335,9 @@ impl DeviceTrait for Device {
             flags: protocol::stream::StreamFlags {
                 // Start the stream suspended.
                 start_corked: true,
+                // When a fixed buffer size is requested, ask PA to configure
+                // the sink hardware to hit the requested latency end-to-end.
+                adjust_latency,
                 ..Default::default()
             },
             ..Default::default()
@@ -372,19 +380,82 @@ fn make_sample_spec(config: &StreamConfig, format: protocol::SampleFormat) -> pr
 }
 
 fn make_channel_map(config: &StreamConfig) -> protocol::ChannelMap {
-    if config.channels == 2 {
-        return protocol::ChannelMap::stereo();
+    use protocol::ChannelPosition::*;
+
+    // Standard channel layouts following the PulseAudio default channel map
+    // (PA_CHANNEL_MAP_DEFAULT) for 1-8 channels, and common Atmos height-
+    // channel conventions for 10 and 12 channels. Counts without a widely
+    // agreed layout (9, 11, >12) fall back to sequential Aux positions.
+    let standard: &[protocol::ChannelPosition] = match config.channels {
+        1 => &[Mono],
+        2 => &[FrontLeft, FrontRight],
+        3 => &[FrontLeft, FrontRight, FrontCenter],
+        4 => &[FrontLeft, FrontRight, RearLeft, RearRight],
+        5 => &[FrontLeft, FrontRight, FrontCenter, RearLeft, RearRight],
+        6 => &[FrontLeft, FrontRight, FrontCenter, Lfe, RearLeft, RearRight],
+        7 => &[
+            FrontLeft,
+            FrontRight,
+            FrontCenter,
+            Lfe,
+            RearLeft,
+            RearRight,
+            RearCenter,
+        ],
+        8 => &[
+            FrontLeft,
+            FrontRight,
+            FrontCenter,
+            Lfe,
+            RearLeft,
+            RearRight,
+            SideLeft,
+            SideRight,
+        ],
+        // 7.1.2 (Dolby Atmos): 7.1 + top-front L/R
+        10 => &[
+            FrontLeft,
+            FrontRight,
+            FrontCenter,
+            Lfe,
+            RearLeft,
+            RearRight,
+            SideLeft,
+            SideRight,
+            TopFrontLeft,
+            TopFrontRight,
+        ],
+        // 7.1.4 (Dolby Atmos): 7.1 + top-front L/R + top-rear L/R
+        12 => &[
+            FrontLeft,
+            FrontRight,
+            FrontCenter,
+            Lfe,
+            RearLeft,
+            RearRight,
+            SideLeft,
+            SideRight,
+            TopFrontLeft,
+            TopFrontRight,
+            TopRearLeft,
+            TopRearRight,
+        ],
+        _ => &[],
+    };
+
+    if !standard.is_empty() {
+        return protocol::ChannelMap::new(standard.iter().copied());
     }
 
-    let mut map = protocol::ChannelMap::empty();
-    for _ in 0..config.channels {
-        map.push(protocol::ChannelPosition::Mono);
-    }
-
-    map
+    let aux = [
+        Aux0, Aux1, Aux2, Aux3, Aux4, Aux5, Aux6, Aux7, Aux8, Aux9, Aux10, Aux11, Aux12, Aux13,
+        Aux14, Aux15, Aux16, Aux17, Aux18, Aux19, Aux20, Aux21, Aux22, Aux23, Aux24, Aux25, Aux26,
+        Aux27, Aux28, Aux29, Aux30, Aux31,
+    ];
+    protocol::ChannelMap::new(aux.iter().copied().take(config.channels as usize))
 }
 
-fn make_buffer_attr(
+fn make_playback_buffer_attr(
     config: &StreamConfig,
     format: protocol::SampleFormat,
 ) -> protocol::stream::BufferAttr {
@@ -393,8 +464,32 @@ fn make_buffer_attr(
         crate::BufferSize::Fixed(frame_count) => {
             let len = frame_count * config.channels as u32 * format.bytes_per_sample() as u32;
             protocol::stream::BufferAttr {
+                // Double-buffer: total buffer = 2 callback periods. With
+                // adjust_latency this becomes the end-to-end latency target,
+                // Minimum request = one callback period, ensuring the server
+                // always asks for exactly frame_count frames per call.
+                max_length: 2 * len,
+                target_length: 2 * len,
+                minimum_request_length: len,
+                ..Default::default()
+            }
+        }
+    }
+}
+
+fn make_record_buffer_attr(
+    config: &StreamConfig,
+    format: protocol::SampleFormat,
+) -> protocol::stream::BufferAttr {
+    match config.buffer_size {
+        crate::BufferSize::Default => Default::default(),
+        crate::BufferSize::Fixed(frame_count) => {
+            let len = frame_count * config.channels as u32 * format.bytes_per_sample() as u32;
+            protocol::stream::BufferAttr {
+                // fragment_size controls the delivery chunk size for record
+                // streams; target_length is playback-only and is ignored here.
                 max_length: len,
-                target_length: len,
+                fragment_size: len,
                 ..Default::default()
             }
         }

--- a/src/host/pulseaudio/stream.rs
+++ b/src/host/pulseaudio/stream.rs
@@ -3,7 +3,7 @@ use std::{
         atomic::{self, AtomicU64},
         Arc, Mutex,
     },
-    time::{self, SystemTime},
+    time,
 };
 
 use futures::executor::block_on;
@@ -57,10 +57,15 @@ impl Stream {
         D: FnMut(&mut Data, &OutputCallbackInfo) + Send + 'static,
         E: FnMut(StreamError) + Send + 'static,
     {
-        let epoch = std::time::SystemTime::now();
+        // Use a monotonic clock relative to stream creation for StreamInstants.
+        let start = std::time::Instant::now();
 
         let current_latency_micros = Arc::new(AtomicU64::new(0));
+        // Microseconds since stream creation at the time of the last latency poll, used
+        // to interpolate the latency between polls.
+        let last_poll_micros = Arc::new(AtomicU64::new(0));
         let latency_clone = current_latency_micros.clone();
+        let poll_clone = last_poll_micros.clone();
         let sample_spec = params.sample_spec;
 
         let format: SampleFormat = sample_spec
@@ -80,14 +85,23 @@ impl Stream {
 
         // Wrap the write callback to match the pulseaudio signature.
         let callback = move |buf: &mut [u8]| {
-            let now = SystemTime::now().duration_since(epoch).unwrap_or_default();
-            let latency = latency_clone.load(atomic::Ordering::Relaxed);
-            let playback_time = now + time::Duration::from_micros(latency);
+            let elapsed = std::time::Instant::now().saturating_duration_since(start);
+            let elapsed_usec = elapsed.as_micros() as u64;
+
+            // Interpolate the latency based on elapsed time since the last
+            // poll: as audio plays, the DAC drains the buffer at a constant
+            // rate, so the latency decreases linearly between polls.
+            let stored_latency = latency_clone.load(atomic::Ordering::Relaxed);
+            let poll_usec = poll_clone.load(atomic::Ordering::Relaxed);
+            let elapsed_since_poll = elapsed_usec.saturating_sub(poll_usec);
+            let latency = stored_latency.saturating_sub(elapsed_since_poll);
+
+            let playback_time = elapsed + time::Duration::from_micros(latency);
 
             let timestamp = OutputStreamTimestamp {
                 callback: StreamInstant {
-                    secs: now.as_secs() as i64,
-                    nanos: now.subsec_nanos(),
+                    secs: elapsed.as_secs() as i64,
+                    nanos: elapsed.subsec_nanos(),
                 },
                 playback: StreamInstant {
                     secs: playback_time.as_secs() as i64,
@@ -138,6 +152,7 @@ impl Stream {
         // exit automatically when the stream ends.
         let stream_clone = stream.clone();
         let latency_clone = current_latency_micros.clone();
+        let poll_clone = last_poll_micros.clone();
         std::thread::spawn(move || loop {
             let timing_info = match block_on(stream_clone.timing_info()) {
                 Ok(timing_info) => timing_info,
@@ -148,6 +163,11 @@ impl Stream {
                     break;
                 }
             };
+
+            let poll_since_epoch = std::time::Instant::now()
+                .saturating_duration_since(start)
+                .as_micros() as u64;
+            poll_clone.store(poll_since_epoch, atomic::Ordering::Relaxed);
 
             store_latency(
                 &latency_clone,
@@ -173,7 +193,7 @@ impl Stream {
         D: FnMut(&Data, &InputCallbackInfo) + Send + 'static,
         E: FnMut(StreamError) + Send + 'static,
     {
-        let epoch = std::time::SystemTime::now();
+        let start = std::time::Instant::now();
 
         let current_latency_micros = Arc::new(AtomicU64::new(0));
         let latency_clone = current_latency_micros.clone();
@@ -185,16 +205,16 @@ impl Stream {
             .map_err(|_| BuildStreamError::StreamConfigNotSupported)?;
 
         let callback = move |buf: &[u8]| {
-            let now = SystemTime::now().duration_since(epoch).unwrap_or_default();
+            let elapsed = std::time::Instant::now().saturating_duration_since(start);
             let latency = latency_clone.load(atomic::Ordering::Relaxed);
-            let capture_time = now
+            let capture_time = elapsed
                 .checked_sub(time::Duration::from_micros(latency))
                 .unwrap_or_default();
 
             let timestamp = InputStreamTimestamp {
                 callback: StreamInstant {
-                    secs: now.as_secs() as i64,
-                    nanos: now.subsec_nanos(),
+                    secs: elapsed.as_secs() as i64,
+                    nanos: elapsed.subsec_nanos(),
                 },
                 capture: StreamInstant {
                     secs: capture_time.as_secs() as i64,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -484,10 +484,11 @@ pub struct Data {
 /// | Host | Source |
 /// | ---- | ------ |
 /// | alsa | `snd_pcm_status_get_htstamp` |
-/// | coreaudio | `mach_absolute_time` |
-/// | wasapi | `QueryPerformanceCounter` |
 /// | asio | `timeGetTime` |
+/// | coreaudio | `mach_absolute_time` |
 /// | emscripten | `AudioContext.getOutputTimestamp` |
+/// | pulseaudio | `std::time::Instant` |
+/// | wasapi | `QueryPerformanceCounter` |
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 pub struct StreamInstant {
     secs: i64,


### PR DESCRIPTION
A few issues I spotted in the PulseAudio backend after it landed. @colinmarc, would you mind casting an eye over these since you know the code best?

First commit contains hot-path and correctness fixes:
- `U8` silence is `0x80`, not `0x00`
- `store_latency` had a sign bug: casting a negative `write_offset - read_offset` to `u64` wrapped around
- Record streams were reading `sink_usec` instead of `source_usec`
- Worker thread errors from `play_all()` were silently dropped
- Latency poll interval reduced from 100 ms to 5 ms

Second commit improves channel maps, buffer configuration, and timestamps:
- Channel map was mapping everything except stereo to `Mono`; now implements standard PA layouts for 1–8 channels, 7.1.2 and 7.1.4 Dolby Atmos for 10 and 12 channels, and sequential `Aux` positions as a fallback
- `make_buffer_attr` split into separate playback and record functions: playback uses a double-buffer (`target_length` = 2N, `minimum_request_length` = N) to guarantee N-frame callbacks; record uses `fragment_size` instead of the playback-only `target_length` field
- `adjust_latency` flag now set when `BufferSize::Fixed` is requested, so PulseAudio configures the hardware end-to-end to hit the target
- `SystemTime` replaced with `Instant` (monotonic, not affected by NTP); playback timestamps now interpolate latency between polls rather than using a stale value for up to 5 ms

