### PR TITLE
fix(alsa): timestamp overflows on 32-bit platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **ALSA**: Fix spurious timestamp errors during stream startup.
 - **ALSA**: Fix spurious timeout errors during polling.
 - **ALSA**: Fix rare panics when dropping the stream is interrupted.
+- **ALSA**: Fix timestamp overflows on 32-bit platforms.
 - **ASIO**: Fix enumeration returning only the first device when using `collect`.
 - **ASIO**: Fix device enumeration and stream creation failing when called from spawned threads.
 - **CoreAudio**: Fix undefined behaviour and silent failure in loopback device creation.

--- a/src/host/alsa/mod.rs
+++ b/src/host/alsa/mod.rs
@@ -1176,12 +1176,9 @@ fn stream_timestamp_fallback(
 // Adapted from `timestamp2ns` here:
 // https://fossies.org/linux/alsa-lib/test/audio_time.c
 #[inline]
+#[allow(clippy::unnecessary_cast)]
 fn timespec_to_nanos(ts: libc::timespec) -> i64 {
-    let nanos = ts.tv_sec * 1_000_000_000 + ts.tv_nsec;
-    #[cfg(target_pointer_width = "64")]
-    return nanos;
-    #[cfg(not(target_pointer_width = "64"))]
-    return nanos.into();
+    ts.tv_sec as i64 * 1_000_000_000 + ts.tv_nsec as i64
 }
 
 // Adapted from `timediff` here:


### PR DESCRIPTION
Cast to `i64` before multiplying: on 32-bit platforms `tv_sec` is `i32`, and `i32 * 1_000_000_000` overflows for any realistic timestamp before widening.

Partly fixes #1134