### PR TITLE
feat(jack): respect user timeout when building stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,12 +55,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   rate change on macOS, and on iOS on route changes that require a stream rebuild.
 - **CoreAudio**: Stream error callback now receives `StreamError::DeviceNotAvailable` on iOS
   when media services are lost.
-- **CoreAudio**: User timeouts are now obeyed when building a stream.
+- **CoreAudio**: User timeouts are now respected when building a stream.
 - **JACK**: Timestamps now use the precise hardware deadline.
 - **JACK**: Buffer size change no longer fires an error callback; internal buffers are resized
   without error.
 - **JACK**: Server shutdown now fires `StreamError::DeviceNotAvailable`.
 - **JACK**: Default client name now includes the process PID.
+- **JACK**: User timeouts are now respected when building a stream.
 - **Linux/BSD**: Default host in order from first to last available now is: PipeWire, PulseAudio,
   ALSA.
 - **WASAPI**: Timestamps now include hardware pipeline latency.

--- a/src/host/jack/device.rs
+++ b/src/host/jack/device.rs
@@ -180,7 +180,7 @@ impl DeviceTrait for Device {
         sample_format: SampleFormat,
         data_callback: D,
         error_callback: E,
-        _timeout: Option<Duration>,
+        timeout: Option<Duration>,
     ) -> Result<Self::Stream, BuildStreamError>
     where
         D: FnMut(&Data, &InputCallbackInfo) + Send + 'static,
@@ -194,25 +194,47 @@ impl DeviceTrait for Device {
             return Err(BuildStreamError::StreamConfigNotSupported);
         }
 
-        // Create a fresh client to validate against live server state.
-        let client_options = super::get_client_options(self.start_server_automatically);
-        let client = super::get_client(&self.name, client_options)
-            .map_err(|err| BuildStreamError::BackendSpecific { err })?;
-        if conf.sample_rate != client.sample_rate() {
-            return Err(BuildStreamError::StreamConfigNotSupported);
-        }
-        if let crate::BufferSize::Fixed(size) = conf.buffer_size {
-            if size != client.buffer_size() {
+        let name = self.name.clone();
+        let start_server_automatically = self.start_server_automatically;
+        let connect_ports_automatically = self.connect_ports_automatically;
+
+        let build = move || -> Result<Stream, BuildStreamError> {
+            // Create a fresh client to validate against live server state.
+            let client_options = super::get_client_options(start_server_automatically);
+            let client = super::get_client(&name, client_options)
+                .map_err(|err| BuildStreamError::BackendSpecific { err })?;
+            if conf.sample_rate != client.sample_rate() {
                 return Err(BuildStreamError::StreamConfigNotSupported);
             }
-        }
-        let mut stream = Stream::new_input(client, conf.channels, data_callback, error_callback)?;
+            if let crate::BufferSize::Fixed(size) = conf.buffer_size {
+                if size != client.buffer_size() {
+                    return Err(BuildStreamError::StreamConfigNotSupported);
+                }
+            }
+            let mut stream =
+                Stream::new_input(client, conf.channels, data_callback, error_callback)?;
+            if connect_ports_automatically {
+                stream.connect_to_system_inputs();
+            }
+            Ok(stream)
+        };
 
-        if self.connect_ports_automatically {
-            stream.connect_to_system_inputs();
+        if let Some(dur) = timeout {
+            let (tx, rx) = std::sync::mpsc::channel();
+            std::thread::spawn(move || {
+                tx.send(build()).ok();
+            });
+            match rx.recv_timeout(dur) {
+                Ok(result) => result,
+                Err(_) => Err(BuildStreamError::BackendSpecific {
+                    err: BackendSpecificError {
+                        description: "timed out waiting for JACK server".into(),
+                    },
+                }),
+            }
+        } else {
+            build()
         }
-
-        Ok(stream)
     }
 
     fn build_output_stream_raw<D, E>(
@@ -221,7 +243,7 @@ impl DeviceTrait for Device {
         sample_format: SampleFormat,
         data_callback: D,
         error_callback: E,
-        _timeout: Option<Duration>,
+        timeout: Option<Duration>,
     ) -> Result<Self::Stream, BuildStreamError>
     where
         D: FnMut(&mut Data, &OutputCallbackInfo) + Send + 'static,
@@ -235,25 +257,47 @@ impl DeviceTrait for Device {
             return Err(BuildStreamError::StreamConfigNotSupported);
         }
 
-        // Create a fresh client to validate against live server state.
-        let client_options = super::get_client_options(self.start_server_automatically);
-        let client = super::get_client(&self.name, client_options)
-            .map_err(|err| BuildStreamError::BackendSpecific { err })?;
-        if conf.sample_rate != client.sample_rate() {
-            return Err(BuildStreamError::StreamConfigNotSupported);
-        }
-        if let crate::BufferSize::Fixed(size) = conf.buffer_size {
-            if size != client.buffer_size() {
+        let name = self.name.clone();
+        let start_server_automatically = self.start_server_automatically;
+        let connect_ports_automatically = self.connect_ports_automatically;
+
+        let build = move || -> Result<Stream, BuildStreamError> {
+            // Create a fresh client to validate against live server state.
+            let client_options = super::get_client_options(start_server_automatically);
+            let client = super::get_client(&name, client_options)
+                .map_err(|err| BuildStreamError::BackendSpecific { err })?;
+            if conf.sample_rate != client.sample_rate() {
                 return Err(BuildStreamError::StreamConfigNotSupported);
             }
-        }
-        let mut stream = Stream::new_output(client, conf.channels, data_callback, error_callback)?;
+            if let crate::BufferSize::Fixed(size) = conf.buffer_size {
+                if size != client.buffer_size() {
+                    return Err(BuildStreamError::StreamConfigNotSupported);
+                }
+            }
+            let mut stream =
+                Stream::new_output(client, conf.channels, data_callback, error_callback)?;
+            if connect_ports_automatically {
+                stream.connect_to_system_outputs();
+            }
+            Ok(stream)
+        };
 
-        if self.connect_ports_automatically {
-            stream.connect_to_system_outputs();
+        if let Some(dur) = timeout {
+            let (tx, rx) = std::sync::mpsc::channel();
+            std::thread::spawn(move || {
+                tx.send(build()).ok();
+            });
+            match rx.recv_timeout(dur) {
+                Ok(result) => result,
+                Err(_) => Err(BuildStreamError::BackendSpecific {
+                    err: BackendSpecificError {
+                        description: "timed out waiting for JACK server".into(),
+                    },
+                }),
+            }
+        } else {
+            build()
         }
-
-        Ok(stream)
     }
 }
 


### PR DESCRIPTION
Defensively, this could hang when `jackd` is stuck and mirrors PipeWire and PulseAudio behavior.