### PR TITLE
fix(webaudio): handle errors and prevent duplicate callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `BuildStreamError` for retryable device access errors (EBUSY, EAGAIN).
 - `StreamConfig` now implements `Copy`.
 - `StreamTrait::buffer_size()` to query the stream's current buffer size in frames per callback.
-- `HostTrait::device_by_id()` is now dispatched to each backend's implementation, allowing to 
-  override it.
+- `HostTrait::device_by_id()` is now dispatched to each backend's implementation, allowing
+  backends to override it.
 - `StreamTrait::now()` to query the current instant on the stream's clock.
 - **ALSA**: `device_by_id()` now accepts PCM shorthand names such as `hw:0,0` and `plughw:foo`.
 - **PipeWire**: New host for Linux and some BSDs using the PipeWire API.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `BuildStreamError` for retryable device access errors (EBUSY, EAGAIN).
 - `StreamConfig` now implements `Copy`.
 - `StreamTrait::buffer_size()` to query the stream's current buffer size in frames per callback.
-- `device_by_id` is now dispatched to each backend's implementation, allowing to override it.
+- `HostTrait::device_by_id()` is now dispatched to each backend's implementation, allowing to 
+  override it.
 - `StreamTrait::now()` to query the current instant on the stream's clock.
-- `StreamInstant` API changed and extended to mirror `std::time::Instant`/`Duration`. See
-  [UPGRADING.md](UPGRADING.md) for migration details.
-- **ALSA**: `device_by_id` now accepts PCM shorthand names such as `hw:0,0` and `plughw:foo`.
+- **ALSA**: `device_by_id()` now accepts PCM shorthand names such as `hw:0,0` and `plughw:foo`.
 - **PipeWire**: New host for Linux and some BSDs using the PipeWire API.
 - **PulseAudio**: New host for Linux and some BSDs using the PulseAudio API.
 
@@ -25,11 +24,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Public error enums are now marked `#[non_exhaustive]` to allow adding variants without
   SemVer-breaking changes.
-- `DeviceTrait::build_*_stream` now takes `StreamConfig` by value instead of `&StreamConfig`
-- `HostId::name` now returns a more human-friendly name instead of the raw backend identifier.
+- `DeviceTrait::build_*_stream()` now takes `StreamConfig` by value instead of `&StreamConfig`
+- `HostId::name()` now returns a more human-friendly name instead of the raw backend identifier.
+- `StreamInstant` API changed and extended to mirror `std::time::Instant`/`Duration`. See
+  [UPGRADING.md](UPGRADING.md) for migration details.
 - **AAudio**: Device names now include the device type suffix (e.g. "Speaker (Builtin Speaker)")
   for easier identification when enumerating devices.
-- **AAudio**: `supported_input_configs` and `supported_output_configs` now return an error for
+- **AAudio**: `supported_input_configs()` and `supported_output_configs()` now return an error for
   direction-mismatched devices (e.g. querying input configs on an output-only device) instead of
   silently returning an empty list.
 - **AAudio**: Bump MSRV to 1.85.
@@ -86,7 +87,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **ALSA**: Fix spurious timeout errors during polling.
 - **ALSA**: Fix rare panics when dropping the stream is interrupted.
 - **ALSA**: Fix timestamp overflows on 32-bit platforms.
-- **ASIO**: Fix enumeration returning only the first device when using `collect`.
+- **ASIO**: Fix enumeration returning only the first device when using `collect()`.
 - **ASIO**: Fix device enumeration and stream creation failing when called from spawned threads.
 - **ASIO**: Fix buffer size not resizing when the driver reports `kAsioBufferSizeChange`.
 - **ASIO**: Fix latency not updating when the driver reports `kAsioLatenciesChanged`.
@@ -99,9 +100,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **JACK**: Fix input capture timestamp using callback execution time instead of cycle start.
 - **JACK**: Poisoned error callback mutex no longer silently drops subsequent error notifications.
 - **JACK**: Port registration failure now fails stream creation instead of silently failing.
-- **JACK**: `activate_async` failure now returns an error instead of panicking.
+- **JACK**: `activate_async()` failure now returns an error instead of panicking.
 - **JACK**: Sample rate is now validated against the live JACK server at stream creation time.
 - **JACK**: Underrun notification no longer blocks the notification thread.
+- **WebAudio**: Fix duplicated callbacks on repeated `play()` calls.
+- **WebAudio**: Report errors through the callback instead of panicking.
 
 ## [0.17.3] - 2026-02-18
 

--- a/src/host/webaudio/mod.rs
+++ b/src/host/webaudio/mod.rs
@@ -501,8 +501,8 @@ impl StreamTrait for Stream {
                     return Ok(());
                 }
                 // Begin webaudio playback, initially scheduling the closures to fire on a timeout
-                // event.
-                let mut offset_ms = 10;
+                // event. Minimum value as per spec: https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#timers
+                let mut offset_ms = 4;
                 let time_step_secs =
                     buffer_time_step_secs(self.buffer_size_frames, self.config.sample_rate);
                 let time_step_ms = (time_step_secs * 1_000.0) as i32;

--- a/src/host/webaudio/mod.rs
+++ b/src/host/webaudio/mod.rs
@@ -385,7 +385,9 @@ impl DeviceTrait for Device {
                             {
                                 let description = format!("{err:?}");
                                 let err = BackendSpecificError { description };
-                                (error_callback_handle.lock().unwrap_or_else(|e| e.into_inner()))(
+                                (error_callback_handle
+                                    .lock()
+                                    .unwrap_or_else(|e| e.into_inner()))(
                                     StreamError::BackendSpecific { err },
                                 );
                                 return;
@@ -406,7 +408,9 @@ impl DeviceTrait for Device {
                             {
                                 let description = format!("{err:?}");
                                 let err = BackendSpecificError { description };
-                                (error_callback_handle.lock().unwrap_or_else(|e| e.into_inner()))(
+                                (error_callback_handle
+                                    .lock()
+                                    .unwrap_or_else(|e| e.into_inner()))(
                                     StreamError::BackendSpecific { err },
                                 );
                                 return;
@@ -421,9 +425,11 @@ impl DeviceTrait for Device {
                         Err(err) => {
                             let description = format!("{err:?}");
                             let err = BackendSpecificError { description };
-                            (error_callback_handle.lock().unwrap_or_else(|e| e.into_inner()))(StreamError::BackendSpecific {
-                                err,
-                            });
+                            (error_callback_handle
+                                .lock()
+                                .unwrap_or_else(|e| e.into_inner()))(
+                                StreamError::BackendSpecific { err },
+                            );
                             return;
                         }
                     };
@@ -431,9 +437,11 @@ impl DeviceTrait for Device {
                     if let Err(err) = source.connect_with_audio_node(&ctx_handle.destination()) {
                         let description = format!("{err:?}");
                         let err = BackendSpecificError { description };
-                        (error_callback_handle.lock().unwrap_or_else(|e| e.into_inner()))(StreamError::BackendSpecific {
-                            err,
-                        });
+                        (error_callback_handle
+                            .lock()
+                            .unwrap_or_else(|e| e.into_inner()))(
+                            StreamError::BackendSpecific { err },
+                        );
                         return;
                     }
                     if let Err(err) = source.add_event_listener_with_callback(
@@ -448,17 +456,21 @@ impl DeviceTrait for Device {
                     ) {
                         let description = format!("{err:?}");
                         let err = BackendSpecificError { description };
-                        (error_callback_handle.lock().unwrap_or_else(|e| e.into_inner()))(StreamError::BackendSpecific {
-                            err,
-                        });
+                        (error_callback_handle
+                            .lock()
+                            .unwrap_or_else(|e| e.into_inner()))(
+                            StreamError::BackendSpecific { err },
+                        );
                         return;
                     }
                     if let Err(err) = source.start_with_when(time_at_start_of_buffer) {
                         let description = format!("{err:?}");
                         let err = BackendSpecificError { description };
-                        (error_callback_handle.lock().unwrap_or_else(|e| e.into_inner()))(StreamError::BackendSpecific {
-                            err,
-                        });
+                        (error_callback_handle
+                            .lock()
+                            .unwrap_or_else(|e| e.into_inner()))(
+                            StreamError::BackendSpecific { err },
+                        );
                         return;
                     }
 

--- a/src/host/webaudio/mod.rs
+++ b/src/host/webaudio/mod.rs
@@ -18,6 +18,7 @@ use crate::{
     SupportedStreamConfig, SupportedStreamConfigRange, SupportedStreamConfigsError,
 };
 use std::ops::DerefMut;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, RwLock};
 use std::time::Duration;
 
@@ -37,6 +38,7 @@ pub struct Stream {
     on_ended_closures: Vec<ClosureHandle>,
     config: StreamConfig,
     buffer_size_frames: usize,
+    is_started: Arc<AtomicBool>,
 }
 
 // WASM runs in a single-threaded environment, so Send and Sync are safe by design.
@@ -206,7 +208,7 @@ impl DeviceTrait for Device {
         config: StreamConfig,
         sample_format: SampleFormat,
         data_callback: D,
-        _error_callback: E,
+        error_callback: E,
         _timeout: Option<Duration>,
     ) -> Result<Self::Stream, BuildStreamError>
     where
@@ -232,6 +234,10 @@ impl DeviceTrait for Device {
         let buffer_time_step_secs = buffer_time_step_secs(buffer_size_frames, config.sample_rate);
 
         let data_callback = Arc::new(Mutex::new(Box::new(data_callback)));
+        let error_callback = Arc::new(Mutex::new(
+            Box::new(error_callback) as Box<dyn FnMut(StreamError) + Send + 'static>
+        ));
+        let is_started = Arc::new(AtomicBool::new(false));
 
         // Create the WebAudio stream.
         let stream_opts = AudioContextOptions::new();
@@ -274,6 +280,7 @@ impl DeviceTrait for Device {
         // can be fetched in the background.
         for _i in 0..2 {
             let data_callback_handle = data_callback.clone();
+            let error_callback_handle = error_callback.clone();
             let ctx_handle = ctx.clone();
             let time_handle = time.clone();
 
@@ -373,11 +380,16 @@ impl DeviceTrait for Device {
 
                         #[cfg(not(target_feature = "atomics"))]
                         {
-                            ctx_buffer
+                            if let Err(err) = ctx_buffer
                                 .copy_to_channel(&temporary_channel_buffer, channel as i32)
-                                .expect(
-                                    "Unable to write sample data into the audio context buffer",
+                            {
+                                let description = format!("{err:?}");
+                                let err = BackendSpecificError { description };
+                                (error_callback_handle.lock().unwrap())(
+                                    StreamError::BackendSpecific { err },
                                 );
+                                return;
+                            }
                         }
 
                         // copyToChannel cannot be directly copied into from a SharedArrayBuffer,
@@ -388,42 +400,67 @@ impl DeviceTrait for Device {
                         #[cfg(target_feature = "atomics")]
                         {
                             temporary_channel_array_view.copy_from(&temporary_channel_buffer);
-                            ctx_buffer
+                            if let Err(err) = ctx_buffer
                                 .unchecked_ref::<ExternalArrayAudioBuffer>()
                                 .copy_to_channel(&temporary_channel_array_view, channel as i32)
-                                .expect(
-                                    "Unable to write sample data into the audio context buffer",
+                            {
+                                let description = format!("{err:?}");
+                                let err = BackendSpecificError { description };
+                                (error_callback_handle.lock().unwrap())(
+                                    StreamError::BackendSpecific { err },
                                 );
+                                return;
+                            }
                         }
                     }
 
                     // Create an AudioBufferSourceNode, schedule it to playback the reused buffer
                     // in the future.
-                    let source = ctx_handle
-                        .create_buffer_source()
-                        .expect("Unable to create a webaudio buffer source");
+                    let source = match ctx_handle.create_buffer_source() {
+                        Ok(s) => s,
+                        Err(err) => {
+                            let description = format!("{err:?}");
+                            let err = BackendSpecificError { description };
+                            (error_callback_handle.lock().unwrap())(StreamError::BackendSpecific {
+                                err,
+                            });
+                            return;
+                        }
+                    };
                     source.set_buffer(Some(&ctx_buffer));
-                    source
-                        .connect_with_audio_node(&ctx_handle.destination())
-                        .expect(
-                        "Unable to connect the web audio buffer source to the context destination",
-                    );
-                    source
-                        .add_event_listener_with_callback(
-                            "ended",
-                            on_ended_closure_handle
-                                .read()
-                                .unwrap()
-                                .as_ref()
-                                .unwrap()
-                                .as_ref()
-                                .unchecked_ref(),
-                        )
-                        .expect("Failed to add ended event listener");
-
-                    source
-                        .start_with_when(time_at_start_of_buffer)
-                        .expect("Unable to start the webaudio buffer source");
+                    if let Err(err) = source.connect_with_audio_node(&ctx_handle.destination()) {
+                        let description = format!("{err:?}");
+                        let err = BackendSpecificError { description };
+                        (error_callback_handle.lock().unwrap())(StreamError::BackendSpecific {
+                            err,
+                        });
+                        return;
+                    }
+                    if let Err(err) = source.add_event_listener_with_callback(
+                        "ended",
+                        on_ended_closure_handle
+                            .read()
+                            .unwrap()
+                            .as_ref()
+                            .unwrap()
+                            .as_ref()
+                            .unchecked_ref(),
+                    ) {
+                        let description = format!("{err:?}");
+                        let err = BackendSpecificError { description };
+                        (error_callback_handle.lock().unwrap())(StreamError::BackendSpecific {
+                            err,
+                        });
+                        return;
+                    }
+                    if let Err(err) = source.start_with_when(time_at_start_of_buffer) {
+                        let description = format!("{err:?}");
+                        let err = BackendSpecificError { description };
+                        (error_callback_handle.lock().unwrap())(StreamError::BackendSpecific {
+                            err,
+                        });
+                        return;
+                    }
 
                     // Keep track of when the next buffer worth of samples should be played.
                     *time_handle.write().unwrap() = time_at_start_of_buffer + buffer_time_step_secs;
@@ -437,6 +474,7 @@ impl DeviceTrait for Device {
             on_ended_closures,
             config,
             buffer_size_frames,
+            is_started,
         })
     }
 }
@@ -454,6 +492,14 @@ impl StreamTrait for Stream {
         let window = web_sys::window().unwrap();
         match self.ctx.resume() {
             Ok(_) => {
+                // Only schedule the initial timeouts once.
+                if self
+                    .is_started
+                    .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+                    .is_err()
+                {
+                    return Ok(());
+                }
                 // Begin webaudio playback, initially scheduling the closures to fire on a timeout
                 // event.
                 let mut offset_ms = 10;

--- a/src/host/webaudio/mod.rs
+++ b/src/host/webaudio/mod.rs
@@ -385,7 +385,7 @@ impl DeviceTrait for Device {
                             {
                                 let description = format!("{err:?}");
                                 let err = BackendSpecificError { description };
-                                (error_callback_handle.lock().unwrap())(
+                                (error_callback_handle.lock().unwrap_or_else(|e| e.into_inner()))(
                                     StreamError::BackendSpecific { err },
                                 );
                                 return;
@@ -406,7 +406,7 @@ impl DeviceTrait for Device {
                             {
                                 let description = format!("{err:?}");
                                 let err = BackendSpecificError { description };
-                                (error_callback_handle.lock().unwrap())(
+                                (error_callback_handle.lock().unwrap_or_else(|e| e.into_inner()))(
                                     StreamError::BackendSpecific { err },
                                 );
                                 return;
@@ -421,7 +421,7 @@ impl DeviceTrait for Device {
                         Err(err) => {
                             let description = format!("{err:?}");
                             let err = BackendSpecificError { description };
-                            (error_callback_handle.lock().unwrap())(StreamError::BackendSpecific {
+                            (error_callback_handle.lock().unwrap_or_else(|e| e.into_inner()))(StreamError::BackendSpecific {
                                 err,
                             });
                             return;
@@ -431,7 +431,7 @@ impl DeviceTrait for Device {
                     if let Err(err) = source.connect_with_audio_node(&ctx_handle.destination()) {
                         let description = format!("{err:?}");
                         let err = BackendSpecificError { description };
-                        (error_callback_handle.lock().unwrap())(StreamError::BackendSpecific {
+                        (error_callback_handle.lock().unwrap_or_else(|e| e.into_inner()))(StreamError::BackendSpecific {
                             err,
                         });
                         return;
@@ -448,7 +448,7 @@ impl DeviceTrait for Device {
                     ) {
                         let description = format!("{err:?}");
                         let err = BackendSpecificError { description };
-                        (error_callback_handle.lock().unwrap())(StreamError::BackendSpecific {
+                        (error_callback_handle.lock().unwrap_or_else(|e| e.into_inner()))(StreamError::BackendSpecific {
                             err,
                         });
                         return;
@@ -456,7 +456,7 @@ impl DeviceTrait for Device {
                     if let Err(err) = source.start_with_when(time_at_start_of_buffer) {
                         let description = format!("{err:?}");
                         let err = BackendSpecificError { description };
-                        (error_callback_handle.lock().unwrap())(StreamError::BackendSpecific {
+                        (error_callback_handle.lock().unwrap_or_else(|e| e.into_inner()))(StreamError::BackendSpecific {
                             err,
                         });
                         return;
@@ -505,7 +505,7 @@ impl StreamTrait for Stream {
                 let mut offset_ms = 4;
                 let time_step_secs =
                     buffer_time_step_secs(self.buffer_size_frames, self.config.sample_rate);
-                let time_step_ms = (time_step_secs * 1_000.0) as i32;
+                let time_step_ms = ((time_step_secs * 1_000.0).ceil() as i32).max(1);
                 for on_ended_closure in self.on_ended_closures.iter() {
                     window
                         .set_timeout_with_callback_and_timeout_and_arguments_0(


### PR DESCRIPTION
- Fix duplicated callbacks on repeated `play()` calls.
- Report errors through the callback instead of panicking.