### PR TITLE
fix(pipewire): detect socket on Snap

### DIFF
--- a/src/host/coreaudio/ios/mod.rs
+++ b/src/host/coreaudio/ios/mod.rs
@@ -510,11 +510,7 @@ where
 
         let latency_frames = device_buffer_frames.unwrap_or_else(|| {
             let channels = buffer.mNumberChannels as usize;
-            if channels > 0 {
-                data.len() / channels
-            } else {
-                0
-            }
+            data.len().checked_div(channels).unwrap_or(0)
         });
         let delay = frames_to_duration(latency_frames, sample_rate);
         let capture = callback.checked_sub(delay).unwrap_or(StreamInstant::ZERO);
@@ -559,11 +555,7 @@ where
 
         let latency_frames = device_buffer_frames.unwrap_or_else(|| {
             let channels = buffer.mNumberChannels as usize;
-            if channels > 0 {
-                data.len() / channels
-            } else {
-                0
-            }
+            data.len().checked_div(channels).unwrap_or(0)
         });
         let delay = frames_to_duration(latency_frames, sample_rate);
         let playback = callback + delay;

--- a/src/host/pipewire/device.rs
+++ b/src/host/pipewire/device.rs
@@ -491,11 +491,18 @@ fn parse_fraction(s: &str) -> Option<(u32, u32)> {
     Some((num, den))
 }
 
+fn remote_props() -> Option<pw::properties::PropertiesBox> {
+    let socket = super::utils::find_socket_path()?;
+    let mut props = pw::properties::PropertiesBox::new();
+    props.insert(*pw::keys::REMOTE_NAME, socket.to_string_lossy().as_ref());
+    Some(props)
+}
+
 pub fn init_devices() -> Option<Vec<Device>> {
     let _pw = PwInitGuard::new();
     let mainloop = pw::main_loop::MainLoopRc::new(None).ok()?;
     let context = pw::context::ContextRc::new(&mainloop, None).ok()?;
-    let core = context.connect_rc(None).ok()?;
+    let core = context.connect_rc(remote_props()).ok()?;
     let registry = core.get_registry_rc().ok()?;
 
     // Discovered hardware nodes collected during enumeration.

--- a/src/host/pipewire/mod.rs
+++ b/src/host/pipewire/mod.rs
@@ -1,5 +1,6 @@
 use crate::traits::HostTrait;
 use device::{init_devices, Class, Device, Devices};
+use std::path::Path;
 use stream::PwInitGuard;
 
 mod device;
@@ -8,10 +9,22 @@ mod utils;
 
 #[inline]
 fn pipewire_available() -> bool {
-    let dir = std::env::var("PIPEWIRE_RUNTIME_DIR")
-        .or_else(|_| std::env::var("XDG_RUNTIME_DIR"))
-        .unwrap_or_default();
-    std::path::Path::new(&dir).join("pipewire-0").exists()
+    fn has_socket(dir: &Path) -> bool {
+        dir.join("pipewire-0").exists()
+    }
+
+    if let Ok(dir) = std::env::var("PIPEWIRE_RUNTIME_DIR") {
+        return has_socket(Path::new(&dir));
+    }
+
+    if let Ok(xdg) = std::env::var("XDG_RUNTIME_DIR") {
+        let path = Path::new(&xdg);
+        // Snap sets XDG_RUNTIME_DIR to a snap-specific subdirectory but keeps
+        // the PipeWire socket in the parent.
+        return has_socket(path) || path.parent().map_or(false, has_socket);
+    }
+
+    false
 }
 
 pub struct Host {

--- a/src/host/pipewire/mod.rs
+++ b/src/host/pipewire/mod.rs
@@ -21,7 +21,7 @@ fn pipewire_available() -> bool {
         let path = Path::new(&xdg);
         // Snap sets XDG_RUNTIME_DIR to a snap-specific subdirectory but keeps
         // the PipeWire socket in the parent.
-        return has_socket(path) || path.parent().map_or(false, has_socket);
+        return has_socket(path) || path.parent().is_some_and(has_socket);
     }
 
     false

--- a/src/host/pipewire/mod.rs
+++ b/src/host/pipewire/mod.rs
@@ -1,31 +1,10 @@
 use crate::traits::HostTrait;
 use device::{init_devices, Class, Device, Devices};
-use std::path::Path;
 use stream::PwInitGuard;
 
 mod device;
 mod stream;
 mod utils;
-
-#[inline]
-fn pipewire_available() -> bool {
-    fn has_socket(dir: &Path) -> bool {
-        dir.join("pipewire-0").exists()
-    }
-
-    if let Ok(dir) = std::env::var("PIPEWIRE_RUNTIME_DIR") {
-        return has_socket(Path::new(&dir));
-    }
-
-    if let Ok(xdg) = std::env::var("XDG_RUNTIME_DIR") {
-        let path = Path::new(&xdg);
-        // Snap sets XDG_RUNTIME_DIR to a snap-specific subdirectory but keeps
-        // the PipeWire socket in the parent.
-        return has_socket(path) || path.parent().is_some_and(has_socket);
-    }
-
-    false
-}
 
 pub struct Host {
     // Keeps PipeWire initialized for the lifetime of the host, preventing
@@ -46,7 +25,7 @@ impl HostTrait for Host {
     type Devices = Devices;
     type Device = Device;
     fn is_available() -> bool {
-        pipewire_available()
+        utils::find_socket_path().is_some()
     }
     fn devices(&self) -> Result<Self::Devices, crate::DevicesError> {
         Ok(self.devices.clone().into_iter())

--- a/src/host/pipewire/stream.rs
+++ b/src/host/pipewire/stream.rs
@@ -327,6 +327,13 @@ fn frames_to_duration(frames: usize, rate: crate::SampleRate) -> std::time::Dura
     std::time::Duration::new(secs, nanos)
 }
 
+fn remote_props() -> Option<pw::properties::PropertiesBox> {
+    let socket = super::utils::find_socket_path()?;
+    let mut props = pw::properties::PropertiesBox::new();
+    props.insert(*pw::keys::REMOTE_NAME, socket.to_string_lossy().as_ref());
+    Some(props)
+}
+
 pub fn connect_output<D, E>(
     config: StreamConfig,
     properties: pw::properties::PropertiesBox,
@@ -341,7 +348,7 @@ where
 {
     let mainloop = pw::main_loop::MainLoopRc::new(None)?;
     let context = pw::context::ContextRc::new(&mainloop, None)?;
-    let core = context.connect_rc(None)?;
+    let core = context.connect_rc(remote_props())?;
 
     let data = UserData {
         data_callback,
@@ -501,7 +508,7 @@ where
 {
     let mainloop = pw::main_loop::MainLoopRc::new(None)?;
     let context = pw::context::ContextRc::new(&mainloop, None)?;
-    let core = context.connect_rc(None)?;
+    let core = context.connect_rc(remote_props())?;
 
     let data = UserData {
         data_callback,

--- a/src/host/pipewire/utils.rs
+++ b/src/host/pipewire/utils.rs
@@ -1,3 +1,6 @@
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+
 pub const METADATA_NAME: &str = "metadata.name";
 
 // NOTE: the icon name contains bluetooth and etc, not icon-name, but icon_name
@@ -26,4 +29,38 @@ pub mod audio {
     pub const DUPLEX: &str = "Audio/Duplex";
     pub const STREAM_OUTPUT: &str = "Stream/Output/Audio";
     pub const STREAM_INPUT: &str = "Stream/Input/Audio";
+}
+
+/// Returns the path of the PipeWire socket, checking the standard locations
+/// including the parent of `XDG_RUNTIME_DIR` for Snap sandboxes.
+pub fn find_socket_path() -> Option<&'static PathBuf> {
+    static SOCKET: OnceLock<Option<PathBuf>> = OnceLock::new();
+    SOCKET
+        .get_or_init(|| {
+            fn socket_in(dir: &Path) -> Option<PathBuf> {
+                let p = dir.join("pipewire-0");
+                p.exists().then_some(p)
+            }
+
+            if let Ok(dir) = std::env::var("PIPEWIRE_RUNTIME_DIR") {
+                if let Some(p) = socket_in(Path::new(&dir)) {
+                    return Some(p);
+                }
+            }
+
+            if let Ok(xdg) = std::env::var("XDG_RUNTIME_DIR") {
+                let path = Path::new(&xdg);
+                if let Some(p) = socket_in(path) {
+                    return Some(p);
+                }
+                // Snap sets XDG_RUNTIME_DIR to a snap-specific subdirectory but keeps
+                // the PipeWire socket in the parent.
+                if let Some(p) = path.parent().and_then(socket_in) {
+                    return Some(p);
+                }
+            }
+
+            None
+        })
+        .as_ref()
 }


### PR DESCRIPTION
Snap sets `XDG_RUNTIME_DIR` to a snap-specific subdirectory but keeps the PipeWire socket in the parent.

Fixes #1166