### PR TITLE
fix(pulseaudio): correctness fixes

### DIFF
--- a/src/host/pulseaudio/mod.rs
+++ b/src/host/pulseaudio/mod.rs
@@ -355,7 +355,7 @@ impl DeviceTrait for Device {
         let client = client.clone();
         if let Some(dur) = timeout {
             // Run stream creation on a thread so we can bound the wait. If the PulseAudio server
-            // is hung, `create_playback_stream`  would blockforever.
+            // is hung, `create_playback_stream` would block forever.
             let (tx, rx) = std::sync::mpsc::channel();
             std::thread::spawn(move || {
                 tx.send(stream::Stream::new_playback(

--- a/src/host/pulseaudio/mod.rs
+++ b/src/host/pulseaudio/mod.rs
@@ -1,5 +1,6 @@
 use futures::executor::block_on;
 use pulseaudio::protocol;
+use std::time::Duration;
 
 mod stream;
 
@@ -248,7 +249,7 @@ impl DeviceTrait for Device {
         sample_format: SampleFormat,
         data_callback: D,
         error_callback: E,
-        _timeout: Option<std::time::Duration>,
+        timeout: Option<Duration>,
     ) -> Result<Self::Stream, BuildStreamError>
     where
         D: FnMut(&Data, &InputCallbackInfo) + Send + 'static,
@@ -283,7 +284,31 @@ impl DeviceTrait for Device {
             ..Default::default()
         };
 
-        stream::Stream::new_record(client.clone(), params, data_callback, error_callback)
+        let client = client.clone();
+        if let Some(dur) = timeout {
+            // Run stream creation on a thread so we can bound the wait. If the PulseAudio server
+            // is hung, `create_record_stream` would block forever.
+            let (tx, rx) = std::sync::mpsc::channel();
+            std::thread::spawn(move || {
+                tx.send(stream::Stream::new_record(
+                    client,
+                    params,
+                    data_callback,
+                    error_callback,
+                ))
+                .ok();
+            });
+            match rx.recv_timeout(dur) {
+                Ok(result) => result,
+                Err(_) => Err(BuildStreamError::BackendSpecific {
+                    err: BackendSpecificError {
+                        description: "timed out waiting for PulseAudio server".into(),
+                    },
+                }),
+            }
+        } else {
+            stream::Stream::new_record(client, params, data_callback, error_callback)
+        }
     }
 
     fn build_output_stream_raw<D, E>(
@@ -292,7 +317,7 @@ impl DeviceTrait for Device {
         sample_format: SampleFormat,
         data_callback: D,
         error_callback: E,
-        _timeout: Option<std::time::Duration>,
+        timeout: Option<Duration>,
     ) -> Result<Self::Stream, BuildStreamError>
     where
         D: FnMut(&mut Data, &OutputCallbackInfo) + Send + 'static,
@@ -327,7 +352,31 @@ impl DeviceTrait for Device {
             ..Default::default()
         };
 
-        stream::Stream::new_playback(client.clone(), params, data_callback, error_callback)
+        let client = client.clone();
+        if let Some(dur) = timeout {
+            // Run stream creation on a thread so we can bound the wait. If the PulseAudio server
+            // is hung, `create_playback_stream`  would blockforever.
+            let (tx, rx) = std::sync::mpsc::channel();
+            std::thread::spawn(move || {
+                tx.send(stream::Stream::new_playback(
+                    client,
+                    params,
+                    data_callback,
+                    error_callback,
+                ))
+                .ok();
+            });
+            match rx.recv_timeout(dur) {
+                Ok(result) => result,
+                Err(_) => Err(BuildStreamError::BackendSpecific {
+                    err: BackendSpecificError {
+                        description: "timed out waiting for PulseAudio server".into(),
+                    },
+                }),
+            }
+        } else {
+            stream::Stream::new_playback(client, params, data_callback, error_callback)
+        }
     }
 
     fn description(&self) -> Result<DeviceDescription, DeviceNameError> {

--- a/src/host/pulseaudio/mod.rs
+++ b/src/host/pulseaudio/mod.rs
@@ -14,6 +14,8 @@ use crate::{
     SupportedStreamConfigRange, SupportedStreamConfigsError,
 };
 
+const MIN_SAMPLE_RATE: SampleRate = 8000;
+
 const PULSE_FORMATS: &[SampleFormat] = &[
     SampleFormat::U8,
     SampleFormat::I16,
@@ -160,10 +162,10 @@ fn supported_config_ranges() -> Vec<SupportedStreamConfigRange> {
             let max_frames = (protocol::MAX_MEMBLOCKQ_LENGTH / bytes_per_frame) as FrameCount;
             ranges.push(SupportedStreamConfigRange {
                 channels: channel_count as _,
-                min_sample_rate: 1,
+                min_sample_rate: MIN_SAMPLE_RATE,
                 max_sample_rate: protocol::sample_spec::MAX_RATE,
                 buffer_size: SupportedBufferSize::Range {
-                    min: 0,
+                    min: 1,
                     max: max_frames,
                 },
                 sample_format: *format,
@@ -187,7 +189,7 @@ fn default_config_from_spec(
         channels: channel_map.num_channels() as _,
         sample_rate: sample_spec.sample_rate,
         buffer_size: SupportedBufferSize::Range {
-            min: 0,
+            min: 1,
             max: max_frames,
         },
         sample_format,

--- a/src/host/pulseaudio/mod.rs
+++ b/src/host/pulseaudio/mod.rs
@@ -11,8 +11,8 @@ use crate::{
     BackendSpecificError, BuildStreamError, Data, DefaultStreamConfigError, DeviceDescription,
     DeviceDescriptionBuilder, DeviceDirection, DeviceId, DeviceIdError, DeviceNameError,
     DevicesError, FrameCount, HostId, HostUnavailable, InputCallbackInfo, OutputCallbackInfo,
-    SampleFormat, StreamConfig, StreamError, SupportedBufferSize, SupportedStreamConfig,
-    SupportedStreamConfigRange, SupportedStreamConfigsError,
+    SampleFormat, SampleRate, StreamConfig, StreamError, SupportedBufferSize,
+    SupportedStreamConfig, SupportedStreamConfigRange, SupportedStreamConfigsError,
 };
 
 const MIN_SAMPLE_RATE: SampleRate = 8000;

--- a/src/host/pulseaudio/stream.rs
+++ b/src/host/pulseaudio/stream.rs
@@ -18,7 +18,7 @@ use crate::{
 const LATENCY_MAX_INTERVAL: Duration = Duration::from_millis(100);
 
 // Coordinates the latency polling thread
-struct LatencyHandle {
+pub(crate) struct LatencyHandle {
     // Cancellation on drop
     cancel: Arc<AtomicBool>,
     // Event-driven early wakeup from callbacks and play/pause
@@ -36,7 +36,7 @@ impl LatencyHandle {
     // Trigger an early poll
     fn notify(&self) {
         let (lock, cvar) = &*self.update;
-        *lock.lock().unwrap() = true;
+        *lock.lock().unwrap_or_else(|e| e.into_inner()) = true;
         cvar.notify_one();
     }
 
@@ -190,7 +190,7 @@ impl Stream {
 
             // Notify the latency thread that audio was written, so it updates timing info.
             let (lock, cvar) = &*update_callback;
-            *lock.lock().unwrap() = true;
+            *lock.lock().unwrap_or_else(|e| e.into_inner()) = true;
             cvar.notify_one();
 
             // We always consider the full buffer filled, because cpal's
@@ -301,7 +301,7 @@ impl Stream {
             let poll_usec = poll_clone.load(atomic::Ordering::Relaxed);
             // Cap to LATENCY_MAX_INTERVAL: the linear-fill assumption is only valid for that
             // window, and a stale poll_usec (e.g. after cork/uncork where timing_info blocks)
-            // would otherwise saturate latency to zero.
+            // would otherwise keep inflating the interpolated latency up to the cap.
             let elapsed_since_poll = elapsed_usec
                 .saturating_sub(poll_usec)
                 .min(LATENCY_MAX_INTERVAL.as_micros() as u64);
@@ -330,7 +330,7 @@ impl Stream {
 
             // Notify the latency thread that audio was read, so it updates timing info.
             let (lock, cvar) = &*update_callback;
-            *lock.lock().unwrap() = true;
+            *lock.lock().unwrap_or_else(|e| e.into_inner()) = true;
             cvar.notify_one();
         };
 

--- a/src/host/pulseaudio/stream.rs
+++ b/src/host/pulseaudio/stream.rs
@@ -1,7 +1,7 @@
 use std::{
     sync::{
         atomic::{self, AtomicBool, AtomicU64},
-        Arc, Mutex,
+        Arc, Condvar, Mutex,
     },
     time::{Duration, Instant},
 };
@@ -15,34 +15,64 @@ use crate::{
     PlayStreamError, SampleFormat, StreamError, StreamInstant,
 };
 
-const LATENCY_POLL_INTERVAL: Duration = Duration::from_millis(5);
+const LATENCY_MAX_INTERVAL: Duration = Duration::from_millis(100);
+
+// Coordinates the latency polling thread
+struct LatencyHandle {
+    // Cancellation on drop
+    cancel: Arc<AtomicBool>,
+    // Event-driven early wakeup from callbacks and play/pause
+    update: Arc<(Mutex<bool>, Condvar)>,
+}
+
+impl LatencyHandle {
+    fn new() -> Self {
+        Self {
+            cancel: Arc::new(AtomicBool::new(false)),
+            update: Arc::new((Mutex::new(false), Condvar::new())),
+        }
+    }
+
+    // Trigger an early poll
+    fn notify(&self) {
+        let (lock, cvar) = &*self.update;
+        *lock.lock().unwrap() = true;
+        cvar.notify_one();
+    }
+
+    // Signal cancellation and wake the thread immediately
+    fn cancel(&self) {
+        self.cancel.store(true, atomic::Ordering::Relaxed);
+        self.notify();
+    }
+}
 
 pub enum Stream {
-    Playback(pulseaudio::PlaybackStream, Instant, Arc<AtomicBool>),
-    Record(pulseaudio::RecordStream, Instant, Arc<AtomicBool>),
+    Playback(pulseaudio::PlaybackStream, Instant, LatencyHandle),
+    Record(pulseaudio::RecordStream, Instant, LatencyHandle),
 }
 
 impl Drop for Stream {
     fn drop(&mut self) {
-        let cancel = match self {
-            Stream::Playback(_, _, cancel) | Stream::Record(_, _, cancel) => cancel,
-        };
-        cancel.store(true, atomic::Ordering::Relaxed);
+        match self {
+            Stream::Playback(_, _, handle) | Stream::Record(_, _, handle) => handle.cancel(),
+        }
     }
 }
 
 impl StreamTrait for Stream {
     fn play(&self) -> Result<(), PlayStreamError> {
         match self {
-            Stream::Playback(stream, _, _) => {
+            Stream::Playback(stream, _, handle) => {
                 block_on(stream.uncork()).map_err(Into::<BackendSpecificError>::into)?;
+                handle.notify();
             }
-            Stream::Record(stream, _, _) => {
+            Stream::Record(stream, _, handle) => {
                 block_on(stream.uncork()).map_err(Into::<BackendSpecificError>::into)?;
                 block_on(stream.started()).map_err(Into::<BackendSpecificError>::into)?;
+                handle.notify();
             }
-        };
-
+        }
         Ok(())
     }
 
@@ -51,8 +81,10 @@ impl StreamTrait for Stream {
             Stream::Playback(stream, _, _) => block_on(stream.cork()),
             Stream::Record(stream, _, _) => block_on(stream.cork()),
         };
-
         res.map_err(Into::<BackendSpecificError>::into)?;
+        match self {
+            Stream::Playback(_, _, handle) | Stream::Record(_, _, handle) => handle.notify(),
+        }
         Ok(())
     }
 
@@ -113,6 +145,9 @@ impl Stream {
             0u8
         };
 
+        let handle = LatencyHandle::new();
+        let update_callback = handle.update.clone();
+
         // Wrap the write callback to match the pulseaudio signature.
         let callback = move |buf: &mut [u8]| {
             let elapsed = Instant::now().saturating_duration_since(start);
@@ -123,12 +158,12 @@ impl Stream {
             // rate, so the latency decreases linearly between polls.
             let stored_latency = latency_clone.load(atomic::Ordering::Relaxed);
             let poll_usec = poll_clone.load(atomic::Ordering::Relaxed);
-            // Cap to one poll interval: the linear-drain assumption is only valid
-            // for that window, and a stale poll_usec (e.g. after cork/uncork where
-            // timing_info blocks) would otherwise saturate latency to zero.
+            // Cap to LATENCY_MAX_INTERVAL: the linear-drain assumption is only valid for that
+            // window, and a stale poll_usec (e.g. after cork/uncork where timing_info blocks)
+            // would otherwise saturate latency to zero.
             let elapsed_since_poll = elapsed_usec
                 .saturating_sub(poll_usec)
-                .min(LATENCY_POLL_INTERVAL.as_micros() as u64);
+                .min(LATENCY_MAX_INTERVAL.as_micros() as u64);
             let latency = stored_latency.saturating_sub(elapsed_since_poll);
 
             let playback_time = elapsed + Duration::from_micros(latency);
@@ -152,6 +187,11 @@ impl Stream {
             let mut data = unsafe { Data::from_parts(buf.as_mut_ptr().cast(), n_samples, format) };
 
             data_callback(&mut data, &OutputCallbackInfo { timestamp });
+
+            // Notify the latency thread that audio was written, so it updates timing info.
+            let (lock, cvar) = &*update_callback;
+            *lock.lock().unwrap() = true;
+            cvar.notify_one();
 
             // We always consider the full buffer filled, because cpal's
             // user-facing API doesn't allow short writes.
@@ -178,13 +218,13 @@ impl Stream {
         });
 
         // Spawn a thread to monitor the stream's latency in a loop.
-        let cancel = Arc::new(AtomicBool::new(false));
-        let cancel_clone = cancel.clone();
+        let cancel_thread = handle.cancel.clone();
+        let update_thread = handle.update.clone();
         let stream_clone = stream.clone();
         let latency_clone = current_latency_micros.clone();
         let poll_clone = last_poll_micros.clone();
         std::thread::spawn(move || loop {
-            if cancel_clone.load(atomic::Ordering::Relaxed) {
+            if cancel_thread.load(atomic::Ordering::Relaxed) {
                 break;
             }
 
@@ -210,10 +250,16 @@ impl Stream {
                 timing_info.read_offset,
             );
 
-            std::thread::sleep(LATENCY_POLL_INTERVAL);
+            // Wait until woken by a write/play/pause/drop event or until LATENCY_MAX_INTERVAL.
+            let (lock, cvar) = &*update_thread;
+            let guard = lock.lock().unwrap();
+            let (mut guard, _) = cvar
+                .wait_timeout_while(guard, LATENCY_MAX_INTERVAL, |notified| !*notified)
+                .unwrap();
+            *guard = false;
         });
 
-        Ok(Self::Playback(stream, start, cancel))
+        Ok(Self::Playback(stream, start, handle))
     }
 
     pub fn new_record<D, E>(
@@ -236,6 +282,9 @@ impl Stream {
             .format
             .try_into()
             .map_err(|_| BuildStreamError::StreamConfigNotSupported)?;
+
+        let handle = LatencyHandle::new();
+        let update_callback = handle.update.clone();
 
         let callback = move |buf: &[u8]| {
             let elapsed = Instant::now().saturating_duration_since(start);
@@ -260,18 +309,23 @@ impl Stream {
             let data = unsafe { Data::from_parts(buf.as_ptr() as *mut _, n_samples, format) };
 
             data_callback(&data, &InputCallbackInfo { timestamp });
+
+            // Notify the latency thread that audio was read, so it updates timing info.
+            let (lock, cvar) = &*update_callback;
+            *lock.lock().unwrap() = true;
+            cvar.notify_one();
         };
 
         let stream = block_on(client.create_record_stream(params, callback))
             .map_err(Into::<BackendSpecificError>::into)?;
 
         // Spawn a thread to monitor the stream's latency in a loop.
-        let cancel = Arc::new(AtomicBool::new(false));
-        let cancel_clone = cancel.clone();
+        let cancel_thread = handle.cancel.clone();
+        let update_thread = handle.update.clone();
         let stream_clone = stream.clone();
         let latency_clone = current_latency_micros.clone();
         std::thread::spawn(move || loop {
-            if cancel_clone.load(atomic::Ordering::Relaxed) {
+            if cancel_thread.load(atomic::Ordering::Relaxed) {
                 break;
             }
 
@@ -293,10 +347,16 @@ impl Stream {
                 timing_info.read_offset,
             );
 
-            std::thread::sleep(LATENCY_POLL_INTERVAL);
+            // Wait until woken by a read/play/pause/drop event or until
+            let (lock, cvar) = &*update_thread;
+            let guard = lock.lock().unwrap();
+            let (mut guard, _) = cvar
+                .wait_timeout_while(guard, LATENCY_MAX_INTERVAL, |notified| !*notified)
+                .unwrap();
+            *guard = false;
         });
 
-        Ok(Self::Record(stream, start, cancel))
+        Ok(Self::Record(stream, start, handle))
     }
 }
 

--- a/src/host/pulseaudio/stream.rs
+++ b/src/host/pulseaudio/stream.rs
@@ -275,7 +275,11 @@ impl Stream {
         let start = Instant::now();
 
         let current_latency_micros = Arc::new(AtomicU64::new(0));
+        // Microseconds since stream creation at the time of the last latency poll, used
+        // to interpolate the latency between polls.
+        let last_poll_micros = Arc::new(AtomicU64::new(0));
         let latency_clone = current_latency_micros.clone();
+        let poll_clone = last_poll_micros.clone();
         let sample_spec = params.sample_spec;
 
         let format: SampleFormat = sample_spec
@@ -288,7 +292,21 @@ impl Stream {
 
         let callback = move |buf: &[u8]| {
             let elapsed = Instant::now().saturating_duration_since(start);
-            let latency = latency_clone.load(atomic::Ordering::Relaxed);
+            let elapsed_usec = elapsed.as_micros() as u64;
+
+            // Interpolate the latency based on elapsed time since the last poll: as audio records,
+            // the ADC fills the buffer at a constant rate, so the latency increases linearly
+            // between polls.
+            let stored_latency = latency_clone.load(atomic::Ordering::Relaxed);
+            let poll_usec = poll_clone.load(atomic::Ordering::Relaxed);
+            // Cap to LATENCY_MAX_INTERVAL: the linear-fill assumption is only valid for that
+            // window, and a stale poll_usec (e.g. after cork/uncork where timing_info blocks)
+            // would otherwise saturate latency to zero.
+            let elapsed_since_poll = elapsed_usec
+                .saturating_sub(poll_usec)
+                .min(LATENCY_MAX_INTERVAL.as_micros() as u64);
+            let latency = stored_latency.saturating_add(elapsed_since_poll);
+
             let capture_time = elapsed
                 .checked_sub(Duration::from_micros(latency))
                 .unwrap_or_default();
@@ -324,6 +342,7 @@ impl Stream {
         let update_thread = handle.update.clone();
         let stream_clone = stream.clone();
         let latency_clone = current_latency_micros.clone();
+        let poll_clone = last_poll_micros.clone();
         std::thread::spawn(move || loop {
             if cancel_thread.load(atomic::Ordering::Relaxed) {
                 break;
@@ -339,6 +358,10 @@ impl Stream {
                 }
             };
 
+            let poll_since_epoch =
+                Instant::now().saturating_duration_since(start).as_micros() as u64;
+            poll_clone.store(poll_since_epoch, atomic::Ordering::Relaxed);
+
             store_latency(
                 &latency_clone,
                 sample_spec,
@@ -347,7 +370,7 @@ impl Stream {
                 timing_info.read_offset,
             );
 
-            // Wait until woken by a read/play/pause/drop event or until
+            // Wait until woken by a read/play/pause/drop event or until LATENCY_MAX_INTERVAL.
             let (lock, cvar) = &*update_thread;
             let guard = lock.lock().unwrap();
             let (mut guard, _) = cvar

--- a/src/host/pulseaudio/stream.rs
+++ b/src/host/pulseaudio/stream.rs
@@ -1,6 +1,6 @@
 use std::{
     sync::{
-        atomic::{self, AtomicU64},
+        atomic::{self, AtomicBool, AtomicU64},
         Arc, Mutex,
     },
     time::{Duration, Instant},
@@ -18,17 +18,26 @@ use crate::{
 const LATENCY_POLL_INTERVAL: Duration = Duration::from_millis(5);
 
 pub enum Stream {
-    Playback(pulseaudio::PlaybackStream, Instant),
-    Record(pulseaudio::RecordStream, Instant),
+    Playback(pulseaudio::PlaybackStream, Instant, Arc<AtomicBool>),
+    Record(pulseaudio::RecordStream, Instant, Arc<AtomicBool>),
+}
+
+impl Drop for Stream {
+    fn drop(&mut self) {
+        let cancel = match self {
+            Stream::Playback(_, _, cancel) | Stream::Record(_, _, cancel) => cancel,
+        };
+        cancel.store(true, atomic::Ordering::Relaxed);
+    }
 }
 
 impl StreamTrait for Stream {
     fn play(&self) -> Result<(), PlayStreamError> {
         match self {
-            Stream::Playback(stream, _) => {
+            Stream::Playback(stream, _, _) => {
                 block_on(stream.uncork()).map_err(Into::<BackendSpecificError>::into)?;
             }
-            Stream::Record(stream, _) => {
+            Stream::Record(stream, _, _) => {
                 block_on(stream.uncork()).map_err(Into::<BackendSpecificError>::into)?;
                 block_on(stream.started()).map_err(Into::<BackendSpecificError>::into)?;
             }
@@ -39,8 +48,8 @@ impl StreamTrait for Stream {
 
     fn pause(&self) -> Result<(), crate::PauseStreamError> {
         let res = match self {
-            Stream::Playback(stream, _) => block_on(stream.cork()),
-            Stream::Record(stream, _) => block_on(stream.cork()),
+            Stream::Playback(stream, _, _) => block_on(stream.cork()),
+            Stream::Record(stream, _, _) => block_on(stream.cork()),
         };
 
         res.map_err(Into::<BackendSpecificError>::into)?;
@@ -49,7 +58,7 @@ impl StreamTrait for Stream {
 
     fn now(&self) -> crate::StreamInstant {
         let start = match self {
-            Stream::Playback(_, start) | Stream::Record(_, start) => *start,
+            Stream::Playback(_, start, _) | Stream::Record(_, start, _) => *start,
         };
         let elapsed = start.elapsed();
         StreamInstant::new(elapsed.as_secs(), elapsed.subsec_nanos())
@@ -57,11 +66,11 @@ impl StreamTrait for Stream {
 
     fn buffer_size(&self) -> Result<FrameCount, crate::StreamError> {
         let (spec, bytes) = match self {
-            Stream::Playback(s, _) => (
+            Stream::Playback(s, _, _) => (
                 s.sample_spec(),
                 s.buffer_attr().minimum_request_length as usize,
             ),
-            Stream::Record(s, _) => (s.sample_spec(), s.buffer_attr().fragment_size as usize),
+            Stream::Record(s, _, _) => (s.sample_spec(), s.buffer_attr().fragment_size as usize),
         };
         let frame_size = spec.channels as usize * spec.format.bytes_per_sample();
         Ok((bytes / frame_size) as _)
@@ -168,12 +177,17 @@ impl Stream {
             }
         });
 
-        // Spawn a thread to monitor the stream's latency in a loop. It will
-        // exit automatically when the stream ends.
+        // Spawn a thread to monitor the stream's latency in a loop.
+        let cancel = Arc::new(AtomicBool::new(false));
+        let cancel_clone = cancel.clone();
         let stream_clone = stream.clone();
         let latency_clone = current_latency_micros.clone();
         let poll_clone = last_poll_micros.clone();
         std::thread::spawn(move || loop {
+            if cancel_clone.load(atomic::Ordering::Relaxed) {
+                break;
+            }
+
             let timing_info = match block_on(stream_clone.timing_info()) {
                 Ok(timing_info) => timing_info,
                 Err(e) => {
@@ -199,7 +213,7 @@ impl Stream {
             std::thread::sleep(LATENCY_POLL_INTERVAL);
         });
 
-        Ok(Self::Playback(stream, start))
+        Ok(Self::Playback(stream, start, cancel))
     }
 
     pub fn new_record<D, E>(
@@ -251,11 +265,16 @@ impl Stream {
         let stream = block_on(client.create_record_stream(params, callback))
             .map_err(Into::<BackendSpecificError>::into)?;
 
-        // Spawn a thread to monitor the stream's latency in a loop. It will
-        // exit automatically when the stream ends.
+        // Spawn a thread to monitor the stream's latency in a loop.
+        let cancel = Arc::new(AtomicBool::new(false));
+        let cancel_clone = cancel.clone();
         let stream_clone = stream.clone();
         let latency_clone = current_latency_micros.clone();
         std::thread::spawn(move || loop {
+            if cancel_clone.load(atomic::Ordering::Relaxed) {
+                break;
+            }
+
             let timing_info = match block_on(stream_clone.timing_info()) {
                 Ok(timing_info) => timing_info,
                 Err(e) => {
@@ -277,7 +296,7 @@ impl Stream {
             std::thread::sleep(LATENCY_POLL_INTERVAL);
         });
 
-        Ok(Self::Record(stream, start))
+        Ok(Self::Record(stream, start, cancel))
     }
 }
 

--- a/src/host/pulseaudio/stream.rs
+++ b/src/host/pulseaudio/stream.rs
@@ -18,7 +18,7 @@ use crate::{
 const LATENCY_MAX_INTERVAL: Duration = Duration::from_millis(100);
 
 // Coordinates the latency polling thread
-pub(crate) struct LatencyHandle {
+struct LatencyHandle {
     // Cancellation on drop
     cancel: Arc<AtomicBool>,
     // Event-driven early wakeup from callbacks and play/pause
@@ -47,27 +47,31 @@ impl LatencyHandle {
     }
 }
 
-pub enum Stream {
+enum StreamInner {
     Playback(pulseaudio::PlaybackStream, Instant, LatencyHandle),
     Record(pulseaudio::RecordStream, Instant, LatencyHandle),
 }
 
+pub struct Stream(StreamInner);
+
 impl Drop for Stream {
     fn drop(&mut self) {
-        match self {
-            Stream::Playback(_, _, handle) | Stream::Record(_, _, handle) => handle.cancel(),
+        match &mut self.0 {
+            StreamInner::Playback(_, _, handle) | StreamInner::Record(_, _, handle) => {
+                handle.cancel()
+            }
         }
     }
 }
 
 impl StreamTrait for Stream {
     fn play(&self) -> Result<(), PlayStreamError> {
-        match self {
-            Stream::Playback(stream, _, handle) => {
+        match &self.0 {
+            StreamInner::Playback(stream, _, handle) => {
                 block_on(stream.uncork()).map_err(Into::<BackendSpecificError>::into)?;
                 handle.notify();
             }
-            Stream::Record(stream, _, handle) => {
+            StreamInner::Record(stream, _, handle) => {
                 block_on(stream.uncork()).map_err(Into::<BackendSpecificError>::into)?;
                 block_on(stream.started()).map_err(Into::<BackendSpecificError>::into)?;
                 handle.notify();
@@ -77,32 +81,36 @@ impl StreamTrait for Stream {
     }
 
     fn pause(&self) -> Result<(), crate::PauseStreamError> {
-        let res = match self {
-            Stream::Playback(stream, _, _) => block_on(stream.cork()),
-            Stream::Record(stream, _, _) => block_on(stream.cork()),
+        let res = match &self.0 {
+            StreamInner::Playback(stream, _, _) => block_on(stream.cork()),
+            StreamInner::Record(stream, _, _) => block_on(stream.cork()),
         };
         res.map_err(Into::<BackendSpecificError>::into)?;
-        match self {
-            Stream::Playback(_, _, handle) | Stream::Record(_, _, handle) => handle.notify(),
+        match &self.0 {
+            StreamInner::Playback(_, _, handle) | StreamInner::Record(_, _, handle) => {
+                handle.notify()
+            }
         }
         Ok(())
     }
 
     fn now(&self) -> crate::StreamInstant {
-        let start = match self {
-            Stream::Playback(_, start, _) | Stream::Record(_, start, _) => *start,
+        let start = match &self.0 {
+            StreamInner::Playback(_, start, _) | StreamInner::Record(_, start, _) => *start,
         };
         let elapsed = start.elapsed();
         StreamInstant::new(elapsed.as_secs(), elapsed.subsec_nanos())
     }
 
     fn buffer_size(&self) -> Result<FrameCount, crate::StreamError> {
-        let (spec, bytes) = match self {
-            Stream::Playback(s, _, _) => (
+        let (spec, bytes) = match &self.0 {
+            StreamInner::Playback(s, _, _) => (
                 s.sample_spec(),
                 s.buffer_attr().minimum_request_length as usize,
             ),
-            Stream::Record(s, _, _) => (s.sample_spec(), s.buffer_attr().fragment_size as usize),
+            StreamInner::Record(s, _, _) => {
+                (s.sample_spec(), s.buffer_attr().fragment_size as usize)
+            }
         };
         let frame_size = spec.channels as usize * spec.format.bytes_per_sample();
         Ok((bytes / frame_size) as _)
@@ -259,7 +267,7 @@ impl Stream {
             *guard = false;
         });
 
-        Ok(Self::Playback(stream, start, handle))
+        Ok(Self(StreamInner::Playback(stream, start, handle)))
     }
 
     pub fn new_record<D, E>(
@@ -379,7 +387,7 @@ impl Stream {
             *guard = false;
         });
 
-        Ok(Self::Record(stream, start, handle))
+        Ok(Self(StreamInner::Record(stream, start, handle)))
     }
 }
 


### PR DESCRIPTION
- Fixes a resource leak where the latency thread would keep running even when the stream was torn down.
- Optimizes the latency loop to poll every 100 ms, or earlier as notified by write/read/play/pause events.
- Fixes minimum sample rate (8000) and buffer size (1).
- Adds timeout handling to stream creation.