### PR TITLE
feat(alsa): implement device_by_id with PCM shorthand support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `BuildStreamError` for retryable device access errors (EBUSY, EAGAIN).
 - `StreamConfig` now implements `Copy`.
 - `StreamTrait::buffer_size()` to query the stream's current buffer size in frames per callback.
+- `device_by_id` is now dispatched to each backend's implementation, allowing to override it.
+- **ALSA**: `device_by_id` now accepts PCM shorthand names such as `hw:0,0` and `plughw:foo`.
 - **PipeWire**: New host for Linux and some BSDs using the PipeWire API.
 - **PulseAudio**: New host for Linux and some BSDs using the PulseAudio API.
 

--- a/src/host/alsa/mod.rs
+++ b/src/host/alsa/mod.rs
@@ -120,6 +120,13 @@ impl HostTrait for Host {
         self.enumerate_devices()
     }
 
+    fn device_by_id(&self, id: &crate::DeviceId) -> Option<Self::Device> {
+        let canonical_id = crate::DeviceId(id.0, canonical_pcm_id(&id.1));
+        self.devices()
+            .ok()?
+            .find(|d| d.id().ok().as_ref() == Some(&canonical_id))
+    }
+
     fn default_input_device(&self) -> Option<Self::Device> {
         Some(Device::default())
     }
@@ -1478,6 +1485,21 @@ fn set_sw_params_from_format(
     }
 
     Ok(period_samples)
+}
+
+fn canonical_pcm_id(pcm_id: &str) -> String {
+    if let Some((prefix, rest)) = pcm_id.split_once(':') {
+        let (card_str, device_str) = match rest.split_once(',') {
+            Some((c, d)) => (c.trim(), d.trim()),
+            None => (rest.trim(), "0"),
+        };
+        if !card_str.contains('=') {
+            if let Ok(device) = device_str.parse::<u32>() {
+                return format!("{prefix}:CARD={card_str},DEV={device}");
+            }
+        }
+    }
+    pcm_id.to_owned()
 }
 
 impl From<alsa::Error> for BackendSpecificError {

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -547,6 +547,17 @@ macro_rules! impl_platform_host {
                 }
             }
 
+            fn device_by_id(&self, id: &crate::DeviceId) -> Option<Self::Device> {
+                match self.0 {
+                    $(
+                        $(#[cfg($feat)])?
+                        HostInner::$HostVariant(ref h) => {
+                            h.device_by_id(id).map(DeviceInner::$HostVariant).map(Device::from)
+                        }
+                    )*
+                }
+            }
+
             fn default_input_device(&self) -> Option<Self::Device> {
                 match self.0 {
                     $(


### PR DESCRIPTION
Support "hw:0,0", "plughw:foo", etc. as PCM ID shorthands.