### PR TITLE
fix(pipewire): enumerate devices without port group

### DIFF
--- a/src/host/pipewire/device.rs
+++ b/src/host/pipewire/device.rs
@@ -3,9 +3,7 @@ use std::time::Duration;
 use std::{cell::RefCell, rc::Rc};
 
 use crate::host::pipewire::stream::{StreamCommand, StreamData, SUPPORTED_FORMATS};
-use crate::host::pipewire::utils::{
-    audio, clock, group, DEVICE_ICON_NAME, METADATA_NAME, PORT_GROUP,
-};
+use crate::host::pipewire::utils::{audio, clock, DEVICE_ICON_NAME, METADATA_NAME};
 use crate::{traits::DeviceTrait, DeviceDirection, SupportedStreamConfigRange};
 use crate::{ChannelCount, FrameCount, InterfaceType, SampleRate};
 
@@ -631,20 +629,12 @@ pub fn init_devices() -> Option<Vec<Device>> {
                                     return;
                                 }
                             };
-                            let Some(group) = props.get(PORT_GROUP) else {
-                                return;
-                            };
-                            let direction = match (group, role) {
-                                (group::PLAY_BACK, Role::Sink) => DeviceDirection::Duplex,
-                                (group::PLAY_BACK, Role::Source) => DeviceDirection::Output,
-                                (group::CAPTURE, _) => DeviceDirection::Input,
-                                (_, Role::Sink) => DeviceDirection::Output,
-                                (_, Role::Source) => DeviceDirection::Input,
-                                (_, Role::Duplex) => DeviceDirection::Duplex,
-                                // Bluetooth and other non-ALSA devices use generic port group
-                                // names like "stream.0" — derive direction from media.class
-                                (_, Role::StreamOutput) => DeviceDirection::Output,
-                                (_, Role::StreamInput) => DeviceDirection::Input,
+                            let direction = match role {
+                                Role::Sink => DeviceDirection::Duplex,
+                                Role::Source => DeviceDirection::Input,
+                                Role::Duplex => DeviceDirection::Duplex,
+                                Role::StreamOutput => DeviceDirection::Output,
+                                Role::StreamInput => DeviceDirection::Input,
                             };
                             let Some(object_serial) = props
                                 .get(*pw::keys::OBJECT_SERIAL)

--- a/src/host/pipewire/utils.rs
+++ b/src/host/pipewire/utils.rs
@@ -1,5 +1,4 @@
 pub const METADATA_NAME: &str = "metadata.name";
-pub const PORT_GROUP: &str = "port.group";
 
 // NOTE: the icon name contains bluetooth and etc, not icon-name, but icon_name
 // I have tried to get the information, and get
@@ -22,9 +21,4 @@ pub mod audio {
     pub const DUPLEX: &str = "Audio/Duplex";
     pub const STREAM_OUTPUT: &str = "Stream/Output/Audio";
     pub const STREAM_INPUT: &str = "Stream/Input/Audio";
-}
-
-pub mod group {
-    pub const PLAY_BACK: &str = "playback";
-    pub const CAPTURE: &str = "capture";
 }


### PR DESCRIPTION
Fixes #1133 