### PR TITLE
WASAPI: Prefer "friendly name" in device description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Linux/BSD**: Default host in order from first to last available now is: PipeWire, PulseAudio,
   ALSA.
 - **WASAPI**: Timestamps now include hardware pipeline latency.
+- **WASAPI**: `FriendlyName` is now preferred as device name over `DeviceDesc`.
 - **WebAudio**: Bump MSRV to 1.85.
 - **WebAudio**: Timestamps now include base and output latency.
 - **WebAudio**: Initial buffer scheduling offset now scales with buffer duration.

--- a/src/host/wasapi/device.rs
+++ b/src/host/wasapi/device.rs
@@ -372,14 +372,14 @@ impl Device {
             );
 
             // Prefer FriendlyName for name (e.g., "Speakers (XYZ Audio Adapter)"), fall back to DeviceDesc
-            let name = friendly_name
-                .clone()
-                .or(device_desc.clone())
-                .ok_or_else(|| DeviceNameError::BackendSpecific {
-                    err: BackendSpecificError {
-                        description: "failed to retrieve device name".to_string(),
-                    },
-                })?;
+            let name =
+                friendly_name
+                    .or(device_desc)
+                    .ok_or_else(|| DeviceNameError::BackendSpecific {
+                        err: BackendSpecificError {
+                            description: "failed to retrieve device name".to_string(),
+                        },
+                    })?;
 
             // Get direction from data flow (eCapture = Input, eRender = Output)
             let direction = self.data_flow().into();

--- a/src/host/wasapi/device.rs
+++ b/src/host/wasapi/device.rs
@@ -371,10 +371,10 @@ impl Device {
                 &PKEY_AUDIOENDPOINT_JACKSUBTYPE as *const _ as *const _,
             );
 
-            // Prefer DeviceDesc for name, fall back to FriendlyName
-            let name = device_desc
+            // Prefer FriendlyName for name (e.g., "Speakers (XYZ Audio Adapter)"), fall back to DeviceDesc
+            let name = friendly_name
                 .clone()
-                .or(friendly_name.clone())
+                .or(device_desc.clone())
                 .ok_or_else(|| DeviceNameError::BackendSpecific {
                     err: BackendSpecificError {
                         description: "failed to retrieve device name".to_string(),
@@ -414,13 +414,6 @@ impl Device {
             // Add interface name to driver field if available
             if let Some(iface_name) = interface_name {
                 builder = builder.driver(iface_name);
-            }
-
-            // Add FriendlyName to extended if different from the name we used
-            if let Some(fname) = friendly_name {
-                if device_desc.is_some() && Some(&fname) != device_desc.as_ref() {
-                    builder = builder.add_extended_line(fname);
-                }
             }
 
             Ok(builder.build())


### PR DESCRIPTION
Fixes common issue where users have multiple devices named "Speakers". The friendly name is the same one as displayed in the OS output selection.

I opted to remove the extended line since it doesn't really add anything now.