### PR TITLE
fix(pipewire): Early pw_deinit() called cause Segfault

### DIFF
--- a/src/host/pipewire/stream.rs
+++ b/src/host/pipewire/stream.rs
@@ -36,7 +36,7 @@ impl PwInitGuard {
     pub(crate) fn new() -> Self {
         let mut count = PW_INIT_COUNT.lock().unwrap_or_else(|e| e.into_inner());
         if *count == 0 {
-            pw::init();
+            unsafe { pw::sys::pw_init(std::ptr::null_mut(), std::ptr::null_mut()) }
         }
         *count += 1;
         Self

--- a/src/host/pipewire/stream.rs
+++ b/src/host/pipewire/stream.rs
@@ -36,6 +36,7 @@ impl PwInitGuard {
     pub(crate) fn new() -> Self {
         let mut count = PW_INIT_COUNT.lock().unwrap_or_else(|e| e.into_inner());
         if *count == 0 {
+            // pw::init() uses a OnceCell, preventing re-init after deinit.
             unsafe { pw::sys::pw_init(std::ptr::null_mut(), std::ptr::null_mut()) }
         }
         *count += 1;


### PR DESCRIPTION
issue: https://github.com/RustAudio/cpal/issues/1160

The problem is that once we called deinit, we cannot use the safe pw::init() again, because in fact, the pw::init() is a OnceLock https://gitlab.freedesktop.org/pipewire/pipewire-rs/-/blob/main/pipewire/src/lib.rs?ref_type=heads#L180-184, so it will never be init again. The only way to init it the second time is to use the unsafe, since we have already managed the lifetime of pipewire in cpal, so maybe it is the right way here. Though I think we can do pw::init free when we want, and never deinit it, because it is quit useless, and because pipewire-rs is designed in this way, I think they also do not hope we to manage the lifetime ourself.

Anyway, this bug can be fixed with the unsafe init