### PR TITLE
refactor: various cleanups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **AAudio**: Fix capture and playback timestamp not accounting for audio pipeline buffer depth.
 - **AAudio**: Fix overflow in `buffer_capacity_in_frames` for large fixed buffer sizes.
 - **AAudio**: Poisoned stream locks now return `ErrorKind::StreamInvalidated` instead of panicking.
+- **AAudio**: Output buffers are now zero-filled before the callback runs.
 - **ALSA**: Fix capture stream hanging or spinning on overruns.
 - **ALSA**: Fix non-monotonic `StreamInstant` during stream startup.
 - **ALSA**: Fix spurious timestamp errors during stream startup.
@@ -93,6 +94,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **ALSA**: Fix rare panics when dropping the stream is interrupted.
 - **ALSA**: Fix timestamp overflows on 32-bit platforms.
 - **ALSA**: Fix overflow in `buffer_capacity_in_frames` for large fixed buffer sizes.
+- **ALSA**: Fix silence template not being applied for DSD.
 - **ASIO**: Fix enumeration returning only the first device when using `collect()`.
 - **ASIO**: Fix device enumeration and stream creation failing when called from spawned threads.
 - **ASIO**: Fix buffer size not resizing when the driver reports `kAsioBufferSizeChange`.
@@ -102,6 +104,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **ASIO**: Poisoned stream mutex in the buffer-size change handler no longer silently skips the
   update.
 - **ASIO**: Poisoned stream locks now return `ErrorKind::StreamInvalidated` instead of panicking.
+- **ASIO**: Output buffers are now zero-filled before the callback runs.
 - **CoreAudio**: Fix undefined behaviour and silent failure in loopback device creation.
 - **CoreAudio**: Poisoned stream locks now return `ErrorKind::StreamInvalidated` instead of 
   panicking.
@@ -112,7 +115,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **JACK**: `activate_async()` failure now returns an error instead of panicking.
 - **JACK**: Sample rate is now validated against the live JACK server at stream creation time.
 - **JACK**: Underrun notification no longer blocks the notification thread.
+- **JACK**: Output buffers are now zero-filled before the callback runs.
 - **WASAPI**: Poisoned locks now returns an error instead of panicking.
+- **WASAPI**: Output buffers are now zero-filled before the callback runs.
 - **WebAudio**: Fix duplicated callbacks on repeated `play()` calls.
 - **WebAudio**: Report errors through the callback instead of panicking.
 

--- a/asio-sys/build.rs
+++ b/asio-sys/build.rs
@@ -2,9 +2,12 @@ extern crate bindgen;
 extern crate cc;
 extern crate walkdir;
 
-use std::env;
-use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::{
+    env,
+    path::{Path, PathBuf},
+    process::Command,
+};
+
 use walkdir::WalkDir;
 
 const CPAL_ASIO_DIR: &str = "CPAL_ASIO_DIR";

--- a/asio-sys/src/bindings/errors.rs
+++ b/asio-sys/src/bindings/errors.rs
@@ -1,5 +1,4 @@
-use std::error::Error;
-use std::fmt;
+use std::{error::Error, fmt};
 
 /// Errors that might occur during `Asio::load_driver`.
 #[derive(Clone, Debug)]

--- a/asio-sys/src/bindings/mod.rs
+++ b/asio-sys/src/bindings/mod.rs
@@ -2,22 +2,24 @@ pub(crate) mod asio_import;
 #[macro_use]
 pub mod errors;
 
-use self::errors::{AsioError, AsioErrorWrapper, LoadDriverError};
-use num_traits::FromPrimitive;
-
-use std::ffi::{CStr, CString};
-use std::os::raw::{c_char, c_double, c_void};
-use std::ptr::null_mut;
-use std::sync::{
-    atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering},
-    Arc, Mutex, MutexGuard, Weak,
-};
-use std::time::Duration;
-
 // On Windows (where ASIO actually runs), c_long is i32.
 // On non-Windows platforms (for docs.rs and local testing), redefine c_long as i32 to match.
 #[cfg(target_os = "windows")]
 use std::os::raw::c_long;
+use std::{
+    ffi::{CStr, CString},
+    os::raw::{c_char, c_double, c_void},
+    ptr::null_mut,
+    sync::{
+        atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering},
+        Arc, Mutex, MutexGuard, Weak,
+    },
+    time::Duration,
+};
+
+use num_traits::FromPrimitive;
+
+use self::errors::{AsioError, AsioErrorWrapper, LoadDriverError};
 #[cfg(not(target_os = "windows"))]
 type c_long = i32;
 

--- a/asio-sys/src/lib.rs
+++ b/asio-sys/src/lib.rs
@@ -5,5 +5,7 @@ extern crate num_derive;
 extern crate num_traits;
 
 pub mod bindings;
-pub use bindings::errors::{AsioError, LoadDriverError};
-pub use bindings::*;
+pub use bindings::{
+    errors::{AsioError, LoadDriverError},
+    *,
+};

--- a/examples/android/src/lib.rs
+++ b/examples/android/src/lib.rs
@@ -5,9 +5,8 @@ extern crate cpal;
 
 use cpal::{
     traits::{DeviceTrait, HostTrait, StreamTrait},
-    SizedSample, I24,
+    Device, FromSample, OutputCallbackInfo, Sample, SampleFormat, SizedSample, StreamConfig, I24,
 };
-use cpal::{FromSample, Sample};
 
 #[cfg_attr(target_os = "android", ndk_glue::main(backtrace = "full"))]
 fn main() {
@@ -20,25 +19,25 @@ fn main() {
     let config = device.default_output_config().unwrap();
 
     match config.sample_format() {
-        cpal::SampleFormat::I8 => run::<i8>(&device, config.into()).unwrap(),
-        cpal::SampleFormat::I16 => run::<i16>(&device, config.into()).unwrap(),
-        cpal::SampleFormat::I24 => run::<I24>(&device, config.into()).unwrap(),
-        cpal::SampleFormat::I32 => run::<i32>(&device, config.into()).unwrap(),
-        // cpal::SampleFormat::I48 => run::<I48>(&device, config.into()).unwrap(),
-        cpal::SampleFormat::I64 => run::<i64>(&device, config.into()).unwrap(),
-        cpal::SampleFormat::U8 => run::<u8>(&device, config.into()).unwrap(),
-        cpal::SampleFormat::U16 => run::<u16>(&device, config.into()).unwrap(),
-        // cpal::SampleFormat::U24 => run::<U24>(&device, config.into()).unwrap(),
-        cpal::SampleFormat::U32 => run::<u32>(&device, config.into()).unwrap(),
-        // cpal::SampleFormat::U48 => run::<U48>(&device, config.into()).unwrap(),
-        cpal::SampleFormat::U64 => run::<u64>(&device, config.into()).unwrap(),
-        cpal::SampleFormat::F32 => run::<f32>(&device, config.into()).unwrap(),
-        cpal::SampleFormat::F64 => run::<f64>(&device, config.into()).unwrap(),
+        SampleFormat::I8 => run::<i8>(&device, config.into()).unwrap(),
+        SampleFormat::I16 => run::<i16>(&device, config.into()).unwrap(),
+        SampleFormat::I24 => run::<I24>(&device, config.into()).unwrap(),
+        SampleFormat::I32 => run::<i32>(&device, config.into()).unwrap(),
+        // SampleFormat::I48 => run::<I48>(&device, config.into()).unwrap(),
+        SampleFormat::I64 => run::<i64>(&device, config.into()).unwrap(),
+        SampleFormat::U8 => run::<u8>(&device, config.into()).unwrap(),
+        SampleFormat::U16 => run::<u16>(&device, config.into()).unwrap(),
+        // SampleFormat::U24 => run::<U24>(&device, config.into()).unwrap(),
+        SampleFormat::U32 => run::<u32>(&device, config.into()).unwrap(),
+        // SampleFormat::U48 => run::<U48>(&device, config.into()).unwrap(),
+        SampleFormat::U64 => run::<u64>(&device, config.into()).unwrap(),
+        SampleFormat::F32 => run::<f32>(&device, config.into()).unwrap(),
+        SampleFormat::F64 => run::<f64>(&device, config.into()).unwrap(),
         sample_format => panic!("Unsupported sample format '{sample_format}'"),
     }
 }
 
-fn run<T>(device: &cpal::Device, config: cpal::StreamConfig) -> Result<(), anyhow::Error>
+fn run<T>(device: &Device, config: StreamConfig) -> Result<(), anyhow::Error>
 where
     T: SizedSample + FromSample<f32>,
 {
@@ -52,11 +51,11 @@ where
         (sample_clock * 440.0 * 2.0 * std::f32::consts::PI / sample_rate).sin()
     };
 
-    let err_fn = |err| eprintln!("an error occurred on stream: {}", err);
+    let err_fn = |err| eprintln!("an error occurred on stream: {err}");
 
     let stream = device.build_output_stream(
         config,
-        move |data: &mut [T], _: &cpal::OutputCallbackInfo| {
+        move |data: &mut [T], _: &OutputCallbackInfo| {
             write_data(data, channels, &mut next_value)
         },
         err_fn,

--- a/examples/audioworklet-beep/src/lib.rs
+++ b/examples/audioworklet-beep/src/lib.rs
@@ -2,7 +2,7 @@ use std::{cell::Cell, rc::Rc};
 
 use cpal::{
     traits::{DeviceTrait, HostTrait, StreamTrait},
-    Stream,
+    Device, FromSample, HostId, Sample, SampleFormat, SizedSample, Stream, StreamConfig,
 };
 use wasm_bindgen::prelude::*;
 use web_sys::console;
@@ -49,7 +49,7 @@ pub fn main_js() -> Result<(), JsValue> {
 
 fn beep() -> Stream {
     let host =
-        cpal::host_from_id(cpal::HostId::AudioWorklet).expect("AudioWorklet host not available");
+        cpal::host_from_id(HostId::AudioWorklet).expect("AudioWorklet host not available");
 
     let device = host
         .default_output_device()
@@ -57,16 +57,16 @@ fn beep() -> Stream {
     let config = device.default_output_config().unwrap();
 
     match config.sample_format() {
-        cpal::SampleFormat::F32 => run::<f32>(&device, config.into()),
-        cpal::SampleFormat::I16 => run::<i16>(&device, config.into()),
-        cpal::SampleFormat::U16 => run::<u16>(&device, config.into()),
+        SampleFormat::F32 => run::<f32>(&device, config.into()),
+        SampleFormat::I16 => run::<i16>(&device, config.into()),
+        SampleFormat::U16 => run::<u16>(&device, config.into()),
         _ => panic!("unsupported sample format"),
     }
 }
 
-fn run<T>(device: &cpal::Device, config: cpal::StreamConfig) -> Stream
+fn run<T>(device: &Device, config: StreamConfig) -> Stream
 where
-    T: cpal::Sample + cpal::SizedSample + cpal::FromSample<f32>,
+    T: Sample + SizedSample + FromSample<f32>,
 {
     let sample_rate = config.sample_rate as f32;
     let channels = config.channels as usize;
@@ -78,7 +78,7 @@ where
         (sample_clock * 440.0 * 2.0 * std::f32::consts::PI / sample_rate).sin()
     };
 
-    let err_fn = |err| console::error_1(&format!("an error occurred on stream: {}", err).into());
+    let err_fn = |err| console::error_1(&format!("an error occurred on stream: {err}").into());
 
     let stream = device
         .build_output_stream(
@@ -94,7 +94,7 @@ where
 
 fn write_data<T>(output: &mut [T], channels: usize, next_sample: &mut dyn FnMut() -> f32)
 where
-    T: cpal::Sample + cpal::FromSample<f32>,
+    T: Sample + FromSample<f32>,
 {
     for frame in output.chunks_mut(channels) {
         let sample = next_sample();

--- a/examples/beep.rs
+++ b/examples/beep.rs
@@ -14,7 +14,8 @@
 use clap::Parser;
 use cpal::{
     traits::{DeviceTrait, HostTrait, StreamTrait},
-    Error, ErrorKind, FromSample, HostId, Sample, SizedSample, I24,
+    Device, Error, ErrorKind, FromSample, HostId, OutputCallbackInfo, Sample, SampleFormat,
+    SizedSample, StreamConfig, I24,
 };
 
 #[derive(Parser, Debug)]
@@ -101,25 +102,25 @@ fn main() -> anyhow::Result<()> {
     println!("Default output config: {config:?}");
 
     match config.sample_format() {
-        cpal::SampleFormat::I8 => run::<i8>(&device, config.into()),
-        cpal::SampleFormat::I16 => run::<i16>(&device, config.into()),
-        cpal::SampleFormat::I24 => run::<I24>(&device, config.into()),
-        cpal::SampleFormat::I32 => run::<i32>(&device, config.into()),
-        // cpal::SampleFormat::I48 => run::<I48>(&device, config.into()),
-        cpal::SampleFormat::I64 => run::<i64>(&device, config.into()),
-        cpal::SampleFormat::U8 => run::<u8>(&device, config.into()),
-        cpal::SampleFormat::U16 => run::<u16>(&device, config.into()),
-        // cpal::SampleFormat::U24 => run::<U24>(&device, config.into()),
-        cpal::SampleFormat::U32 => run::<u32>(&device, config.into()),
-        // cpal::SampleFormat::U48 => run::<U48>(&device, config.into()),
-        cpal::SampleFormat::U64 => run::<u64>(&device, config.into()),
-        cpal::SampleFormat::F32 => run::<f32>(&device, config.into()),
-        cpal::SampleFormat::F64 => run::<f64>(&device, config.into()),
+        SampleFormat::I8 => run::<i8>(&device, config.into()),
+        SampleFormat::I16 => run::<i16>(&device, config.into()),
+        SampleFormat::I24 => run::<I24>(&device, config.into()),
+        SampleFormat::I32 => run::<i32>(&device, config.into()),
+        // SampleFormat::I48 => run::<I48>(&device, config.into()),
+        SampleFormat::I64 => run::<i64>(&device, config.into()),
+        SampleFormat::U8 => run::<u8>(&device, config.into()),
+        SampleFormat::U16 => run::<u16>(&device, config.into()),
+        // SampleFormat::U24 => run::<U24>(&device, config.into()),
+        SampleFormat::U32 => run::<u32>(&device, config.into()),
+        // SampleFormat::U48 => run::<U48>(&device, config.into()),
+        SampleFormat::U64 => run::<u64>(&device, config.into()),
+        SampleFormat::F32 => run::<f32>(&device, config.into()),
+        SampleFormat::F64 => run::<f64>(&device, config.into()),
         sample_format => panic!("Unsupported sample format '{sample_format}'"),
     }
 }
 
-pub fn run<T>(device: &cpal::Device, config: cpal::StreamConfig) -> Result<(), anyhow::Error>
+pub fn run<T>(device: &Device, config: StreamConfig) -> Result<(), anyhow::Error>
 where
     T: SizedSample + FromSample<f32>,
 {
@@ -137,9 +138,7 @@ where
 
     let stream = device.build_output_stream(
         config,
-        move |data: &mut [T], _: &cpal::OutputCallbackInfo| {
-            write_data(data, channels, &mut next_value)
-        },
+        move |data: &mut [T], _: &OutputCallbackInfo| write_data(data, channels, &mut next_value),
         err_fn,
         None,
     )?;

--- a/examples/custom.rs
+++ b/examples/custom.rs
@@ -1,18 +1,16 @@
-use std::time::Instant;
 use std::{
     sync::{
         atomic::{AtomicBool, Ordering},
         Arc,
     },
-    time::Duration,
+    time::{Duration, Instant},
 };
 
-use cpal::OutputCallbackInfo;
 use cpal::{
     traits::{DeviceTrait, HostTrait, StreamTrait},
     ChannelCount, Data, DeviceDescription, DeviceDescriptionBuilder, Error, ErrorKind, FrameCount,
-    FromSample, Sample, SampleFormat, StreamConfig, SupportedBufferSize, SupportedStreamConfig,
-    SupportedStreamConfigRange,
+    FromSample, OutputCallbackInfo, Sample, SampleFormat, StreamConfig, SupportedBufferSize,
+    SupportedStreamConfig, SupportedStreamConfigRange,
 };
 
 #[allow(dead_code)]

--- a/examples/custom.rs
+++ b/examples/custom.rs
@@ -8,9 +8,10 @@ use std::{
 
 use cpal::{
     traits::{DeviceTrait, HostTrait, StreamTrait},
-    ChannelCount, Data, DeviceDescription, DeviceDescriptionBuilder, Error, ErrorKind, FrameCount,
-    FromSample, OutputCallbackInfo, Sample, SampleFormat, StreamConfig, SupportedBufferSize,
-    SupportedStreamConfig, SupportedStreamConfigRange,
+    ChannelCount, Data, Device, DeviceDescription, DeviceDescriptionBuilder, DeviceId, Error,
+    ErrorKind, FrameCount, FromSample, InputCallbackInfo, OutputCallbackInfo,
+    OutputStreamTimestamp, Sample, SampleFormat, Stream, StreamConfig, StreamInstant,
+    SupportedBufferSize, SupportedStreamConfig, SupportedStreamConfigRange,
 };
 
 #[allow(dead_code)]
@@ -70,10 +71,10 @@ impl DeviceTrait for MyDevice {
     }
 
     fn description(&self) -> Result<DeviceDescription, Error> {
-        Ok(DeviceDescriptionBuilder::new("Custom Device".to_string()).build())
+        Ok(DeviceDescriptionBuilder::new("Custom Device").build())
     }
 
-    fn id(&self) -> Result<cpal::DeviceId, Error> {
+    fn id(&self) -> Result<DeviceId, Error> {
         Err(Error::new(ErrorKind::UnsupportedOperation))
     }
 
@@ -119,7 +120,7 @@ impl DeviceTrait for MyDevice {
         _: Option<Duration>,
     ) -> Result<Self::Stream, Error>
     where
-        D: FnMut(&Data, &cpal::InputCallbackInfo) + Send + 'static,
+        D: FnMut(&Data, &InputCallbackInfo) + Send + 'static,
         E: FnMut(Error) + Send + 'static,
     {
         Err(Error::new(ErrorKind::UnsupportedConfig))
@@ -162,18 +163,14 @@ impl DeviceTrait for MyDevice {
                 // data is cpal's way of having a type erased buffer.
                 // you're expected to provide a raw pointer, the amount of samples, and the sample format of the buffer
                 let mut data = unsafe {
-                    cpal::Data::from_parts(
-                        buffer.as_mut_ptr().cast(),
-                        buffer.len(),
-                        cpal::SampleFormat::F32,
-                    )
+                    Data::from_parts(buffer.as_mut_ptr().cast(), buffer.len(), SampleFormat::F32)
                 };
 
                 let duration = Instant::now().duration_since(start);
                 let secs = duration.as_nanos() / 1_000_000_000;
                 let subsec_nanos = duration.as_nanos() - secs * 1_000_000_000;
-                let stream_instant = cpal::StreamInstant::new(secs as _, subsec_nanos as _);
-                let timestamp = cpal::OutputStreamTimestamp {
+                let stream_instant = StreamInstant::new(secs as _, subsec_nanos as _);
+                let timestamp = OutputStreamTimestamp {
                     callback: stream_instant,
                     playback: stream_instant,
                 };
@@ -203,12 +200,12 @@ impl StreamTrait for MyStream {
         Ok(())
     }
 
-    fn now(&self) -> cpal::StreamInstant {
+    fn now(&self) -> StreamInstant {
         let elapsed = self.start.elapsed();
-        cpal::StreamInstant::new(elapsed.as_secs(), elapsed.subsec_nanos())
+        StreamInstant::new(elapsed.as_secs(), elapsed.subsec_nanos())
     }
 
-    fn buffer_size(&self) -> Result<cpal::FrameCount, Error> {
+    fn buffer_size(&self) -> Result<FrameCount, Error> {
         Ok(BUFFER_SIZE)
     }
 }
@@ -313,10 +310,7 @@ impl Oscillator {
     }
 }
 
-pub fn make_stream(
-    device: &cpal::Device,
-    config: StreamConfig,
-) -> Result<cpal::Stream, anyhow::Error> {
+pub fn make_stream(device: &Device, config: StreamConfig) -> Result<Stream, anyhow::Error> {
     let num_channels = config.channels as usize;
     let mut oscillator = Oscillator {
         waveform: Waveform::Sine,
@@ -331,7 +325,7 @@ pub fn make_stream(
 
     let stream = device.build_output_stream(
         config,
-        move |output: &mut [f32], _: &cpal::OutputCallbackInfo| {
+        move |output: &mut [f32], _: &OutputCallbackInfo| {
             // for 0-1s play sine, 1-2s play square, 2-3s play saw, 3-4s play triangle_wave
             let time_since_start = Instant::now().duration_since(time_at_start).as_secs_f32();
             if time_since_start < 1.0 {

--- a/examples/feedback.rs
+++ b/examples/feedback.rs
@@ -9,7 +9,7 @@
 use clap::Parser;
 use cpal::{
     traits::{DeviceTrait, HostTrait, StreamTrait},
-    Error, ErrorKind, HostId,
+    Error, ErrorKind, HostId, InputCallbackInfo, OutputCallbackInfo, StreamConfig,
 };
 use ringbuf::{
     traits::{Consumer, Producer, Split},
@@ -103,7 +103,7 @@ fn main() -> anyhow::Result<()> {
     println!("Using output device: \"{}\"", output_device.id()?);
 
     // We'll try and use the same configuration between streams to keep it simple.
-    let config: cpal::StreamConfig = input_device.default_input_config()?.into();
+    let config: StreamConfig = input_device.default_input_config()?.into();
 
     // Create a delay in case the input and output devices aren't synced.
     let latency_frames = (opt.latency / 1_000.0) * config.sample_rate as f32;
@@ -120,7 +120,7 @@ fn main() -> anyhow::Result<()> {
         producer.try_push(0.0).unwrap();
     }
 
-    let input_data_fn = move |data: &[f32], _: &cpal::InputCallbackInfo| {
+    let input_data_fn = move |data: &[f32], _: &InputCallbackInfo| {
         let mut output_fell_behind = false;
         for &sample in data {
             if producer.try_push(sample).is_err() {
@@ -132,7 +132,7 @@ fn main() -> anyhow::Result<()> {
         }
     };
 
-    let output_data_fn = move |data: &mut [f32], _: &cpal::OutputCallbackInfo| {
+    let output_data_fn = move |data: &mut [f32], _: &OutputCallbackInfo| {
         let mut input_fell_behind = false;
         for sample in data {
             *sample = match consumer.try_pop() {

--- a/examples/ios-feedback/src/feedback.rs
+++ b/examples/ios-feedback/src/feedback.rs
@@ -10,7 +10,10 @@ extern crate anyhow;
 extern crate cpal;
 extern crate ringbuf;
 
-use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
+use cpal::{
+    traits::{DeviceTrait, HostTrait, StreamTrait},
+    Error, InputCallbackInfo, OutputCallbackInfo, StreamConfig,
+};
 use ringbuf::{
     traits::{Consumer, Producer, Split},
     HeapRb,
@@ -32,7 +35,7 @@ pub fn run_example() -> Result<(), anyhow::Error> {
     println!("Using default output device: \"{}\"", output_device.name()?);
 
     // We'll try and use the same configuration between streams to keep it simple.
-    let config: cpal::StreamConfig = input_device.default_input_config()?.into();
+    let config: StreamConfig = input_device.default_input_config()?.into();
 
     // Create a delay in case the input and output devices aren't synced.
     let latency_frames = (LATENCY_MS / 1_000.0) * config.sample_rate as f32;
@@ -49,7 +52,7 @@ pub fn run_example() -> Result<(), anyhow::Error> {
         producer.try_push(0.0).unwrap();
     }
 
-    let input_data_fn = move |data: &[f32], _: &cpal::InputCallbackInfo| {
+    let input_data_fn = move |data: &[f32], _: &InputCallbackInfo| {
         let mut output_fell_behind = false;
         for &sample in data {
             if producer.try_push(sample).is_err() {
@@ -61,7 +64,7 @@ pub fn run_example() -> Result<(), anyhow::Error> {
         }
     };
 
-    let output_data_fn = move |data: &mut [f32], _: &cpal::OutputCallbackInfo| {
+    let output_data_fn = move |data: &mut [f32], _: &OutputCallbackInfo| {
         let mut input_fell_behind = false;
         for sample in data {
             *sample = match consumer.try_pop() {
@@ -78,10 +81,7 @@ pub fn run_example() -> Result<(), anyhow::Error> {
     };
 
     // Build streams.
-    println!(
-        "Attempting to build both streams with f32 samples and `{:?}`.",
-        config
-    );
+    println!("Attempting to build both streams with f32 samples and `{config:?}`.");
     println!("Setup input stream");
     let input_stream = input_device.build_input_stream(config, input_data_fn, err_fn, None)?;
     println!("Setup output stream");
@@ -89,10 +89,7 @@ pub fn run_example() -> Result<(), anyhow::Error> {
     println!("Successfully built streams.");
 
     // Play the streams.
-    println!(
-        "Starting the input and output streams with `{}` milliseconds of latency.",
-        LATENCY_MS
-    );
+    println!("Starting the input and output streams with `{LATENCY_MS}` milliseconds of latency.");
     input_stream.play()?;
     output_stream.play()?;
 
@@ -103,6 +100,6 @@ pub fn run_example() -> Result<(), anyhow::Error> {
     Ok(())
 }
 
-fn err_fn(err: cpal::Error) {
-    eprintln!("an error occurred on stream: {}", err);
+fn err_fn(err: Error) {
+    eprintln!("an error occurred on stream: {err}");
 }

--- a/examples/record_wav.rs
+++ b/examples/record_wav.rs
@@ -2,12 +2,17 @@
 //!
 //! The input data is recorded to "$CARGO_MANIFEST_DIR/recorded.wav".
 
+use std::{
+    fs::File,
+    io::BufWriter,
+    sync::{Arc, Mutex},
+};
+
 use clap::Parser;
-use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
-use cpal::{Error, ErrorKind, FromSample, HostId, Sample};
-use std::fs::File;
-use std::io::BufWriter;
-use std::sync::{Arc, Mutex};
+use cpal::{
+    traits::{DeviceTrait, HostTrait, StreamTrait},
+    Error, ErrorKind, FromSample, HostId, Sample,
+};
 
 #[derive(Parser, Debug)]
 #[command(version, about = "CPAL record_wav example", long_about = None)]

--- a/examples/record_wav.rs
+++ b/examples/record_wav.rs
@@ -11,7 +11,7 @@ use std::{
 use clap::Parser;
 use cpal::{
     traits::{DeviceTrait, HostTrait, StreamTrait},
-    Error, ErrorKind, FromSample, HostId, Sample,
+    Error, ErrorKind, FromSample, HostId, Sample, SampleFormat, SupportedStreamConfig,
 };
 
 #[derive(Parser, Debug)]
@@ -125,25 +125,25 @@ fn main() -> Result<(), anyhow::Error> {
     };
 
     let stream = match config.sample_format() {
-        cpal::SampleFormat::I8 => device.build_input_stream(
+        SampleFormat::I8 => device.build_input_stream(
             config.into(),
             move |data, _: &_| write_input_data::<i8, i8>(data, &writer_2),
             err_fn,
             None,
         )?,
-        cpal::SampleFormat::I16 => device.build_input_stream(
+        SampleFormat::I16 => device.build_input_stream(
             config.into(),
             move |data, _: &_| write_input_data::<i16, i16>(data, &writer_2),
             err_fn,
             None,
         )?,
-        cpal::SampleFormat::I32 => device.build_input_stream(
+        SampleFormat::I32 => device.build_input_stream(
             config.into(),
             move |data, _: &_| write_input_data::<i32, i32>(data, &writer_2),
             err_fn,
             None,
         )?,
-        cpal::SampleFormat::F32 => device.build_input_stream(
+        SampleFormat::F32 => device.build_input_stream(
             config.into(),
             move |data, _: &_| write_input_data::<f32, f32>(data, &writer_2),
             err_fn,
@@ -166,7 +166,7 @@ fn main() -> Result<(), anyhow::Error> {
     Ok(())
 }
 
-fn sample_format(format: cpal::SampleFormat) -> hound::SampleFormat {
+fn sample_format(format: SampleFormat) -> hound::SampleFormat {
     if format.is_dsd() {
         panic!("DSD formats cannot be written to WAV files");
     } else if format.is_float() {
@@ -176,7 +176,7 @@ fn sample_format(format: cpal::SampleFormat) -> hound::SampleFormat {
     }
 }
 
-fn wav_spec_from_config(config: &cpal::SupportedStreamConfig) -> hound::WavSpec {
+fn wav_spec_from_config(config: &SupportedStreamConfig) -> hound::WavSpec {
     hound::WavSpec {
         channels: config.channels() as _,
         sample_rate: config.sample_rate() as _,

--- a/examples/synth_tones.rs
+++ b/examples/synth_tones.rs
@@ -8,9 +8,8 @@ extern crate cpal;
 
 use cpal::{
     traits::{DeviceTrait, HostTrait, StreamTrait},
-    SizedSample, I24, U24,
+    FromSample, Sample, SizedSample, I24, U24,
 };
-use cpal::{FromSample, Sample};
 
 fn main() -> anyhow::Result<()> {
     let stream = stream_setup_for()?;

--- a/examples/synth_tones.rs
+++ b/examples/synth_tones.rs
@@ -8,7 +8,8 @@ extern crate cpal;
 
 use cpal::{
     traits::{DeviceTrait, HostTrait, StreamTrait},
-    FromSample, Sample, SizedSample, I24, U24,
+    Device, FromSample, Host, OutputCallbackInfo, Sample, SampleFormat, SizedSample, Stream,
+    StreamConfig, SupportedStreamConfig, I24, U24,
 };
 
 fn main() -> anyhow::Result<()> {
@@ -89,32 +90,31 @@ impl Oscillator {
     }
 }
 
-pub fn stream_setup_for() -> Result<cpal::Stream, anyhow::Error>
+pub fn stream_setup_for() -> Result<Stream, anyhow::Error>
 where
 {
     let (_host, device, config) = host_device_setup()?;
 
     match config.sample_format() {
-        cpal::SampleFormat::I8 => make_stream::<i8>(&device, config.into()),
-        cpal::SampleFormat::I16 => make_stream::<i16>(&device, config.into()),
-        cpal::SampleFormat::I24 => make_stream::<I24>(&device, config.into()),
-        cpal::SampleFormat::I32 => make_stream::<i32>(&device, config.into()),
-        cpal::SampleFormat::I64 => make_stream::<i64>(&device, config.into()),
-        cpal::SampleFormat::U8 => make_stream::<u8>(&device, config.into()),
-        cpal::SampleFormat::U16 => make_stream::<u16>(&device, config.into()),
-        cpal::SampleFormat::U24 => make_stream::<U24>(&device, config.into()),
-        cpal::SampleFormat::U32 => make_stream::<u32>(&device, config.into()),
-        cpal::SampleFormat::U64 => make_stream::<u64>(&device, config.into()),
-        cpal::SampleFormat::F32 => make_stream::<f32>(&device, config.into()),
-        cpal::SampleFormat::F64 => make_stream::<f64>(&device, config.into()),
+        SampleFormat::I8 => make_stream::<i8>(&device, config.into()),
+        SampleFormat::I16 => make_stream::<i16>(&device, config.into()),
+        SampleFormat::I24 => make_stream::<I24>(&device, config.into()),
+        SampleFormat::I32 => make_stream::<i32>(&device, config.into()),
+        SampleFormat::I64 => make_stream::<i64>(&device, config.into()),
+        SampleFormat::U8 => make_stream::<u8>(&device, config.into()),
+        SampleFormat::U16 => make_stream::<u16>(&device, config.into()),
+        SampleFormat::U24 => make_stream::<U24>(&device, config.into()),
+        SampleFormat::U32 => make_stream::<u32>(&device, config.into()),
+        SampleFormat::U64 => make_stream::<u64>(&device, config.into()),
+        SampleFormat::F32 => make_stream::<f32>(&device, config.into()),
+        SampleFormat::F64 => make_stream::<f64>(&device, config.into()),
         sample_format => Err(anyhow::Error::msg(format!(
             "Unsupported sample format '{sample_format}'"
         ))),
     }
 }
 
-pub fn host_device_setup(
-) -> Result<(cpal::Host, cpal::Device, cpal::SupportedStreamConfig), anyhow::Error> {
+pub fn host_device_setup() -> Result<(Host, Device, SupportedStreamConfig), anyhow::Error> {
     let host = cpal::default_host();
 
     let device = host
@@ -128,10 +128,7 @@ pub fn host_device_setup(
     Ok((host, device, config))
 }
 
-pub fn make_stream<T>(
-    device: &cpal::Device,
-    config: cpal::StreamConfig,
-) -> Result<cpal::Stream, anyhow::Error>
+pub fn make_stream<T>(device: &Device, config: StreamConfig) -> Result<Stream, anyhow::Error>
 where
     T: SizedSample + FromSample<f32>,
 {
@@ -149,7 +146,7 @@ where
 
     let stream = device.build_output_stream(
         config,
-        move |output: &mut [T], _: &cpal::OutputCallbackInfo| {
+        move |output: &mut [T], _: &OutputCallbackInfo| {
             // for 0-1s play sine, 1-2s play square, 2-3s play saw, 3-4s play triangle_wave
             let time_since_start = std::time::Instant::now()
                 .duration_since(time_at_start)

--- a/examples/wasm-beep/src/lib.rs
+++ b/examples/wasm-beep/src/lib.rs
@@ -2,7 +2,7 @@ use std::{cell::Cell, rc::Rc};
 
 use cpal::{
     traits::{DeviceTrait, HostTrait, StreamTrait},
-    Stream,
+    Device, FromSample, Sample, SampleFormat, SizedSample, Stream, StreamConfig,
 };
 use wasm_bindgen::prelude::*;
 use web_sys::console;
@@ -55,16 +55,16 @@ fn beep() -> Stream {
     let config = device.default_output_config().unwrap();
 
     match config.sample_format() {
-        cpal::SampleFormat::F32 => run::<f32>(&device, config.into()),
-        cpal::SampleFormat::I16 => run::<i16>(&device, config.into()),
-        cpal::SampleFormat::U16 => run::<u16>(&device, config.into()),
+        SampleFormat::F32 => run::<f32>(&device, config.into()),
+        SampleFormat::I16 => run::<i16>(&device, config.into()),
+        SampleFormat::U16 => run::<u16>(&device, config.into()),
         _ => panic!("unsupported sample format"),
     }
 }
 
-fn run<T>(device: &cpal::Device, config: cpal::StreamConfig) -> Stream
+fn run<T>(device: &Device, config: StreamConfig) -> Stream
 where
-    T: cpal::Sample + cpal::SizedSample + cpal::FromSample<f32>,
+    T: Sample + SizedSample + FromSample<f32>,
 {
     let sample_rate = config.sample_rate as f32;
     let channels = config.channels as usize;
@@ -73,10 +73,10 @@ where
     let mut sample_clock = 0f32;
     let mut next_value = move || {
         sample_clock = (sample_clock + 1.0) % sample_rate;
-        (sample_clock * 440.0 * 2.0 * 3.141592 / sample_rate).sin()
+        (sample_clock * 440.0 * 2.0 * std::f32::consts::PI / sample_rate).sin()
     };
 
-    let err_fn = |err| console::error_1(&format!("an error occurred on stream: {}", err).into());
+    let err_fn = |err| console::error_1(&format!("an error occurred on stream: {err}").into());
 
     let stream = device
         .build_output_stream(
@@ -92,7 +92,7 @@ where
 
 fn write_data<T>(output: &mut [T], channels: usize, next_sample: &mut dyn FnMut() -> f32)
 where
-    T: cpal::Sample + cpal::FromSample<f32>,
+    T: Sample + FromSample<f32>,
 {
     for frame in output.chunks_mut(channels) {
         let sample = next_sample();

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,8 @@
-use std::borrow::Cow;
-use std::error::Error as StdError;
-use std::fmt::{Display, Formatter};
+use std::{
+    borrow::Cow,
+    error::Error as StdError,
+    fmt::{Display, Formatter},
+};
 
 /// A list specifying general categories of CPAL error.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]

--- a/src/host/aaudio/java_interface/devices_info.rs
+++ b/src/host/aaudio/java_interface/devices_info.rs
@@ -1,7 +1,5 @@
 use num_traits::FromPrimitive;
 
-use crate::{DeviceDirection, SampleFormat};
-
 use super::{
     android_device_flags,
     utils::{
@@ -12,6 +10,7 @@ use super::{
     },
     AudioDeviceInfo, AudioDeviceType, Context,
 };
+use crate::{DeviceDirection, SampleFormat};
 
 impl AudioDeviceInfo {
     /**

--- a/src/host/aaudio/java_interface/utils.rs
+++ b/src/host/aaudio/java_interface/utils.rs
@@ -1,14 +1,12 @@
-use jni::sys::jobject;
-use ndk_context::AndroidContext;
 use std::sync::Arc;
 
-pub use jni::Executor;
-
+use jni::sys::jobject;
 pub use jni::{
     errors::Result as JResult,
     objects::{JIntArray, JObject, JObjectArray, JString},
-    JNIEnv, JavaVM,
+    Executor, JNIEnv, JavaVM,
 };
+use ndk_context::AndroidContext;
 
 pub fn get_context() -> AndroidContext {
     ndk_context::android_context()

--- a/src/host/aaudio/mod.rs
+++ b/src/host/aaudio/mod.rs
@@ -7,9 +7,9 @@ use std::{
     convert::TryInto,
     sync::{
         atomic::{AtomicI32, Ordering},
-        time::Duration,
         Arc, Mutex,
     },
+    time::Duration,
     vec::IntoIter as VecIntoIter,
 };
 
@@ -17,7 +17,7 @@ use crate::{
     traits::{DeviceTrait, HostTrait, StreamTrait},
     BufferSize, ChannelCount, Data, DeviceDescription, DeviceDescriptionBuilder, DeviceDirection,
     DeviceId, DeviceType, Error, ErrorKind, FrameCount, InputCallbackInfo, InputStreamTimestamp,
-    InterfaceType, OutputCallbackInfo, OutputStreamTimestamp, SampleFormat, SampleRate,
+    InterfaceType, OutputCallbackInfo, OutputStreamTimestamp, ResultExt, SampleFormat, SampleRate,
     StreamConfig, StreamInstant, SupportedBufferSize, SupportedStreamConfig,
     SupportedStreamConfigRange,
 };

--- a/src/host/aaudio/mod.rs
+++ b/src/host/aaudio/mod.rs
@@ -22,6 +22,7 @@ use crate::{
     OutputCallbackInfo, OutputStreamTimestamp, SampleFormat, StreamConfig, SupportedBufferSize,
     SupportedStreamConfig, SupportedStreamConfigRange,
 };
+use crate::{Error, ErrorKind};
 
 mod convert;
 mod java_interface;

--- a/src/host/aaudio/mod.rs
+++ b/src/host/aaudio/mod.rs
@@ -2,33 +2,34 @@
 //!
 //! Default backend on Android.
 
-use std::cmp;
-use std::convert::TryInto;
-use std::sync::atomic::{AtomicI32, Ordering};
-use std::sync::{Arc, Mutex};
-use std::time::Duration;
-use std::vec::IntoIter as VecIntoIter;
+use std::{
+    cmp,
+    convert::TryInto,
+    sync::{
+        atomic::{AtomicI32, Ordering},
+        time::Duration,
+        Arc, Mutex,
+    },
+    vec::IntoIter as VecIntoIter,
+};
+
+use crate::{
+    traits::{DeviceTrait, HostTrait, StreamTrait},
+    BufferSize, ChannelCount, Data, DeviceDescription, DeviceDescriptionBuilder, DeviceDirection,
+    DeviceId, DeviceType, Error, ErrorKind, FrameCount, InputCallbackInfo, InputStreamTimestamp,
+    InterfaceType, OutputCallbackInfo, OutputStreamTimestamp, SampleFormat, SampleRate,
+    StreamConfig, StreamInstant, SupportedBufferSize, SupportedStreamConfig,
+    SupportedStreamConfigRange,
+};
 
 extern crate ndk;
-
-use convert::{input_stream_instant, now_stream_instant, output_stream_instant};
-use java_interface::{AudioDeviceInfo, AudioManager};
-
-use crate::traits::{DeviceTrait, HostTrait, StreamTrait};
-use crate::{error::ResultExt, Error, ErrorKind};
-use crate::{
-    BufferSize, Data, DeviceDescription, DeviceDescriptionBuilder, DeviceDirection, DeviceId,
-    DeviceType, FrameCount, InputCallbackInfo, InputStreamTimestamp, InterfaceType,
-    OutputCallbackInfo, OutputStreamTimestamp, SampleFormat, StreamConfig, SupportedBufferSize,
-    SupportedStreamConfig, SupportedStreamConfigRange,
-};
-use crate::{Error, ErrorKind};
+use self::ndk::audio::AudioStream;
 
 mod convert;
 mod java_interface;
 
-use self::ndk::audio::AudioStream;
-use java_interface::AudioDeviceType as AndroidDeviceType;
+use convert::{input_stream_instant, now_stream_instant, output_stream_instant};
+use java_interface::{AudioDeviceInfo, AudioDeviceType as AndroidDeviceType, AudioManager};
 
 impl From<AndroidDeviceType> for DeviceType {
     fn from(device_type: AndroidDeviceType) -> Self {
@@ -105,7 +106,7 @@ const CHANNEL_OUT_STEREO: i32 = 12;
 // Android Java API supports up to 8 channels
 // TODO: more channels available in native AAudio
 // Maps channel masks to their corresponding channel counts
-const CHANNEL_CONFIGS: [(i32, u16); 2] = [(CHANNEL_OUT_MONO, 1), (CHANNEL_OUT_STEREO, 2)];
+const CHANNEL_CONFIGS: [(i32, ChannelCount); 2] = [(CHANNEL_OUT_MONO, 1), (CHANNEL_OUT_STEREO, 2)];
 
 const SAMPLE_RATES: [i32; 15] = [
     5512, 8000, 11025, 12000, 16000, 22050, 24000, 32000, 44100, 48000, 64000, 88200, 96000,
@@ -164,7 +165,7 @@ pub use crate::iter::{SupportedInputConfigs, SupportedOutputConfigs};
 pub type Devices = std::vec::IntoIter<Device>;
 
 impl Host {
-    pub fn new() -> Result<Self, crate::Error> {
+    pub fn new() -> Result<Self, Error> {
         Ok(Host)
     }
 }
@@ -215,8 +216,8 @@ fn default_supported_configs() -> VecIntoIter<SupportedStreamConfigRange> {
             for sample_rate in &SAMPLE_RATES {
                 output.push(SupportedStreamConfigRange {
                     channels: *channel_count,
-                    min_sample_rate: *sample_rate as u32,
-                    max_sample_rate: *sample_rate as u32,
+                    min_sample_rate: *sample_rate as SampleRate,
+                    max_sample_rate: *sample_rate as SampleRate,
                     buffer_size,
                     sample_format: *sample_format,
                 });
@@ -260,9 +261,9 @@ fn device_supported_configs(device: &AudioDeviceInfo) -> VecIntoIter<SupportedSt
             }
             for format in formats {
                 output.push(SupportedStreamConfigRange {
-                    channels: cmp::min(*channel_count as u16, 2u16),
-                    min_sample_rate: *sample_rate as u32,
-                    max_sample_rate: *sample_rate as u32,
+                    channels: cmp::min(*channel_count as ChannelCount, 2),
+                    min_sample_rate: *sample_rate as SampleRate,
+                    max_sample_rate: *sample_rate as SampleRate,
                     buffer_size,
                     sample_format: *format,
                 });
@@ -371,6 +372,14 @@ where
 
     let stream = builder
         .data_callback(Box::new(move |stream, data, num_frames| {
+            // Pre-fill with equilibrium so unwritten frames are silent.
+            let n_samples: usize = (num_frames * channel_count).try_into().unwrap();
+            let byte_count = n_samples * sample_format.sample_size();
+            // SAFETY: `data` is the buffer pointer provided by AAudio for this callback.
+            unsafe {
+                std::slice::from_raw_parts_mut(data as *mut u8, byte_count).fill(0);
+            }
+
             // Deliver audio data to user callback
             let cb_info = OutputCallbackInfo {
                 timestamp: OutputStreamTimestamp {
@@ -379,13 +388,7 @@ where
                 },
             };
             (data_callback)(
-                &mut unsafe {
-                    Data::from_parts(
-                        data as *mut _,
-                        (num_frames * channel_count).try_into().unwrap(),
-                        sample_format,
-                    )
-                },
+                &mut unsafe { Data::from_parts(data as *mut _, n_samples, sample_format) },
                 &cb_info,
             );
 
@@ -721,11 +724,11 @@ impl StreamTrait for Stream {
         }
     }
 
-    fn now(&self) -> crate::StreamInstant {
+    fn now(&self) -> StreamInstant {
         now_stream_instant()
     }
 
-    fn buffer_size(&self) -> Result<crate::FrameCount, Error> {
+    fn buffer_size(&self) -> Result<FrameCount, Error> {
         let stream = self.inner.lock().map_err(|_| {
             Error::with_message(ErrorKind::StreamInvalidated, "stream lock poisoned")
         })?;
@@ -736,6 +739,6 @@ impl StreamTrait for Stream {
             Some(size) if size > 0 => size,
             _ => stream.frames_per_burst(),
         };
-        Ok(frames as crate::FrameCount)
+        Ok(frames as FrameCount)
     }
 }

--- a/src/host/alsa/mod.rs
+++ b/src/host/alsa/mod.rs
@@ -18,15 +18,15 @@ use std::{
 
 use self::alsa::poll::Descriptors;
 pub use self::enumerate::Devices;
-
 use crate::{
-    host::fill_with_equilibrium,
+    host::{fill_with_equilibrium, frames_to_duration},
     iter::{SupportedInputConfigs, SupportedOutputConfigs},
     traits::{DeviceTrait, HostTrait, StreamTrait},
     BufferSize, ChannelCount, Data, DeviceDescription, DeviceDescriptionBuilder, DeviceDirection,
-    DeviceId, Error, ErrorKind, FrameCount, InputCallbackInfo, OutputCallbackInfo, SampleFormat,
-    SampleRate, StreamConfig, StreamInstant, SupportedBufferSize, SupportedStreamConfig,
-    SupportedStreamConfigRange,
+    DeviceId, Error, ErrorKind, FrameCount, InputCallbackInfo, InputStreamTimestamp,
+    OutputCallbackInfo, OutputStreamTimestamp, SampleFormat, SampleRate, StreamConfig,
+    StreamInstant, SupportedBufferSize, SupportedStreamConfig, SupportedStreamConfigRange,
+    COMMON_SAMPLE_RATES,
 };
 
 mod enumerate;
@@ -97,7 +97,7 @@ pub struct Host {
 }
 
 impl Host {
-    pub fn new() -> Result<Self, crate::Error> {
+    pub fn new() -> Result<Self, Error> {
         let inner = AlsaContext::new().map_err(|e| {
             Error::with_message(ErrorKind::HostUnavailable, format!("ALSA unavailable: {e}"))
         })?;
@@ -120,8 +120,8 @@ impl HostTrait for Host {
         self.enumerate_devices()
     }
 
-    fn device_by_id(&self, id: &crate::DeviceId) -> Option<Self::Device> {
-        let canonical_id = crate::DeviceId(id.0, canonical_pcm_id(&id.1));
+    fn device_by_id(&self, id: &DeviceId) -> Option<Self::Device> {
+        let canonical_id = DeviceId(id.0, canonical_pcm_id(&id.1));
         self.devices()
             .ok()?
             .find(|d| d.id().ok().as_ref() == Some(&canonical_id))
@@ -280,8 +280,9 @@ impl TriggerSender {
             }
             // write() can be interrupted by a signal before writing any bytes; retry.
             assert_eq!(ret, -1, "wakeup: unexpected return value {ret}");
-            if std::io::Error::last_os_error().kind() != std::io::ErrorKind::Interrupted {
-                panic!("wakeup: {}", std::io::Error::last_os_error());
+            let err = std::io::Error::last_os_error();
+            if err.kind() != std::io::ErrorKind::Interrupted {
+                panic!("wakeup: {err}");
             }
         }
     }
@@ -297,8 +298,9 @@ impl TriggerReceiver {
             }
             // read() can be interrupted by a signal before reading any bytes; retry.
             assert_eq!(ret, -1, "clear_pipe: unexpected return value {ret}");
-            if std::io::Error::last_os_error().kind() != std::io::ErrorKind::Interrupted {
-                panic!("clear_pipe: {}", std::io::Error::last_os_error());
+            let err = std::io::Error::last_os_error();
+            if err.kind() != std::io::ErrorKind::Interrupted {
+                panic!("clear_pipe: {err}");
             }
         }
     }
@@ -416,8 +418,8 @@ impl Device {
         let period_bytes = period_frames * frame_size;
         let mut silence_template = vec![0u8; period_bytes].into_boxed_slice();
 
-        // Only fill buffer for unsigned formats that don't have a zero value for silence.
-        if sample_format.is_uint() {
+        // Signed integers and floats have zero-byte equilibrium; fill everything else.
+        if !sample_format.is_int() && !sample_format.is_float() {
             fill_with_equilibrium(&mut silence_template, sample_format);
         }
 
@@ -550,7 +552,7 @@ impl Device {
             vec![(min_rate, max_rate)]
         } else {
             let mut rates = Vec::new();
-            for &sample_rate in crate::COMMON_SAMPLE_RATES.iter() {
+            for &sample_rate in COMMON_SAMPLE_RATES.iter() {
                 if hw_params.test_rate(sample_rate).is_ok() {
                     rates.push((sample_rate, sample_rate));
                 }
@@ -1063,12 +1065,12 @@ fn process_input(
     } else {
         stream_timestamp_fallback(stream.creation_instant)
     }?;
-    let delay_duration = frames_to_duration(delay_frames, stream.conf.sample_rate);
+    let delay_duration = frames_to_duration(delay_frames as FrameCount, stream.conf.sample_rate);
     let capture = callback
         .checked_sub(delay_duration)
         .unwrap_or(StreamInstant::ZERO);
-    let timestamp = crate::InputStreamTimestamp { callback, capture };
-    let info = crate::InputCallbackInfo { timestamp };
+    let timestamp = InputStreamTimestamp { callback, capture };
+    let info = InputCallbackInfo { timestamp };
     data_callback(&data, &info);
 
     Ok(())
@@ -1094,10 +1096,11 @@ fn process_output(
         } else {
             stream_timestamp_fallback(stream.creation_instant)
         }?;
-        let delay_duration = frames_to_duration(delay_frames, stream.conf.sample_rate);
+        let delay_duration =
+            frames_to_duration(delay_frames as FrameCount, stream.conf.sample_rate);
         let playback = callback + delay_duration;
-        let timestamp = crate::OutputStreamTimestamp { callback, playback };
-        let info = crate::OutputCallbackInfo { timestamp };
+        let timestamp = OutputStreamTimestamp { callback, playback };
+        let info = OutputCallbackInfo { timestamp };
         data_callback(&mut data, &info);
     }
 
@@ -1191,15 +1194,6 @@ fn timespec_to_nanos(ts: libc::timespec) -> i64 {
 #[inline]
 fn timespec_diff_nanos(a: libc::timespec, b: libc::timespec) -> i64 {
     timespec_to_nanos(a) - timespec_to_nanos(b)
-}
-
-// Convert the given duration in frames at the given sample rate to a `std::time::Duration`.
-#[inline]
-fn frames_to_duration(frames: usize, rate: crate::SampleRate) -> std::time::Duration {
-    let secsf = frames as f64 / rate as f64;
-    let secs = secsf as u64;
-    let nanos = ((secsf - secs as f64) * 1_000_000_000.0) as u32;
-    std::time::Duration::new(secs, nanos)
 }
 
 impl Stream {

--- a/src/host/alsa/mod.rs
+++ b/src/host/alsa/mod.rs
@@ -101,7 +101,7 @@ impl Host {
         let inner = AlsaContext::new().map_err(|e| {
             Error::with_message(ErrorKind::HostUnavailable, format!("ALSA unavailable: {e}"))
         })?;
-        Ok(Host {
+        Ok(Self {
             inner: Arc::new(inner),
         })
     }
@@ -128,11 +128,11 @@ impl HostTrait for Host {
     }
 
     fn default_input_device(&self) -> Option<Self::Device> {
-        Some(Device::default())
+        Some(Self::Device::default())
     }
 
     fn default_output_device(&self) -> Option<Self::Device> {
-        Some(Device::default())
+        Some(Self::Device::default())
     }
 }
 
@@ -171,15 +171,15 @@ impl DeviceTrait for Device {
 
     // ALSA overrides name() to return pcm_id directly instead of from description
     fn name(&self) -> Result<String, Error> {
-        Device::name(self)
+        Self::name(self)
     }
 
     fn description(&self) -> Result<DeviceDescription, Error> {
-        Device::description(self)
+        Self::description(self)
     }
 
     fn id(&self) -> Result<DeviceId, Error> {
-        Device::id(self)
+        Self::id(self)
     }
 
     // Override trait defaults to avoid opening devices during enumeration.
@@ -202,19 +202,19 @@ impl DeviceTrait for Device {
     }
 
     fn supported_input_configs(&self) -> Result<Self::SupportedInputConfigs, Error> {
-        Device::supported_input_configs(self)
+        Self::supported_input_configs(self)
     }
 
     fn supported_output_configs(&self) -> Result<Self::SupportedOutputConfigs, Error> {
-        Device::supported_output_configs(self)
+        Self::supported_output_configs(self)
     }
 
     fn default_input_config(&self) -> Result<SupportedStreamConfig, Error> {
-        Device::default_input_config(self)
+        Self::default_input_config(self)
     }
 
     fn default_output_config(&self) -> Result<SupportedStreamConfig, Error> {
-        Device::default_output_config(self)
+        Self::default_output_config(self)
     }
 
     fn build_input_stream_raw<D, E>(

--- a/src/host/alsa/mod.rs
+++ b/src/host/alsa/mod.rs
@@ -19,7 +19,10 @@ use std::{
 use self::alsa::poll::Descriptors;
 pub use self::enumerate::Devices;
 use crate::{
-    host::{fill_equilibrium, frames_to_duration, DSD_EQUILIBRIUM_BYTE, U8_EQUILIBRIUM_BYTE},
+    host::{
+        equilibrium::{fill_equilibrium, DSD_EQUILIBRIUM_BYTE, U8_EQUILIBRIUM_BYTE},
+        frames_to_duration,
+    },
     iter::{SupportedInputConfigs, SupportedOutputConfigs},
     traits::{DeviceTrait, HostTrait, StreamTrait},
     BufferSize, ChannelCount, Data, DeviceDescription, DeviceDescriptionBuilder, DeviceDirection,
@@ -416,7 +419,7 @@ impl Device {
         let frame_size = sample_format.sample_size() * conf.channels as usize;
         let period_bytes = period_frames * frame_size;
 
-        let equilibrium_fill = EquilibriumFill::new(sample_format, period_bytes as FrameCount);
+        let equilibrium_fill = EquilibriumFill::new(sample_format, period_bytes);
 
         let stream_inner = StreamInner {
             dropping: AtomicBool::new(false),
@@ -680,7 +683,7 @@ enum EquilibriumFill {
 
 impl EquilibriumFill {
     /// Compute the equilibrium-fill strategy for the given sample format at stream creation.
-    fn new(sample_format: SampleFormat, period_bytes: FrameCount) -> Self {
+    fn new(sample_format: SampleFormat, period_bytes: usize) -> Self {
         if sample_format.is_int() || sample_format.is_float() {
             Self::Byte(0)
         } else if sample_format == SampleFormat::U8 {
@@ -691,7 +694,7 @@ impl EquilibriumFill {
             // Multi-byte unsigned integer formats require a fill equal to the midpoint of their
             // range.
             debug_assert!(sample_format.is_uint());
-            let mut template = vec![0u8; period_bytes as usize].into_boxed_slice();
+            let mut template = vec![0u8; period_bytes].into_boxed_slice();
             fill_equilibrium(&mut template, sample_format);
             Self::Template(template)
         }

--- a/src/host/alsa/mod.rs
+++ b/src/host/alsa/mod.rs
@@ -19,7 +19,7 @@ use std::{
 use self::alsa::poll::Descriptors;
 pub use self::enumerate::Devices;
 use crate::{
-    host::{fill_with_equilibrium, frames_to_duration},
+    host::{fill_equilibrium, frames_to_duration, DSD_EQUILIBRIUM_BYTE, U8_EQUILIBRIUM_BYTE},
     iter::{SupportedInputConfigs, SupportedOutputConfigs},
     traits::{DeviceTrait, HostTrait, StreamTrait},
     BufferSize, ChannelCount, Data, DeviceDescription, DeviceDescriptionBuilder, DeviceDirection,
@@ -412,16 +412,11 @@ impl Device {
             handle.start()?;
         }
 
-        // Pre-compute a period-sized buffer filled with silence values.
         let period_frames = period_samples / conf.channels as usize;
         let frame_size = sample_format.sample_size() * conf.channels as usize;
         let period_bytes = period_frames * frame_size;
-        let mut silence_template = vec![0u8; period_bytes].into_boxed_slice();
 
-        // Signed integers and floats have zero-byte equilibrium; fill everything else.
-        if !sample_format.is_int() && !sample_format.is_float() {
-            fill_with_equilibrium(&mut silence_template, sample_format);
-        }
+        let equilibrium_fill = EquilibriumFill::new(sample_format, period_bytes as FrameCount);
 
         let stream_inner = StreamInner {
             dropping: AtomicBool::new(false),
@@ -432,7 +427,7 @@ impl Device {
             period_samples,
             period_frames,
             frame_size,
-            silence_template,
+            equilibrium: equilibrium_fill,
             can_pause,
             creation_instant,
             use_hw_timestamps,
@@ -674,6 +669,43 @@ impl Default for Device {
     }
 }
 
+/// Strategy for pre-filling an output buffer with the equilibrium value.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+enum EquilibriumFill {
+    /// Equilibrium is represented as a single repeating byte value.
+    Byte(u8),
+    /// A period-sized buffer pre-filled with the equilibrium value.
+    Template(Box<[u8]>),
+}
+
+impl EquilibriumFill {
+    /// Compute the equilibrium-fill strategy for the given sample format at stream creation.
+    fn new(sample_format: SampleFormat, period_bytes: FrameCount) -> Self {
+        if sample_format.is_int() || sample_format.is_float() {
+            Self::Byte(0)
+        } else if sample_format == SampleFormat::U8 {
+            Self::Byte(U8_EQUILIBRIUM_BYTE)
+        } else if sample_format.is_dsd() {
+            Self::Byte(DSD_EQUILIBRIUM_BYTE)
+        } else {
+            // Multi-byte unsigned integer formats require a fill equal to the midpoint of their
+            // range.
+            debug_assert!(sample_format.is_uint());
+            let mut template = vec![0u8; period_bytes as usize].into_boxed_slice();
+            fill_equilibrium(&mut template, sample_format);
+            Self::Template(template)
+        }
+    }
+
+    #[inline]
+    fn fill(&self, buffer: &mut [u8]) {
+        match self {
+            Self::Byte(b) => buffer.fill(*b),
+            Self::Template(t) => buffer.copy_from_slice(t),
+        }
+    }
+}
+
 #[derive(Debug)]
 struct StreamInner {
     // Flag used to check when to stop polling, regardless of the state of the stream
@@ -697,7 +729,7 @@ struct StreamInner {
     period_samples: usize,
     period_frames: usize,
     frame_size: usize,
-    silence_template: Box<[u8]>,
+    equilibrium: EquilibriumFill,
 
     #[allow(dead_code)]
     // Whether or not the hardware supports pausing the stream.
@@ -756,8 +788,9 @@ impl StreamWorkerContext {
             -1 // Don't timeout, wait forever.
         };
 
-        // Pre-allocate buffer to exactly one period size with proper equilibrium values.
-        let transfer_buffer = stream.silence_template.clone();
+        // Pre-allocate a period-sized working buffer. Contents are overwritten each callback.
+        let transfer_buffer =
+            vec![0u8; stream.period_frames * stream.frame_size].into_boxed_slice();
 
         // Pre-allocate and initialize descriptors vector: 1 for self-pipe + stream.num_descriptors
         // for ALSA. The descriptor count is constant for the lifetime of stream parameters, and
@@ -1084,8 +1117,8 @@ fn process_output(
     delay_frames: usize,
     data_callback: &mut (dyn FnMut(&mut Data, &OutputCallbackInfo) + Send + 'static),
 ) -> Result<(), Error> {
-    // Buffer is always pre-filled with equilibrium, user overwrites what they want
-    buffer.copy_from_slice(&stream.silence_template);
+    // Pre-fill buffer with equilibrium; user callback overwrites what it wants.
+    stream.equilibrium.fill(buffer);
     {
         let data = buffer.as_mut_ptr() as *mut ();
         let mut data =

--- a/src/host/asio/device.rs
+++ b/src/host/asio/device.rs
@@ -159,7 +159,7 @@ impl Iterator for Devices {
     type Item = Device;
 
     /// Enumerate devices by briefly loading each driver to capture its metadata.
-    fn next(&mut self) -> Option<Device> {
+    fn next(&mut self) -> Option<Self::Item> {
         // Drop the previously loaded driver before attempting to load the next one.
         self.current_driver = None;
 

--- a/src/host/asio/device.rs
+++ b/src/host/asio/device.rs
@@ -1,23 +1,15 @@
-pub use crate::iter::{SupportedInputConfigs, SupportedOutputConfigs};
+use std::{
+    hash::{Hash, Hasher},
+    sync::{atomic::AtomicU32, Arc, Mutex},
+};
 
 use super::sys;
-use crate::host::com;
-use crate::ChannelCount;
-use crate::DeviceDescription;
-use crate::DeviceDescriptionBuilder;
-use crate::DeviceId;
-use crate::Error;
-use crate::ErrorKind;
-use crate::FrameCount;
-use crate::SampleFormat;
-use crate::SampleRate;
-use crate::SupportedBufferSize;
-use crate::SupportedStreamConfig;
-use crate::SupportedStreamConfigRange;
-
-use std::hash::{Hash, Hasher};
-use std::sync::atomic::AtomicU32;
-use std::sync::{Arc, Mutex};
+pub use crate::iter::{SupportedInputConfigs, SupportedOutputConfigs};
+use crate::{
+    host::com, ChannelCount, DeviceDescription, DeviceDescriptionBuilder, DeviceId, Error,
+    ErrorKind, FrameCount, SampleFormat, SampleRate, SupportedBufferSize, SupportedStreamConfig,
+    SupportedStreamConfigRange,
+};
 
 /// A ASIO Device
 #[derive(Clone)]

--- a/src/host/asio/mod.rs
+++ b/src/host/asio/mod.rs
@@ -5,17 +5,21 @@
 
 extern crate asio_sys as sys;
 
-use crate::host::com;
-use crate::traits::{DeviceTrait, HostTrait, StreamTrait};
-use crate::{
-    Data, DeviceDescription, DeviceId, Error, InputCallbackInfo, OutputCallbackInfo, SampleFormat,
-    StreamConfig, SupportedStreamConfig,
+use std::{
+    sync::{Arc, OnceLock},
+    time::Duration,
 };
 
-pub use self::device::{Device, Devices, SupportedInputConfigs, SupportedOutputConfigs};
-pub use self::stream::Stream;
-use std::sync::{Arc, OnceLock};
-use std::time::Duration;
+pub use self::{
+    device::{Device, Devices, SupportedInputConfigs, SupportedOutputConfigs},
+    stream::Stream,
+};
+use crate::{
+    host::com,
+    traits::{DeviceTrait, HostTrait, StreamTrait},
+    Data, DeviceDescription, DeviceId, Error, FrameCount, InputCallbackInfo, OutputCallbackInfo,
+    SampleFormat, StreamConfig, StreamInstant, SupportedStreamConfig,
+};
 
 mod device;
 mod stream;
@@ -33,7 +37,7 @@ pub struct Host {
 }
 
 impl Host {
-    pub fn new() -> Result<Self, crate::Error> {
+    pub fn new() -> Result<Self, Error> {
         com::com_initialized();
         let asio = GLOBAL_ASIO
             .get_or_init(|| Arc::new(sys::Asio::new()))
@@ -150,11 +154,11 @@ impl StreamTrait for Stream {
         Stream::pause(self)
     }
 
-    fn now(&self) -> crate::StreamInstant {
+    fn now(&self) -> StreamInstant {
         Stream::now(self)
     }
 
-    fn buffer_size(&self) -> Result<crate::FrameCount, Error> {
+    fn buffer_size(&self) -> Result<FrameCount, Error> {
         Stream::buffer_size(self)
     }
 }

--- a/src/host/asio/stream.rs
+++ b/src/host/asio/stream.rs
@@ -1,18 +1,22 @@
 extern crate asio_sys as sys;
 extern crate num_traits;
 
-use crate::host::com;
-use crate::I24;
+use std::{
+    sync::{
+        atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering},
+        Arc, Mutex,
+    },
+    time::Duration,
+};
 
 use self::num_traits::{FromPrimitive, PrimInt};
 use super::Device;
 use crate::{
-    BufferSize, Data, Error, ErrorKind, InputCallbackInfo, OutputCallbackInfo, SampleFormat,
-    StreamConfig, StreamInstant,
+    host::{com, frames_to_duration},
+    BufferSize, Data, Error, ErrorKind, FrameCount, InputCallbackInfo, InputStreamTimestamp,
+    OutputCallbackInfo, OutputStreamTimestamp, SampleFormat, SampleRate, StreamConfig,
+    StreamInstant, I24,
 };
-use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
-use std::sync::{Arc, Mutex};
-use std::time::Duration;
 
 /// Shared state for extending the 32-bit `timeGetTime()` millisecond counter into a
 /// monotonic 64-bit nanosecond value, shared between `now()` and audio callbacks.
@@ -82,7 +86,7 @@ impl Stream {
         Ok(())
     }
 
-    pub fn buffer_size(&self) -> Result<crate::FrameCount, Error> {
+    pub fn buffer_size(&self) -> Result<FrameCount, Error> {
         let streams = self.asio_streams.lock().map_err(|_| {
             Error::with_message(ErrorKind::StreamInvalidated, "stream lock poisoned")
         })?;
@@ -91,7 +95,7 @@ impl Stream {
             .as_ref()
             .or(streams.input.as_ref())
             .expect("ASIO stream has neither input nor output")
-            .buffer_size as crate::FrameCount)
+            .buffer_size as FrameCount)
     }
 }
 
@@ -218,7 +222,7 @@ impl Device {
                 interleaved: &mut [u8],
                 asio_stream: &sys::AsioStream,
                 asio_info: &sys::CallbackInfo,
-                sample_rate: crate::SampleRate,
+                sample_rate: SampleRate,
                 format: SampleFormat,
                 from_endianness: F,
                 hardware_latency_frames: usize,
@@ -544,7 +548,7 @@ impl Device {
                 silence_asio_buffer: bool,
                 asio_stream: &mut sys::AsioStream,
                 asio_info: &sys::CallbackInfo,
-                sample_rate: crate::SampleRate,
+                sample_rate: SampleRate,
                 format: SampleFormat,
                 mix_samples: F,
                 hardware_latency_frames: usize,
@@ -579,6 +583,7 @@ impl Device {
                 }
             }
 
+            interleaved.fill(0);
             match (sample_format, &stream_type) {
                 (SampleFormat::I16, &sys::AsioSampleType::ASIOSTInt16LSB) => {
                     process_output_callback::<i16, _, _>(
@@ -751,8 +756,7 @@ impl Device {
 
                 unsupported_format_pair => unreachable!(
                     "`build_output_stream_raw` should have returned with unsupported \
-                     format {:?}",
-                    unsupported_format_pair
+                     format {unsupported_format_pair:?}"
                 ),
             }
         });
@@ -965,15 +969,6 @@ impl Drop for Stream {
     }
 }
 
-// Convert the given duration in frames at the given sample rate to a `std::time::Duration`.
-#[inline]
-fn frames_to_duration(frames: usize, rate: crate::SampleRate) -> std::time::Duration {
-    let secsf = frames as f64 / rate as f64;
-    let secs = secsf as u64;
-    let nanos = ((secsf - secs as f64) * 1_000_000_000.0) as u32;
-    std::time::Duration::new(secs, nanos)
-}
-
 /// Check whether or not the desired config is supported by the stream.
 ///
 /// Checks sample rate, data type, number of channels, and buffer size.
@@ -1046,17 +1041,20 @@ fn check_config(
 /// Cast a byte slice into a mutable slice of desired type.
 ///
 /// Safety: it's up to the caller to ensure that the input slice has valid bit representations.
+#[inline]
 unsafe fn cast_slice_mut<T>(v: &mut [u8]) -> &mut [T] {
     debug_assert!(v.len() % std::mem::size_of::<T>() == 0);
     std::slice::from_raw_parts_mut(v.as_mut_ptr() as *mut T, v.len() / std::mem::size_of::<T>())
 }
 
 /// Helper function to convert from little endianness.
+#[inline]
 fn from_le<T: PrimInt>(t: T) -> T {
     T::from_le(t)
 }
 
-/// Helper function to convert from little endianness.
+/// Helper function to convert from big endianness.
+#[inline]
 fn from_be<T: PrimInt>(t: T) -> T {
     T::from_be(t)
 }
@@ -1065,6 +1063,7 @@ fn from_be<T: PrimInt>(t: T) -> T {
 ///
 /// The channel length is automatically inferred from the buffer size or some
 /// value can be passed to enforce a certain length (for odd sized sample formats)
+#[inline]
 unsafe fn asio_channel_slice<T>(
     asio_stream: &sys::AsioStream,
     buffer_index: usize,
@@ -1081,6 +1080,7 @@ unsafe fn asio_channel_slice<T>(
 ///
 /// The channel length is automatically inferred from the buffer size or some
 /// value can be passed to enforce a certain length (for odd sized sample formats)
+#[inline]
 unsafe fn asio_channel_slice_mut<T>(
     asio_stream: &mut sys::AsioStream,
     buffer_index: usize,
@@ -1114,6 +1114,7 @@ fn build_stream_err(e: sys::AsioError) -> Error {
 }
 
 /// Convert i24 bytes to i32
+#[inline]
 fn i24_bytes_to_i32(i24_bytes: &[u8; 3], little_endian: bool) -> i32 {
     let sample = if little_endian {
         i32::from_le_bytes([i24_bytes[0], i24_bytes[1], i24_bytes[2], 0u8])
@@ -1135,7 +1136,7 @@ unsafe fn process_output_callback_i24<D>(
     little_endian: bool,
     asio_stream: &mut sys::AsioStream,
     asio_info: &sys::CallbackInfo,
-    sample_rate: crate::SampleRate,
+    sample_rate: SampleRate,
     hardware_latency_frames: usize,
     callback_instant: StreamInstant,
 ) where
@@ -1206,7 +1207,7 @@ unsafe fn process_input_callback_i24<D>(
     interleaved: &mut [u8],
     asio_stream: &sys::AsioStream,
     asio_info: &sys::CallbackInfo,
-    sample_rate: crate::SampleRate,
+    sample_rate: SampleRate,
     little_endian: bool,
     hardware_latency_frames: usize,
     callback_instant: StreamInstant,
@@ -1253,11 +1254,12 @@ unsafe fn process_input_callback_i24<D>(
 }
 
 /// Apply the output callback to the interleaved buffer.
+#[inline]
 unsafe fn apply_output_callback_to_data<A, D>(
     data_callback: &mut D,
     interleaved: &mut [A],
     callback_instant: StreamInstant,
-    sample_rate: crate::SampleRate,
+    sample_rate: SampleRate,
     sample_format: SampleFormat,
     hardware_latency_frames: usize,
 ) where
@@ -1269,9 +1271,9 @@ unsafe fn apply_output_callback_to_data<A, D>(
         interleaved.len(),
         sample_format,
     );
-    let delay = frames_to_duration(hardware_latency_frames, sample_rate);
+    let delay = frames_to_duration(hardware_latency_frames as FrameCount, sample_rate);
     let playback = callback_instant + delay;
-    let timestamp = crate::OutputStreamTimestamp {
+    let timestamp = OutputStreamTimestamp {
         callback: callback_instant,
         playback,
     };
@@ -1280,11 +1282,12 @@ unsafe fn apply_output_callback_to_data<A, D>(
 }
 
 /// Apply the input callback to the interleaved buffer.
+#[inline]
 unsafe fn apply_input_callback_to_data<A, D>(
     data_callback: &mut D,
     interleaved: &mut [A],
     callback_instant: StreamInstant,
-    sample_rate: crate::SampleRate,
+    sample_rate: SampleRate,
     format: SampleFormat,
     hardware_latency_frames: usize,
 ) where
@@ -1296,11 +1299,11 @@ unsafe fn apply_input_callback_to_data<A, D>(
         interleaved.len(),
         format,
     );
-    let delay = frames_to_duration(hardware_latency_frames, sample_rate);
+    let delay = frames_to_duration(hardware_latency_frames as FrameCount, sample_rate);
     let capture = callback_instant
         .checked_sub(delay)
         .unwrap_or(StreamInstant::ZERO);
-    let timestamp = crate::InputStreamTimestamp {
+    let timestamp = InputStreamTimestamp {
         callback: callback_instant,
         capture,
     };

--- a/src/host/audioworklet/mod.rs
+++ b/src/host/audioworklet/mod.rs
@@ -400,7 +400,7 @@ impl Iterator for Devices {
     fn next(&mut self) -> Option<Self::Item> {
         if self.0 {
             self.0 = false;
-            Some(Self::Item)
+            Some(Device)
         } else {
             None
         }

--- a/src/host/audioworklet/mod.rs
+++ b/src/host/audioworklet/mod.rs
@@ -48,11 +48,11 @@ const SUPPORTED_SAMPLE_FORMAT: SampleFormat = SampleFormat::F32;
 const DEFAULT_RENDER_SIZE: u64 = 128;
 
 impl Host {
-    pub fn new() -> Result<Self, crate::Error> {
+    pub fn new() -> Result<Self, Error> {
         if Self::is_available() {
             Ok(Host)
         } else {
-            Err(crate::Error::with_message(
+            Err(Error::with_message(
                 ErrorKind::HostUnavailable,
                 "AudioWorklet API is not available",
             ))

--- a/src/host/audioworklet/mod.rs
+++ b/src/host/audioworklet/mod.rs
@@ -3,24 +3,28 @@
 //! Available on WebAssembly with the `audioworklet` feature. Requires atomics support.
 //! See the `audioworklet-beep` example for setup instructions.
 
-mod dependent_module;
-use js_sys::wasm_bindgen;
-use std::sync::{
-    atomic::{AtomicU64, Ordering},
-    Arc,
+use std::{
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc,
+    },
+    time::Duration,
 };
 
-use crate::dependent_module;
+use js_sys::wasm_bindgen;
 use wasm_bindgen::prelude::*;
 
-use crate::traits::{DeviceTrait, HostTrait, StreamTrait};
 use crate::{
-    ChannelCount, Data, DeviceDescription, DeviceDescriptionBuilder, DeviceId, Error, ErrorKind,
-    InputCallbackInfo, OutputCallbackInfo, SampleFormat, SampleRate, StreamConfig, StreamInstant,
+    host::frames_to_duration,
+    traits::{DeviceTrait, HostTrait, StreamTrait},
+    BufferSize, ChannelCount, Data, DeviceDescription, DeviceDescriptionBuilder, DeviceDirection,
+    DeviceId, Error, ErrorKind, FrameCount, InputCallbackInfo, OutputCallbackInfo,
+    OutputStreamTimestamp, SampleFormat, SampleRate, StreamConfig, StreamInstant,
     SupportedBufferSize, SupportedStreamConfig, SupportedStreamConfigRange,
 };
 
-use std::time::Duration;
+mod dependent_module;
+use crate::dependent_module;
 
 /// Content is false if the iterator is empty.
 pub struct Devices(bool);
@@ -106,14 +110,12 @@ impl DeviceTrait for Device {
     type SupportedOutputConfigs = SupportedOutputConfigs;
     type Stream = Stream;
 
-    #[inline]
     fn description(&self) -> Result<DeviceDescription, Error> {
         Ok(DeviceDescriptionBuilder::new("Default Device".to_string())
-            .direction(crate::DeviceDirection::Output)
+            .direction(DeviceDirection::Output)
             .build())
     }
 
-    #[inline]
     fn id(&self) -> Result<DeviceId, Error> {
         Ok(DeviceId(
             crate::platform::HostId::AudioWorklet,
@@ -121,13 +123,11 @@ impl DeviceTrait for Device {
         ))
     }
 
-    #[inline]
     fn supported_input_configs(&self) -> Result<Self::SupportedInputConfigs, Error> {
         // TODO
         Ok(Vec::new().into_iter())
     }
 
-    #[inline]
     fn supported_output_configs(&self) -> Result<Self::SupportedOutputConfigs, Error> {
         let buffer_size = SupportedBufferSize::Unknown;
 
@@ -146,7 +146,6 @@ impl DeviceTrait for Device {
         Ok(configs.into_iter())
     }
 
-    #[inline]
     fn default_input_config(&self) -> Result<SupportedStreamConfig, Error> {
         Err(Error::with_message(
             ErrorKind::UnsupportedOperation,
@@ -154,7 +153,6 @@ impl DeviceTrait for Device {
         ))
     }
 
-    #[inline]
     fn default_output_config(&self) -> Result<SupportedStreamConfig, Error> {
         const EXPECT: &str = "expected at least one valid webaudio stream config";
         let config = self
@@ -239,7 +237,7 @@ impl DeviceTrait for Device {
 
         let stream_opts = web_sys::AudioContextOptions::new();
         stream_opts.set_sample_rate(config.sample_rate as f32);
-        if let crate::BufferSize::Fixed(n) = config.buffer_size {
+        if let BufferSize::Fixed(n) = config.buffer_size {
             let _ = js_sys::Reflect::set(
                 stream_opts.as_ref(),
                 &JsValue::from_str("renderSizeHint"),
@@ -260,8 +258,8 @@ impl DeviceTrait for Device {
         }
 
         let initial_quantum = match config.buffer_size {
-            crate::BufferSize::Fixed(n) => n as u64,
-            crate::BufferSize::Default => DEFAULT_RENDER_SIZE,
+            BufferSize::Fixed(n) => n as u64,
+            BufferSize::Default => DEFAULT_RENDER_SIZE,
         };
         let buffer_size_frames = Arc::new(AtomicU64::new(initial_quantum));
         let buffer_size_frames_cb = buffer_size_frames.clone();
@@ -314,11 +312,12 @@ impl DeviceTrait for Device {
                             };
 
                             let callback = StreamInstant::from_secs_f64(now);
-                            let buffer_duration = frames_to_duration(frame_size as _, sample_rate);
+                            let buffer_duration =
+                                frames_to_duration(frame_size as FrameCount, sample_rate);
                             let playback = callback
                                 + (buffer_duration
                                     + Duration::from_secs_f64(total_output_latency_secs));
-                            let timestamp = crate::OutputStreamTimestamp { callback, playback };
+                            let timestamp = OutputStreamTimestamp { callback, playback };
                             let info = OutputCallbackInfo { timestamp };
                             (data_callback)(&mut data, &info);
                         },
@@ -354,8 +353,8 @@ impl DeviceTrait for Device {
 }
 
 impl StreamTrait for Stream {
-    fn buffer_size(&self) -> Result<crate::FrameCount, Error> {
-        Ok(self.buffer_size_frames.load(Ordering::Relaxed) as crate::FrameCount)
+    fn buffer_size(&self) -> Result<FrameCount, Error> {
+        Ok(self.buffer_size_frames.load(Ordering::Relaxed) as FrameCount)
     }
 
     fn play(&self) -> Result<(), Error> {
@@ -397,7 +396,6 @@ impl Default for Devices {
 
 impl Iterator for Devices {
     type Item = Device;
-    #[inline]
     fn next(&mut self) -> Option<Device> {
         if self.0 {
             self.0 = false;
@@ -406,14 +404,6 @@ impl Iterator for Devices {
             None
         }
     }
-}
-
-// Convert the given duration in frames at the given sample rate to a `std::time::Duration`.
-fn frames_to_duration(frames: usize, rate: crate::SampleRate) -> std::time::Duration {
-    let secsf = frames as f64 / rate as f64;
-    let secs = secsf as u64;
-    let nanos = ((secsf - secs as f64) * 1_000_000_000.0) as u32;
-    std::time::Duration::new(secs, nanos)
 }
 
 type AudioProcessorCallback = Box<dyn FnMut(&mut [f32], u32, u32, f64)>;

--- a/src/host/audioworklet/mod.rs
+++ b/src/host/audioworklet/mod.rs
@@ -345,7 +345,7 @@ impl DeviceTrait for Device {
             }
         });
 
-        Ok(Stream {
+        Ok(Self::Stream {
             audio_context,
             buffer_size_frames,
         })
@@ -389,17 +389,18 @@ impl Drop for Stream {
 }
 
 impl Default for Devices {
-    fn default() -> Devices {
-        Devices(true)
+    fn default() -> Self {
+        Self(true)
     }
 }
 
 impl Iterator for Devices {
     type Item = Device;
-    fn next(&mut self) -> Option<Device> {
+
+    fn next(&mut self) -> Option<Self::Item> {
         if self.0 {
             self.0 = false;
-            Some(Device)
+            Some(Self::Item)
         } else {
             None
         }

--- a/src/host/com.rs
+++ b/src/host/com.rs
@@ -1,10 +1,11 @@
 //! Handles COM initialization and cleanup.
 
-use std::io::Error as IoError;
-use std::marker::PhantomData;
+use std::{io::Error as IoError, marker::PhantomData};
 
-use windows::Win32::Foundation::RPC_E_CHANGED_MODE;
-use windows::Win32::System::Com::{CoInitializeEx, CoUninitialize, COINIT_APARTMENTTHREADED};
+use windows::Win32::{
+    Foundation::RPC_E_CHANGED_MODE,
+    System::Com::{CoInitializeEx, CoUninitialize, COINIT_APARTMENTTHREADED},
+};
 
 thread_local!(static COM_INITIALIZED: ComInitialized = {
     unsafe {
@@ -50,7 +51,6 @@ impl Drop for ComInitialized {
 }
 
 /// Ensures that COM is initialized in this thread.
-#[inline]
 pub fn com_initialized() {
     COM_INITIALIZED.with(|_| {});
 }

--- a/src/host/coreaudio/ios/enumerate.rs
+++ b/src/host/coreaudio/ios/enumerate.rs
@@ -1,7 +1,6 @@
 use std::vec::IntoIter as VecIntoIter;
 
 use super::Device;
-
 pub use crate::iter::{SupportedInputConfigs, SupportedOutputConfigs};
 
 // TODO: Support enumerating earpiece vs headset vs speaker etc?

--- a/src/host/coreaudio/ios/enumerate.rs
+++ b/src/host/coreaudio/ios/enumerate.rs
@@ -13,15 +13,15 @@ impl Devices {
 }
 
 impl Default for Devices {
-    fn default() -> Devices {
-        Devices(vec![Device].into_iter())
+    fn default() -> Self {
+        Self(vec![Device].into_iter())
     }
 }
 
 impl Iterator for Devices {
     type Item = Device;
 
-    fn next(&mut self) -> Option<Device> {
+    fn next(&mut self) -> Option<Self::Item> {
         self.0.next()
     }
 }

--- a/src/host/coreaudio/ios/mod.rs
+++ b/src/host/coreaudio/ios/mod.rs
@@ -1,29 +1,31 @@
 //! CoreAudio implementation for iOS using AVAudioSession and RemoteIO Audio Units.
 
-use std::ptr::NonNull;
-use std::sync::Arc;
-use std::sync::Mutex;
-use std::time::Duration;
+use std::{
+    ptr::NonNull,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
 
-use coreaudio::audio_unit::render_callback::data;
-use coreaudio::audio_unit::{render_callback, AudioUnit, Element, Scope};
+use coreaudio::audio_unit::{
+    render_callback::{self, data},
+    AudioUnit, Element, Scope,
+};
 use objc2_audio_toolbox::{kAudioOutputUnitProperty_EnableIO, kAudioUnitProperty_StreamFormat};
 use objc2_avf_audio::AVAudioSession;
 use objc2_core_audio_types::AudioBuffer;
 
-use super::{asbd_from_config, frames_to_duration, host_time_to_stream_instant};
-use crate::traits::{DeviceTrait, HostTrait, StreamTrait};
-
-use crate::{
-    error::ResultExt, BufferSize, ChannelCount, Data, DeviceDescription, DeviceDescriptionBuilder,
-    DeviceId, Error, ErrorKind, InputCallbackInfo, OutputCallbackInfo, SampleFormat, SampleRate,
-    StreamConfig, StreamInstant, SupportedBufferSize, SupportedStreamConfig,
-    SupportedStreamConfigRange,
-};
-
 use self::enumerate::{
     default_input_device, default_output_device, Devices, SupportedInputConfigs,
     SupportedOutputConfigs,
+};
+use super::{asbd_from_config, host_time_to_stream_instant};
+use crate::{
+    host::frames_to_duration,
+    traits::{DeviceTrait, HostTrait, StreamTrait},
+    BufferSize, ChannelCount, Data, DeviceDescription, DeviceDescriptionBuilder, DeviceId, Error,
+    ErrorKind, FrameCount, InputCallbackInfo, InputStreamTimestamp, OutputCallbackInfo,
+    OutputStreamTimestamp, ResultExt, SampleFormat, SampleRate, StreamConfig, StreamInstant,
+    SupportedBufferSize, SupportedStreamConfig, SupportedStreamConfigRange,
 };
 
 pub mod enumerate;
@@ -39,7 +41,7 @@ pub struct Device;
 pub struct Host;
 
 impl Host {
-    pub fn new() -> Result<Self, crate::Error> {
+    pub fn new() -> Result<Self, Error> {
         Ok(Host)
     }
 }
@@ -295,8 +297,8 @@ impl StreamTrait for Stream {
         host_time_to_stream_instant(m_host_time).expect("mach_timebase_info failed")
     }
 
-    fn buffer_size(&self) -> Result<crate::FrameCount, Error> {
-        Ok(get_device_buffer_frames() as crate::FrameCount)
+    fn buffer_size(&self) -> Result<FrameCount, Error> {
+        Ok(get_device_buffer_frames() as FrameCount)
     }
 }
 
@@ -335,8 +337,8 @@ fn configure_for_recording(audio_unit: &mut AudioUnit) -> Result<(), coreaudio::
 ///
 /// Note: iOS may not honor the exact request due to system constraints.
 fn set_audio_session_buffer_size(
-    buffer_size: u32,
-    sample_rate: crate::SampleRate,
+    buffer_size: FrameCount,
+    sample_rate: SampleRate,
 ) -> Result<(), Error> {
     // SAFETY: AVAudioSession::sharedInstance() returns the global audio session singleton
     let audio_session = unsafe { AVAudioSession::sharedInstance() };
@@ -379,11 +381,11 @@ fn get_supported_stream_configs(is_input: bool) -> std::vec::IntoIter<SupportedS
     // SAFETY: AVAudioSession methods are safe to call on the singleton instance
     let (sample_rate, max_channels) = unsafe {
         let audio_session = AVAudioSession::sharedInstance();
-        let sample_rate = audio_session.sampleRate() as u32;
+        let sample_rate = audio_session.sampleRate() as SampleRate;
         let max_channels = if is_input {
-            audio_session.inputNumberOfChannels() as u16
+            audio_session.inputNumberOfChannels() as ChannelCount
         } else {
-            audio_session.outputNumberOfChannels() as u16
+            audio_session.outputNumberOfChannels() as ChannelCount
         };
         (sample_rate, max_channels)
     };
@@ -517,9 +519,9 @@ where
             let channels = buffer.mNumberChannels as usize;
             data.len().checked_div(channels).unwrap_or(0)
         });
-        let delay = frames_to_duration(latency_frames, sample_rate);
+        let delay = frames_to_duration(latency_frames as FrameCount, sample_rate);
         let capture = callback.checked_sub(delay).unwrap_or(StreamInstant::ZERO);
-        let timestamp = crate::InputStreamTimestamp { callback, capture };
+        let timestamp = InputStreamTimestamp { callback, capture };
 
         let info = InputCallbackInfo { timestamp };
         data_callback(&data, &info);
@@ -562,9 +564,9 @@ where
             let channels = buffer.mNumberChannels as usize;
             data.len().checked_div(channels).unwrap_or(0)
         });
-        let delay = frames_to_duration(latency_frames, sample_rate);
+        let delay = frames_to_duration(latency_frames as FrameCount, sample_rate);
         let playback = callback + delay;
-        let timestamp = crate::OutputStreamTimestamp { callback, playback };
+        let timestamp = OutputStreamTimestamp { callback, playback };
 
         let info = OutputCallbackInfo { timestamp };
         data_callback(&mut data, &info);
@@ -591,7 +593,7 @@ mod tests {
 
         let result = device.build_output_stream(
             &config,
-            |_data: &mut [f32], _info: &crate::OutputCallbackInfo| {},
+            |_data: &mut [f32], _info: &OutputCallbackInfo| {},
             |_err| {},
             None,
         );

--- a/src/host/coreaudio/ios/session_event_manager.rs
+++ b/src/host/coreaudio/ios/session_event_manager.rs
@@ -1,7 +1,9 @@
 //! Monitors AVAudioSession lifecycle events and reports them as stream errors.
 
-use std::ptr::NonNull;
-use std::sync::{Arc, Mutex};
+use std::{
+    ptr::NonNull,
+    sync::{Arc, Mutex},
+};
 
 use block2::RcBlock;
 use objc2::runtime::AnyObject;

--- a/src/host/coreaudio/macos/device.rs
+++ b/src/host/coreaudio/macos/device.rs
@@ -1,13 +1,18 @@
 use super::Stream;
-use super::{asbd_from_config, check_os_status, frames_to_duration, host_time_to_stream_instant};
-use crate::host::coreaudio::macos::loopback::LoopbackDevice;
-use crate::host::coreaudio::macos::StreamInner;
-use crate::traits::DeviceTrait;
+use super::{asbd_from_config, check_os_status, host_time_to_stream_instant};
+
 use crate::{
-    error::ResultExt, BufferSize, ChannelCount, Data, DeviceId, Error, ErrorKind,
-    InputCallbackInfo, OutputCallbackInfo, SampleFormat, SampleRate, StreamConfig,
-    SupportedBufferSize, SupportedStreamConfig, SupportedStreamConfigRange,
+    host::{
+        coreaudio::macos::{loopback::LoopbackDevice, StreamInner},
+        frames_to_duration,
+    },
+    traits::DeviceTrait,
+    BufferSize, ChannelCount, Data, DeviceDescription, DeviceDescriptionBuilder, DeviceId, Error,
+    ErrorKind, FrameCount, InputCallbackInfo, InputStreamTimestamp, InterfaceType,
+    OutputCallbackInfo, OutputStreamTimestamp, ResultExt, SampleFormat, SampleRate, StreamConfig,
+    StreamInstant, SupportedBufferSize, SupportedStreamConfig, SupportedStreamConfigRange,
 };
+
 use coreaudio::audio_unit::audio_format::LinearPcmFlags;
 use coreaudio::audio_unit::macos_helpers::{
     find_matching_physical_format, set_device_physical_stream_format, RateListener,
@@ -272,7 +277,7 @@ impl DeviceTrait for Device {
     type SupportedOutputConfigs = SupportedOutputConfigs;
     type Stream = Stream;
 
-    fn description(&self) -> Result<crate::DeviceDescription, Error> {
+    fn description(&self) -> Result<DeviceDescription, Error> {
         Device::description(self)
     }
 
@@ -406,11 +411,11 @@ impl Device {
         let direction =
             crate::device_description::direction_from_counts(input_configs, output_configs);
 
-        let mut builder = crate::DeviceDescriptionBuilder::new(name).direction(direction);
+        let mut builder = DeviceDescriptionBuilder::new(name).direction(direction);
 
         // Check if this is an aggregate device
         if self.is_aggregate_device() {
-            builder = builder.interface_type(crate::InterfaceType::Aggregate);
+            builder = builder.interface_type(InterfaceType::Aggregate);
         }
 
         Ok(builder.build())
@@ -787,11 +792,9 @@ impl Device {
             let buffer_frames = len / channels as usize;
             let latency_frames =
                 device_buffer_frames.unwrap_or(buffer_frames) + extra_latency_frames;
-            let delay = frames_to_duration(latency_frames, sample_rate);
-            let capture = callback
-                .checked_sub(delay)
-                .unwrap_or(crate::StreamInstant::ZERO);
-            let timestamp = crate::InputStreamTimestamp { callback, capture };
+            let delay = frames_to_duration(latency_frames as FrameCount, sample_rate);
+            let capture = callback.checked_sub(delay).unwrap_or(StreamInstant::ZERO);
+            let timestamp = InputStreamTimestamp { callback, capture };
 
             let info = InputCallbackInfo { timestamp };
             data_callback(&data, &info);
@@ -897,9 +900,9 @@ impl Device {
             // Use device buffer size for latency calculation if available
             let latency_frames =
                 device_buffer_frames.unwrap_or(buffer_frames) + extra_latency_frames;
-            let delay = frames_to_duration(latency_frames, sample_rate);
+            let delay = frames_to_duration(latency_frames as FrameCount, sample_rate);
             let playback = callback + delay;
-            let timestamp = crate::OutputStreamTimestamp { callback, playback };
+            let timestamp = OutputStreamTimestamp { callback, playback };
 
             let info = OutputCallbackInfo { timestamp };
             data_callback(&mut data, &info);
@@ -995,7 +998,7 @@ fn setup_callback_vars(
     config: StreamConfig,
     sample_format: SampleFormat,
     scope: Scope,
-) -> (usize, crate::SampleRate, Option<usize>, usize) {
+) -> (usize, SampleRate, Option<usize>, usize) {
     let bytes_per_channel = sample_format.sample_size();
     let sample_rate = config.sample_rate;
 

--- a/src/host/coreaudio/macos/enumerate.rs
+++ b/src/host/coreaudio/macos/enumerate.rs
@@ -13,6 +13,7 @@ use objc2_core_audio::{
 };
 
 use super::{check_os_status, Device};
+pub use crate::iter::{SupportedInputConfigs, SupportedOutputConfigs};
 use crate::Error;
 
 unsafe fn audio_devices() -> Result<Vec<AudioDeviceID>, Error> {
@@ -64,15 +65,15 @@ pub struct Devices(VecIntoIter<AudioDeviceID>);
 impl Devices {
     pub fn new() -> Result<Self, Error> {
         let devices = unsafe { audio_devices() }?;
-        Ok(Devices(devices.into_iter()))
+        Ok(Self(devices.into_iter()))
     }
 }
 
 impl Iterator for Devices {
     type Item = Device;
 
-    fn next(&mut self) -> Option<Device> {
-        self.0.next().map(|id| Device {
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next().map(|id| Self::Item {
             audio_device_id: id,
         })
     }
@@ -131,5 +132,3 @@ pub fn default_output_device() -> Option<Device> {
     let device = Device { audio_device_id };
     Some(device)
 }
-
-pub use crate::iter::{SupportedInputConfigs, SupportedOutputConfigs};

--- a/src/host/coreaudio/macos/enumerate.rs
+++ b/src/host/coreaudio/macos/enumerate.rs
@@ -1,5 +1,9 @@
-use super::{check_os_status, Device};
-use crate::Error;
+use std::{
+    mem,
+    ptr::{null, NonNull},
+    vec::IntoIter as VecIntoIter,
+};
+
 use objc2_core_audio::{
     kAudioHardwareNoError, kAudioHardwarePropertyDefaultInputDevice,
     kAudioHardwarePropertyDefaultOutputDevice, kAudioHardwarePropertyDevices,
@@ -7,9 +11,9 @@ use objc2_core_audio::{
     AudioDeviceID, AudioObjectGetPropertyData, AudioObjectGetPropertyDataSize, AudioObjectID,
     AudioObjectPropertyAddress,
 };
-use std::mem;
-use std::ptr::{null, NonNull};
-use std::vec::IntoIter as VecIntoIter;
+
+use super::{check_os_status, Device};
+use crate::Error;
 
 unsafe fn audio_devices() -> Result<Vec<AudioDeviceID>, Error> {
     let property_address = AudioObjectPropertyAddress {

--- a/src/host/coreaudio/macos/loopback.rs
+++ b/src/host/coreaudio/macos/loopback.rs
@@ -1,7 +1,11 @@
 //! Manages loopback recording (recording system audio output)
 
-use super::device::Device;
-use crate::{host::coreaudio::check_os_status, Error, ErrorKind};
+use std::{
+    ffi::{c_void, CStr},
+    mem::MaybeUninit,
+    ptr::NonNull,
+};
+
 use objc2::{rc::Retained, AnyThread};
 use objc2_core_audio::{
     kAudioAggregateDeviceNameKey, kAudioAggregateDeviceTapAutoStartKey,
@@ -19,11 +23,9 @@ use objc2_core_foundation::{
     CFString, CFStringCreateWithCString,
 };
 use objc2_foundation::{ns_string, NSArray, NSNumber, NSString};
-use std::{
-    ffi::{c_void, CStr},
-    mem::MaybeUninit,
-    ptr::NonNull,
-};
+
+use super::device::Device;
+use crate::{host::coreaudio::check_os_status, Error, ErrorKind};
 type CFStringRef = *mut std::os::raw::c_void;
 
 impl Device {

--- a/src/host/coreaudio/macos/mod.rs
+++ b/src/host/coreaudio/macos/mod.rs
@@ -264,7 +264,7 @@ impl StreamTrait for Stream {
         })?;
         device::get_device_buffer_frame_size(&stream.audio_unit)
             .map(|size| size as FrameCount)
-            .map_err(Error::from)
+            .context("failed to get buffer frame size")
     }
 }
 

--- a/src/host/coreaudio/macos/mod.rs
+++ b/src/host/coreaudio/macos/mod.rs
@@ -1,21 +1,21 @@
 #![allow(deprecated)]
-use super::{asbd_from_config, check_os_status, frames_to_duration, host_time_to_stream_instant};
-
-use super::OSStatus;
-use crate::host::coreaudio::macos::loopback::LoopbackDevice;
-use crate::traits::{HostTrait, StreamTrait};
-use crate::{error::ResultExt, Error, ErrorKind};
-use coreaudio::audio_unit::AudioUnit;
-use objc2_core_audio::AudioDeviceID;
 use std::sync::{mpsc, Arc, Mutex, Weak};
 
-pub use self::enumerate::{default_input_device, default_output_device, Devices};
-
+use coreaudio::audio_unit::AudioUnit;
 use objc2_core_audio::{
     kAudioDevicePropertyDeviceIsAlive, kAudioDevicePropertyNominalSampleRate,
-    kAudioObjectPropertyElementMain, kAudioObjectPropertyScopeGlobal, AudioObjectPropertyAddress,
+    kAudioObjectPropertyElementMain, kAudioObjectPropertyScopeGlobal, AudioDeviceID,
+    AudioObjectPropertyAddress,
 };
 use property_listener::AudioObjectPropertyListener;
+
+pub use self::enumerate::{default_input_device, default_output_device, Devices};
+use super::{asbd_from_config, check_os_status, host_time_to_stream_instant, OSStatus};
+use crate::{
+    host::coreaudio::macos::loopback::LoopbackDevice,
+    traits::{HostTrait, StreamTrait},
+    Error, ErrorKind, FrameCount, ResultExt, StreamInstant,
+};
 
 mod device;
 pub mod enumerate;
@@ -28,7 +28,7 @@ pub use device::Device;
 pub struct Host;
 
 impl Host {
-    pub fn new() -> Result<Self, crate::Error> {
+    pub fn new() -> Result<Self, Error> {
         Ok(Host)
     }
 }
@@ -253,18 +253,18 @@ impl StreamTrait for Stream {
             .pause()
     }
 
-    fn now(&self) -> crate::StreamInstant {
+    fn now(&self) -> StreamInstant {
         let m_host_time = unsafe { mach2::mach_time::mach_absolute_time() };
         host_time_to_stream_instant(m_host_time).expect("mach_timebase_info failed")
     }
 
-    fn buffer_size(&self) -> Result<crate::FrameCount, Error> {
+    fn buffer_size(&self) -> Result<FrameCount, Error> {
         let stream = self.inner.lock().map_err(|_| {
             Error::with_message(ErrorKind::StreamInvalidated, "stream lock poisoned")
         })?;
         device::get_device_buffer_frame_size(&stream.audio_unit)
-            .map(|size| size as crate::FrameCount)
-            .context("failed to get buffer frame size")
+            .map(|size| size as FrameCount)
+            .map_err(Error::from)
     }
 }
 
@@ -273,7 +273,7 @@ mod test {
     use crate::{
         default_host,
         traits::{DeviceTrait, HostTrait, StreamTrait},
-        Sample,
+        InputCallbackInfo, OutputCallbackInfo, Sample,
     };
 
     #[test]
@@ -320,7 +320,7 @@ mod test {
         let stream = device
             .build_input_stream(
                 config,
-                move |data: &[f32], _: &crate::InputCallbackInfo| {
+                move |data: &[f32], _: &InputCallbackInfo| {
                     // react to stream events and read or write stream data here.
                     println!("Got data: {:?}", &data[..25]);
                 },
@@ -353,7 +353,7 @@ mod test {
         let stream = device
             .build_input_stream(
                 config,
-                move |data: &[f32], _: &crate::InputCallbackInfo| {
+                move |data: &[f32], _: &InputCallbackInfo| {
                     // react to stream events and read or write stream data here.
                     println!("Got data: {:?}", &data[..25]);
                 },
@@ -365,7 +365,7 @@ mod test {
         std::thread::sleep(std::time::Duration::from_secs(1));
     }
 
-    fn write_silence<T: Sample>(data: &mut [T], _: &crate::OutputCallbackInfo) {
+    fn write_silence<T: Sample>(data: &mut [T], _: &OutputCallbackInfo) {
         for sample in data.iter_mut() {
             *sample = Sample::EQUILIBRIUM;
         }

--- a/src/host/coreaudio/mod.rs
+++ b/src/host/coreaudio/mod.rs
@@ -7,7 +7,7 @@ use objc2_core_audio_types::{
     kAudioFormatLinearPCM, AudioStreamBasicDescription,
 };
 
-use crate::{Error, ErrorKind, SampleFormat, StreamConfig};
+use crate::{Error, ErrorKind, SampleFormat, StreamConfig, StreamInstant};
 
 // iOS and tvOS share the same CoreAudio / AudioUnit surface (RemoteIO,
 // AVAudioSession), so both target the `ios` submodule.
@@ -22,7 +22,6 @@ pub use self::ios::{
     enumerate::{Devices, SupportedInputConfigs, SupportedOutputConfigs},
     Device, Host, Stream,
 };
-
 #[cfg(target_os = "macos")]
 pub use self::macos::{Host, Stream};
 
@@ -67,7 +66,7 @@ fn asbd_from_config(
 }
 
 #[inline]
-fn host_time_to_stream_instant(m_host_time: u64) -> Result<crate::StreamInstant, Error> {
+fn host_time_to_stream_instant(m_host_time: u64) -> Result<StreamInstant, Error> {
     let mut info: mach2::mach_time::mach_timebase_info = Default::default();
     let res = unsafe { mach2::mach_time::mach_timebase_info(&mut info) };
     check_os_status(res)?;
@@ -75,16 +74,7 @@ fn host_time_to_stream_instant(m_host_time: u64) -> Result<crate::StreamInstant,
     let secs = u64::try_from(nanos / 1_000_000_000)
         .map_err(|_| Error::with_message(ErrorKind::Other, "mach absolute time overflow"))?;
     let subsec_nanos = (nanos % 1_000_000_000) as u32;
-    Ok(crate::StreamInstant::new(secs, subsec_nanos))
-}
-
-// Convert the given duration in frames at the given sample rate to a `std::time::Duration`.
-#[inline]
-fn frames_to_duration(frames: usize, rate: crate::SampleRate) -> std::time::Duration {
-    let secsf = frames as f64 / rate as f64;
-    let secs = secsf as u64;
-    let nanos = ((secsf - secs as f64) * 1_000_000_000.0) as u32;
-    std::time::Duration::new(secs, nanos)
+    Ok(StreamInstant::new(secs, subsec_nanos))
 }
 
 impl From<coreaudio::Error> for Error {

--- a/src/host/custom/mod.rs
+++ b/src/host/custom/mod.rs
@@ -3,12 +3,14 @@
 //! Allows user-defined host implementations with the `custom` feature.
 //! See `examples/custom.rs` for usage.
 
-use crate::traits::{DeviceTrait, HostTrait, StreamTrait};
-use crate::{
-    Data, DeviceDescription, DeviceId, Error, InputCallbackInfo, OutputCallbackInfo, SampleFormat,
-    StreamConfig, StreamInstant, SupportedStreamConfig, SupportedStreamConfigRange,
-};
 use core::time::Duration;
+
+use crate::{
+    traits::{DeviceTrait, HostTrait, StreamTrait},
+    Data, DeviceDescription, DeviceId, Error, ErrorKind, FrameCount, InputCallbackInfo,
+    OutputCallbackInfo, SampleFormat, StreamConfig, StreamInstant, SupportedStreamConfig,
+    SupportedStreamConfigRange,
+};
 
 /// A host that can be used to write custom [`HostTrait`] implementations.
 ///
@@ -27,8 +29,8 @@ pub struct Host(Box<dyn HostErased>);
 
 impl Host {
     // this only exists for impl_platform_host, which requires it
-    pub(crate) fn new() -> Result<Self, crate::Error> {
-        Err(crate::Error::new(crate::ErrorKind::HostUnavailable))
+    pub(crate) fn new() -> Result<Self, Error> {
+        Err(Error::new(ErrorKind::HostUnavailable))
     }
 
     /// Construct a custom host from an arbitrary [`HostTrait`] implementation.
@@ -176,7 +178,7 @@ trait StreamErased: Send + Sync {
     fn play(&self) -> Result<(), Error>;
     fn pause(&self) -> Result<(), Error>;
     fn now(&self) -> StreamInstant;
-    fn buffer_size(&self) -> Result<crate::FrameCount, Error>;
+    fn buffer_size(&self) -> Result<FrameCount, Error>;
 }
 
 fn device_to_erased(d: impl DeviceErased + 'static) -> Device {
@@ -317,7 +319,7 @@ where
         <T as StreamTrait>::now(self)
     }
 
-    fn buffer_size(&self) -> Result<crate::FrameCount, Error> {
+    fn buffer_size(&self) -> Result<FrameCount, Error> {
         <T as StreamTrait>::buffer_size(self)
     }
 }
@@ -444,7 +446,7 @@ impl StreamTrait for Stream {
         self.0.now()
     }
 
-    fn buffer_size(&self) -> Result<crate::FrameCount, Error> {
+    fn buffer_size(&self) -> Result<FrameCount, Error> {
         self.0.buffer_size()
     }
 }

--- a/src/host/equilibrium.rs
+++ b/src/host/equilibrium.rs
@@ -1,0 +1,56 @@
+use crate::{Sample, SampleFormat, U24};
+
+pub const DSD_EQUILIBRIUM_BYTE: u8 = 0x69;
+pub const U8_EQUILIBRIUM_BYTE: u8 = 0x80;
+
+/// Fill `buffer` with the equilibrium value for any `sample_format`.
+#[inline]
+pub fn fill_equilibrium(buffer: &mut [u8], sample_format: SampleFormat) {
+    macro_rules! fill_typed {
+        ($sample_type:ty) => {{
+            let sample_size = std::mem::size_of::<$sample_type>();
+
+            debug_assert_eq!(
+                buffer.len() % sample_size,
+                0,
+                "Buffer size must be aligned to sample size for format {:?}",
+                sample_format
+            );
+
+            let num_samples = buffer.len() / sample_size;
+            let equilibrium = <$sample_type as Sample>::EQUILIBRIUM;
+
+            // Safety: buffer length is verified to be a multiple of the sample size above.
+            let samples = unsafe {
+                std::slice::from_raw_parts_mut(
+                    buffer.as_mut_ptr() as *mut $sample_type,
+                    num_samples,
+                )
+            };
+
+            for sample in samples {
+                *sample = equilibrium;
+            }
+        }};
+    }
+
+    if sample_format.is_int() || sample_format.is_float() {
+        buffer.fill(0);
+    } else if sample_format == SampleFormat::U8 {
+        buffer.fill(U8_EQUILIBRIUM_BYTE);
+    } else if sample_format.is_dsd() {
+        buffer.fill(DSD_EQUILIBRIUM_BYTE);
+    } else {
+        // Multi-byte unsigned integer formats require a fill equal to the midpoint of their range.
+        debug_assert!(sample_format.is_uint());
+        match sample_format {
+            SampleFormat::U16 => fill_typed!(u16),
+            SampleFormat::U24 => fill_typed!(U24),
+            SampleFormat::U32 => fill_typed!(u32),
+            SampleFormat::U64 => fill_typed!(u64),
+            _ => unimplemented!(
+                "failed to fill equilibrium for unsupported unsigned format {sample_format:?}"
+            ),
+        }
+    }
+}

--- a/src/host/jack/device.rs
+++ b/src/host/jack/device.rs
@@ -1,16 +1,16 @@
-use crate::traits::DeviceTrait;
-use crate::{
-    Data, DeviceDescription, DeviceDescriptionBuilder, DeviceDirection, DeviceId, Error, ErrorKind,
-    InputCallbackInfo, OutputCallbackInfo, SampleFormat, SampleRate, StreamConfig,
-    SupportedBufferSize, SupportedStreamConfig, SupportedStreamConfigRange,
+use std::{
+    hash::{Hash, Hasher},
+    time::Duration,
 };
-use std::hash::{Hash, Hasher};
-use std::time::Duration;
 
-use super::stream::Stream;
-use super::JACK_SAMPLE_FORMAT;
-
+use super::{stream::Stream, JACK_SAMPLE_FORMAT};
 pub use crate::iter::{SupportedInputConfigs, SupportedOutputConfigs};
+use crate::{
+    traits::DeviceTrait, BufferSize, Data, DeviceDescription, DeviceDescriptionBuilder,
+    DeviceDirection, DeviceId, Error, ErrorKind, InputCallbackInfo, OutputCallbackInfo,
+    SampleFormat, SampleRate, StreamConfig, SupportedBufferSize, SupportedStreamConfig,
+    SupportedStreamConfigRange,
+};
 
 const DEFAULT_NUM_CHANNELS: u16 = 2;
 const DEFAULT_SUPPORTED_CHANNELS: [u16; 10] = [1, 2, 4, 6, 8, 16, 24, 32, 48, 64];
@@ -210,7 +210,7 @@ impl DeviceTrait for Device {
                     ),
                 ));
             }
-            if let crate::BufferSize::Fixed(size) = conf.buffer_size {
+            if let BufferSize::Fixed(size) = conf.buffer_size {
                 if size != client.buffer_size() {
                     return Err(Error::with_message(
                         ErrorKind::UnsupportedConfig,
@@ -289,7 +289,7 @@ impl DeviceTrait for Device {
                     ),
                 ));
             }
-            if let crate::BufferSize::Fixed(size) = conf.buffer_size {
+            if let BufferSize::Fixed(size) = conf.buffer_size {
                 if size != client.buffer_size() {
                     return Err(Error::with_message(
                         ErrorKind::UnsupportedConfig,

--- a/src/host/jack/mod.rs
+++ b/src/host/jack/mod.rs
@@ -4,8 +4,7 @@
 
 extern crate jack;
 
-use crate::traits::HostTrait;
-use crate::{Error, ErrorKind, SampleFormat};
+use crate::{traits::HostTrait, Error, ErrorKind, SampleFormat};
 
 mod device;
 mod stream;
@@ -43,7 +42,7 @@ pub struct Host {
 }
 
 impl Host {
-    pub fn new() -> Result<Self, crate::Error> {
+    pub fn new() -> Result<Self, Error> {
         let mut host = Host {
             name: format!("cpal_client_{}", std::process::id()),
             connect_ports_automatically: true,

--- a/src/host/jack/stream.rs
+++ b/src/host/jack/stream.rs
@@ -1,14 +1,14 @@
-use crate::traits::StreamTrait;
-use crate::ChannelCount;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex};
-
-use crate::{
-    error::ResultExt, Data, Error, ErrorKind, InputCallbackInfo, OutputCallbackInfo, SampleRate,
-    StreamInstant,
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc, Mutex,
 };
 
 use super::JACK_SAMPLE_FORMAT;
+use crate::{
+    host::frames_to_duration, traits::StreamTrait, ChannelCount, Data, Error, ErrorKind,
+    FrameCount, InputCallbackInfo, InputStreamTimestamp, OutputCallbackInfo, OutputStreamTimestamp,
+    ResultExt, Sample, SampleRate, StreamInstant,
+};
 
 type ErrorCallbackPtr = Arc<Mutex<dyn FnMut(Error) + Send + 'static>>;
 
@@ -192,8 +192,8 @@ impl StreamTrait for Stream {
         micros_to_stream_instant(self.async_client.as_client().time())
     }
 
-    fn buffer_size(&self) -> Result<crate::FrameCount, Error> {
-        Ok(self.async_client.as_client().buffer_size() as crate::FrameCount)
+    fn buffer_size(&self) -> Result<FrameCount, Error> {
+        Ok(self.async_client.as_client().buffer_size() as FrameCount)
     }
 }
 
@@ -278,7 +278,7 @@ impl jack::ProcessHandler for LocalProcessHandler {
         let start_cycle_instant = micros_to_stream_instant(current_start_usecs);
         let start_callback_instant = start_cycle_instant
             + frames_to_duration(
-                process_scope.frames_since_cycle_start() as usize,
+                process_scope.frames_since_cycle_start() as FrameCount,
                 self.sample_rate,
             );
 
@@ -304,19 +304,19 @@ impl jack::ProcessHandler for LocalProcessHandler {
             let callback = start_callback_instant;
             // Input data was made available at the start of the cycle (current_usecs).
             let capture = start_cycle_instant;
-            let timestamp = crate::InputStreamTimestamp { callback, capture };
-            let info = crate::InputCallbackInfo { timestamp };
+            let timestamp = InputStreamTimestamp { callback, capture };
+            let info = InputCallbackInfo { timestamp };
             input_callback(&data, &info);
         }
 
         if let Some(output_callback) = &mut self.output_data_callback {
             let num_out_channels = self.out_ports.len();
 
+            let total = current_frame_count * num_out_channels;
+            self.temp_output_buffer[..total].fill(f32::EQUILIBRIUM);
+
             // Create a slice of exactly current_frame_count frames
-            let mut data = temp_buffer_to_data(
-                &mut self.temp_output_buffer,
-                current_frame_count * num_out_channels,
-            );
+            let mut data = temp_buffer_to_data(&mut self.temp_output_buffer, total);
             // Create timestamp
             let callback = start_callback_instant;
             // Use next_usecs (the hardware deadline for this cycle) when available; it is the
@@ -324,11 +324,12 @@ impl jack::ProcessHandler for LocalProcessHandler {
             let playback = match next_usecs_opt {
                 Some(next_usecs) => micros_to_stream_instant(next_usecs),
                 None => {
-                    start_cycle_instant + frames_to_duration(current_frame_count, self.sample_rate)
+                    start_cycle_instant
+                        + frames_to_duration(current_frame_count as FrameCount, self.sample_rate)
                 }
             };
-            let timestamp = crate::OutputStreamTimestamp { callback, playback };
-            let info = crate::OutputCallbackInfo { timestamp };
+            let timestamp = OutputStreamTimestamp { callback, playback };
+            let info = OutputCallbackInfo { timestamp };
             output_callback(&mut data, &info);
 
             // Deinterlace
@@ -359,16 +360,9 @@ impl jack::ProcessHandler for LocalProcessHandler {
     }
 }
 
+#[inline]
 fn micros_to_stream_instant(micros: u64) -> StreamInstant {
     StreamInstant::from_micros(micros)
-}
-
-// Convert the given duration in frames at the given sample rate to a `std::time::Duration`.
-fn frames_to_duration(frames: usize, rate: crate::SampleRate) -> std::time::Duration {
-    let secsf = frames as f64 / rate as f64;
-    let secs = secsf as u64;
-    let nanos = ((secsf - secs as f64) * 1_000_000_000.0) as u32;
-    std::time::Duration::new(secs, nanos)
 }
 
 /// Receives notifications from the JACK server. It is unclear if this may be run concurrent with itself under JACK2 specs

--- a/src/host/mod.rs
+++ b/src/host/mod.rs
@@ -36,8 +36,14 @@ use crate::{FrameCount, SampleRate};
 ))]
 use std::time::Duration;
 
-#[cfg(any(target_os = "linux", target_os = "windows"))]
-use crate::{Sample, SampleFormat, U24};
+#[cfg(any(
+    target_os = "linux",
+    target_os = "dragonfly",
+    target_os = "freebsd",
+    target_os = "netbsd",
+    target_os = "windows",
+))]
+pub(crate) mod equilibrium;
 
 #[cfg(windows)]
 pub(crate) mod com;
@@ -121,64 +127,6 @@ pub(crate) mod custom;
     all(target_arch = "wasm32", feature = "wasm-bindgen"),
 )))]
 pub(crate) mod null;
-
-#[cfg(any(target_os = "linux", target_os = "windows"))]
-pub(crate) const DSD_EQUILIBRIUM_BYTE: u8 = 0x69;
-#[cfg(any(target_os = "linux", target_os = "windows"))]
-pub(crate) const U8_EQUILIBRIUM_BYTE: u8 = 0x80;
-
-/// Fill `buffer` with the equilibrium value for any `sample_format`.
-#[cfg(any(target_os = "linux", target_os = "windows"))]
-#[inline]
-pub(crate) fn fill_equilibrium(buffer: &mut [u8], sample_format: SampleFormat) {
-    macro_rules! fill_typed {
-        ($sample_type:ty) => {{
-            let sample_size = std::mem::size_of::<$sample_type>();
-
-            debug_assert_eq!(
-                buffer.len() % sample_size,
-                0,
-                "Buffer size must be aligned to sample size for format {:?}",
-                sample_format
-            );
-
-            let num_samples = buffer.len() / sample_size;
-            let equilibrium = <$sample_type as Sample>::EQUILIBRIUM;
-
-            // Safety: buffer length is verified to be a multiple of the sample size above.
-            let samples = unsafe {
-                std::slice::from_raw_parts_mut(
-                    buffer.as_mut_ptr() as *mut $sample_type,
-                    num_samples,
-                )
-            };
-
-            for sample in samples {
-                *sample = equilibrium;
-            }
-        }};
-    }
-
-    if sample_format.is_int() || sample_format.is_float() {
-        buffer.fill(0);
-    } else if sample_format == SampleFormat::U8 {
-        buffer.fill(U8_EQUILIBRIUM_BYTE);
-    } else if sample_format.is_dsd() {
-        buffer.fill(DSD_EQUILIBRIUM_BYTE);
-    } else {
-        // Multi-byte unsigned integer formats require a fill equal to the midpoint of their range.
-        debug_assert!(sample_format.is_uint());
-        match sample_format {
-            SampleFormat::U16 => fill_typed!(u16),
-            SampleFormat::U24 => fill_typed!(U24),
-            SampleFormat::U32 => fill_typed!(u32),
-            SampleFormat::U64 => fill_typed!(u64),
-            _ => unimplemented!(
-                "failed to fill equilibrium for unsupported unsigned format {sample_format:?}"
-            ),
-        }
-    }
-}
 
 /// Convert a frame count at a given sample rate to a [`std::time::Duration`].
 #[cfg(any(

--- a/src/host/mod.rs
+++ b/src/host/mod.rs
@@ -1,4 +1,4 @@
-use crate::{Sample, SampleFormat, I24, U24};
+use crate::{FrameCount, Sample, SampleFormat, SampleRate, I24, U24};
 
 #[cfg(target_os = "android")]
 pub(crate) mod aaudio;
@@ -124,4 +124,13 @@ pub(crate) fn fill_with_equilibrium(buffer: &mut [u8], sample_format: SampleForm
             buffer.fill(DSD_SILENCE_BYTE)
         }
     }
+}
+
+/// Convert a frame count at a given sample rate to a [`std::time::Duration`].
+#[inline]
+pub(crate) fn frames_to_duration(frames: FrameCount, rate: SampleRate) -> std::time::Duration {
+    let secsf = frames as f64 / rate as f64;
+    let secs = secsf as u64;
+    let nanos = ((secsf - secs as f64) * 1_000_000_000.0) as u32;
+    std::time::Duration::new(secs, nanos)
 }

--- a/src/host/mod.rs
+++ b/src/host/mod.rs
@@ -1,7 +1,50 @@
-use crate::{FrameCount, Sample, SampleFormat, SampleRate, I24, U24};
+#[cfg(any(
+    target_os = "linux",
+    target_os = "windows",
+    target_vendor = "apple",
+    feature = "audioworklet",
+    all(
+        feature = "jack",
+        any(
+            target_os = "linux",
+            target_os = "dragonfly",
+            target_os = "freebsd",
+            target_os = "netbsd",
+            target_os = "macos",
+            target_os = "windows",
+        )
+    )
+))]
+use crate::{FrameCount, SampleRate};
+
+#[cfg(any(
+    target_os = "linux",
+    target_os = "windows",
+    target_vendor = "apple",
+    feature = "audioworklet",
+    all(
+        feature = "jack",
+        any(
+            target_os = "linux",
+            target_os = "dragonfly",
+            target_os = "freebsd",
+            target_os = "netbsd",
+            target_os = "macos",
+            target_os = "windows",
+        )
+    )
+))]
+use std::time::Duration;
+
+#[cfg(any(target_os = "linux", target_os = "windows"))]
+use crate::{Sample, SampleFormat, U24};
+
+#[cfg(windows)]
+pub(crate) mod com;
 
 #[cfg(target_os = "android")]
 pub(crate) mod aaudio;
+
 #[cfg(any(
     target_os = "linux",
     target_os = "dragonfly",
@@ -9,18 +52,20 @@ pub(crate) mod aaudio;
     target_os = "netbsd"
 ))]
 pub(crate) mod alsa;
+
 #[cfg(all(windows, feature = "asio"))]
 pub(crate) mod asio;
+
 #[cfg(all(
     feature = "wasm-bindgen",
     feature = "audioworklet",
     target_feature = "atomics"
 ))]
 pub(crate) mod audioworklet;
-#[cfg(windows)]
-pub(crate) mod com;
+
 #[cfg(target_vendor = "apple")]
 pub(crate) mod coreaudio;
+
 #[cfg(all(
     feature = "jack",
     any(
@@ -33,6 +78,7 @@ pub(crate) mod coreaudio;
     )
 ))]
 pub(crate) mod jack;
+
 #[cfg(all(
     any(
         target_os = "linux",
@@ -43,6 +89,7 @@ pub(crate) mod jack;
     feature = "pipewire"
 ))]
 pub(crate) mod pipewire;
+
 #[cfg(all(
     any(
         target_os = "linux",
@@ -53,13 +100,16 @@ pub(crate) mod pipewire;
     feature = "pulseaudio"
 ))]
 pub(crate) mod pulseaudio;
+
 #[cfg(windows)]
 pub(crate) mod wasapi;
+
 #[cfg(all(target_arch = "wasm32", feature = "wasm-bindgen"))]
 pub(crate) mod webaudio;
 
 #[cfg(feature = "custom")]
 pub(crate) mod custom;
+
 #[cfg(not(any(
     windows,
     target_os = "linux",
@@ -72,10 +122,15 @@ pub(crate) mod custom;
 )))]
 pub(crate) mod null;
 
-// Fill a buffer with equilibrium values for any sample format.
-// Works with any buffer size, even if not perfectly aligned to sample boundaries.
-#[allow(unused)]
-pub(crate) fn fill_with_equilibrium(buffer: &mut [u8], sample_format: SampleFormat) {
+#[cfg(any(target_os = "linux", target_os = "windows"))]
+pub(crate) const DSD_EQUILIBRIUM_BYTE: u8 = 0x69;
+#[cfg(any(target_os = "linux", target_os = "windows"))]
+pub(crate) const U8_EQUILIBRIUM_BYTE: u8 = 0x80;
+
+/// Fill `buffer` with the equilibrium value for any `sample_format`.
+#[cfg(any(target_os = "linux", target_os = "windows"))]
+#[inline]
+pub(crate) fn fill_equilibrium(buffer: &mut [u8], sample_format: SampleFormat) {
     macro_rules! fill_typed {
         ($sample_type:ty) => {{
             let sample_size = std::mem::size_of::<$sample_type>();
@@ -90,7 +145,7 @@ pub(crate) fn fill_with_equilibrium(buffer: &mut [u8], sample_format: SampleForm
             let num_samples = buffer.len() / sample_size;
             let equilibrium = <$sample_type as Sample>::EQUILIBRIUM;
 
-            // Safety: We verified the buffer size is correctly aligned for the sample type
+            // Safety: buffer length is verified to be a multiple of the sample size above.
             let samples = unsafe {
                 std::slice::from_raw_parts_mut(
                     buffer.as_mut_ptr() as *mut $sample_type,
@@ -103,34 +158,55 @@ pub(crate) fn fill_with_equilibrium(buffer: &mut [u8], sample_format: SampleForm
             }
         }};
     }
-    const DSD_SILENCE_BYTE: u8 = 0x69;
 
-    match sample_format {
-        SampleFormat::I8 => fill_typed!(i8),
-        SampleFormat::I16 => fill_typed!(i16),
-        SampleFormat::I24 => fill_typed!(I24),
-        SampleFormat::I32 => fill_typed!(i32),
-        // SampleFormat::I48 => fill_typed!(I48),
-        SampleFormat::I64 => fill_typed!(i64),
-        SampleFormat::U8 => fill_typed!(u8),
-        SampleFormat::U16 => fill_typed!(u16),
-        SampleFormat::U24 => fill_typed!(U24),
-        SampleFormat::U32 => fill_typed!(u32),
-        // SampleFormat::U48 => fill_typed!(U48),
-        SampleFormat::U64 => fill_typed!(u64),
-        SampleFormat::F32 => fill_typed!(f32),
-        SampleFormat::F64 => fill_typed!(f64),
-        SampleFormat::DsdU8 | SampleFormat::DsdU16 | SampleFormat::DsdU32 => {
-            buffer.fill(DSD_SILENCE_BYTE)
+    if sample_format.is_int() || sample_format.is_float() {
+        buffer.fill(0);
+    } else if sample_format == SampleFormat::U8 {
+        buffer.fill(U8_EQUILIBRIUM_BYTE);
+    } else if sample_format.is_dsd() {
+        buffer.fill(DSD_EQUILIBRIUM_BYTE);
+    } else {
+        // Multi-byte unsigned integer formats require a fill equal to the midpoint of their range.
+        debug_assert!(sample_format.is_uint());
+        match sample_format {
+            SampleFormat::U16 => fill_typed!(u16),
+            SampleFormat::U24 => fill_typed!(U24),
+            SampleFormat::U32 => fill_typed!(u32),
+            SampleFormat::U64 => fill_typed!(u64),
+            _ => unimplemented!(
+                "failed to fill equilibrium for unsupported unsigned format {sample_format:?}"
+            ),
         }
     }
 }
 
 /// Convert a frame count at a given sample rate to a [`std::time::Duration`].
+#[cfg(any(
+    target_os = "linux",
+    target_os = "windows",
+    target_vendor = "apple",
+    feature = "audioworklet",
+    all(
+        feature = "jack",
+        any(
+            target_os = "linux",
+            target_os = "dragonfly",
+            target_os = "freebsd",
+            target_os = "netbsd",
+            target_os = "macos",
+            target_os = "windows",
+        )
+    )
+))]
 #[inline]
-pub(crate) fn frames_to_duration(frames: FrameCount, rate: SampleRate) -> std::time::Duration {
-    let secsf = frames as f64 / rate as f64;
-    let secs = secsf as u64;
-    let nanos = ((secsf - secs as f64) * 1_000_000_000.0) as u32;
-    std::time::Duration::new(secs, nanos)
+pub(crate) fn frames_to_duration(frames: FrameCount, rate: SampleRate) -> Duration {
+    if rate == 0 {
+        return Duration::ZERO;
+    }
+    let rate = rate as u64;
+    let secs = frames as u64 / rate;
+    // rem_frames < rate <= u32::MAX, so rem_frames * 1_000_000_000 < u64::MAX
+    let rem_frames = frames as u64 % rate;
+    let nanos = rem_frames * 1_000_000_000 / rate;
+    Duration::new(secs, nanos as u32)
 }

--- a/src/host/null/mod.rs
+++ b/src/host/null/mod.rs
@@ -34,13 +34,13 @@ pub struct SupportedOutputConfigs;
 impl Host {
     #[allow(dead_code)]
     pub fn new() -> Result<Self, Error> {
-        Ok(Host)
+        Ok(Self)
     }
 }
 
 impl Devices {
     pub fn new() -> Result<Self, Error> {
-        Ok(Devices)
+        Ok(Self)
     }
 }
 
@@ -50,7 +50,7 @@ impl DeviceTrait for Device {
     type Stream = Stream;
 
     fn description(&self) -> Result<DeviceDescription, Error> {
-        Ok(DeviceDescriptionBuilder::new("Null Device".to_string()).build())
+        Ok(DeviceDescriptionBuilder::new("Null Device").build())
     }
 
     fn id(&self) -> Result<DeviceId, Error> {
@@ -117,11 +117,11 @@ impl HostTrait for Host {
         Devices::new()
     }
 
-    fn default_input_device(&self) -> Option<Device> {
+    fn default_input_device(&self) -> Option<Self::Device> {
         None
     }
 
-    fn default_output_device(&self) -> Option<Device> {
+    fn default_output_device(&self) -> Option<Self::Device> {
         None
     }
 }
@@ -147,7 +147,7 @@ impl StreamTrait for Stream {
 impl Iterator for Devices {
     type Item = Device;
 
-    fn next(&mut self) -> Option<Device> {
+    fn next(&mut self) -> Option<Self::Item> {
         None
     }
 }
@@ -155,7 +155,7 @@ impl Iterator for Devices {
 impl Iterator for SupportedInputConfigs {
     type Item = SupportedStreamConfigRange;
 
-    fn next(&mut self) -> Option<SupportedStreamConfigRange> {
+    fn next(&mut self) -> Option<Self::Item> {
         None
     }
 }
@@ -163,7 +163,7 @@ impl Iterator for SupportedInputConfigs {
 impl Iterator for SupportedOutputConfigs {
     type Item = SupportedStreamConfigRange;
 
-    fn next(&mut self) -> Option<SupportedStreamConfigRange> {
+    fn next(&mut self) -> Option<Self::Item> {
         None
     }
 }

--- a/src/host/null/mod.rs
+++ b/src/host/null/mod.rs
@@ -4,11 +4,11 @@
 
 use std::time::Duration;
 
-use crate::traits::{DeviceTrait, HostTrait, StreamTrait};
 use crate::{
-    Data, DeviceDescription, DeviceDescriptionBuilder, DeviceId, Error, InputCallbackInfo,
-    OutputCallbackInfo, SampleFormat, StreamConfig, SupportedStreamConfig,
-    SupportedStreamConfigRange,
+    traits::{DeviceTrait, HostTrait, StreamTrait},
+    Data, DeviceDescription, DeviceDescriptionBuilder, DeviceId, Error, FrameCount,
+    InputCallbackInfo, OutputCallbackInfo, SampleFormat, StreamConfig, StreamInstant,
+    SupportedStreamConfig, SupportedStreamConfigRange,
 };
 
 #[derive(Default)]
@@ -33,7 +33,7 @@ pub struct SupportedOutputConfigs;
 
 impl Host {
     #[allow(dead_code)]
-    pub fn new() -> Result<Self, crate::Error> {
+    pub fn new() -> Result<Self, Error> {
         Ok(Host)
     }
 }
@@ -135,11 +135,11 @@ impl StreamTrait for Stream {
         unimplemented!()
     }
 
-    fn now(&self) -> crate::StreamInstant {
+    fn now(&self) -> StreamInstant {
         unimplemented!()
     }
 
-    fn buffer_size(&self) -> Result<crate::FrameCount, Error> {
+    fn buffer_size(&self) -> Result<FrameCount, Error> {
         unimplemented!()
     }
 }

--- a/src/host/pipewire/device.rs
+++ b/src/host/pipewire/device.rs
@@ -1,13 +1,11 @@
-use std::sync::{atomic::AtomicU64, Arc};
-use std::time::Duration;
-use std::{cell::RefCell, rc::Rc};
+use std::{
+    cell::RefCell,
+    rc::Rc,
+    sync::{atomic::AtomicU64, Arc},
+    thread,
+    time::Duration,
+};
 
-use crate::host::pipewire::stream::{PwInitGuard, StreamCommand, StreamData, SUPPORTED_FORMATS};
-use crate::host::pipewire::utils::{audio, clock, node, DEVICE_ICON_NAME, METADATA_NAME};
-use crate::{traits::DeviceTrait, DeviceDirection, SupportedStreamConfigRange};
-use crate::{ChannelCount, FrameCount, InterfaceType, SampleRate};
-
-use crate::iter::{SupportedInputConfigs, SupportedOutputConfigs};
 use pipewire::{
     self as pw,
     metadata::{Metadata, MetadataListener},
@@ -16,9 +14,17 @@ use pipewire::{
     spa::utils::result::AsyncSeq,
 };
 
-use std::thread;
-
 use super::stream::Stream;
+use crate::{
+    host::pipewire::stream::{PwInitGuard, StreamCommand, StreamData, SUPPORTED_FORMATS},
+    iter::{SupportedInputConfigs, SupportedOutputConfigs},
+    traits::DeviceTrait,
+    utils::{audio, clock, node, DEVICE_ICON_NAME, METADATA_NAME},
+    BufferSize, ChannelCount, Data, DeviceDescription, DeviceDescriptionBuilder, DeviceDirection,
+    DeviceId, DeviceType, Error, ErrorKind, FrameCount, HostId, InputCallbackInfo, InterfaceType,
+    OutputCallbackInfo, SampleFormat, SampleRate, StreamConfig, SupportedBufferSize,
+    SupportedStreamConfig, SupportedStreamConfigRange,
+};
 
 pub type Devices = std::vec::IntoIter<Device>;
 
@@ -104,20 +110,20 @@ impl Device {
         }
     }
 
-    fn device_type(&self) -> crate::DeviceType {
+    fn device_type(&self) -> DeviceType {
         match self.icon_name.as_str() {
-            "audio-headphones" => crate::DeviceType::Headphones,
-            "audio-headset" => crate::DeviceType::Headset,
-            "audio-input-microphone" => crate::DeviceType::Microphone,
-            "audio-speakers" => crate::DeviceType::Speaker,
-            _ => crate::DeviceType::Unknown,
+            "audio-headphones" => DeviceType::Headphones,
+            "audio-headset" => DeviceType::Headset,
+            "audio-input-microphone" => DeviceType::Microphone,
+            "audio-speakers" => DeviceType::Speaker,
+            _ => DeviceType::Unknown,
         }
     }
 
     pub(crate) fn pw_properties(
         &self,
         direction: DeviceDirection,
-        config: &crate::StreamConfig,
+        config: &StreamConfig,
     ) -> pw::properties::PropertiesBox {
         let mut properties = match direction {
             DeviceDirection::Output => pw::properties::properties! {
@@ -141,7 +147,7 @@ impl Device {
         // preventing phase drift between simultaneous input/output streams.
         properties.insert("node.group", format!("cpal-{}", std::process::id()));
 
-        if let crate::BufferSize::Fixed(buffer_size) = config.buffer_size {
+        if let BufferSize::Fixed(buffer_size) = config.buffer_size {
             properties.insert(*pw::keys::NODE_FORCE_QUANTUM, buffer_size.to_string());
         }
         properties
@@ -152,15 +158,12 @@ impl DeviceTrait for Device {
     type SupportedInputConfigs = SupportedInputConfigs;
     type SupportedOutputConfigs = SupportedOutputConfigs;
 
-    fn id(&self) -> Result<crate::DeviceId, crate::Error> {
-        Ok(crate::DeviceId(
-            crate::HostId::PipeWire,
-            self.node_name.clone(),
-        ))
+    fn id(&self) -> Result<DeviceId, Error> {
+        Ok(DeviceId(HostId::PipeWire, self.node_name.clone()))
     }
 
-    fn description(&self) -> Result<crate::DeviceDescription, crate::Error> {
-        let mut builder = crate::DeviceDescriptionBuilder::new(&self.nick_name)
+    fn description(&self) -> Result<DeviceDescription, Error> {
+        let mut builder = DeviceDescriptionBuilder::new(&self.nick_name)
             .direction(self.direction)
             .device_type(self.device_type())
             .interface_type(self.interface_type);
@@ -190,7 +193,7 @@ impl DeviceTrait for Device {
         )
     }
 
-    fn supported_input_configs(&self) -> Result<Self::SupportedInputConfigs, crate::Error> {
+    fn supported_input_configs(&self) -> Result<Self::SupportedInputConfigs, Error> {
         if !self.supports_input() {
             return Ok(vec![].into_iter());
         }
@@ -208,7 +211,7 @@ impl DeviceTrait for Device {
                         channels: self.channels,
                         min_sample_rate: rate,
                         max_sample_rate: rate,
-                        buffer_size: crate::SupportedBufferSize::Range {
+                        buffer_size: SupportedBufferSize::Range {
                             min: self.min_quantum,
                             max: self.max_quantum,
                         },
@@ -218,7 +221,7 @@ impl DeviceTrait for Device {
             .collect::<Vec<_>>()
             .into_iter())
     }
-    fn supported_output_configs(&self) -> Result<Self::SupportedOutputConfigs, crate::Error> {
+    fn supported_output_configs(&self) -> Result<Self::SupportedOutputConfigs, Error> {
         if !self.supports_output() {
             return Ok(vec![].into_iter());
         }
@@ -236,7 +239,7 @@ impl DeviceTrait for Device {
                         channels: self.channels,
                         min_sample_rate: rate,
                         max_sample_rate: rate,
-                        buffer_size: crate::SupportedBufferSize::Range {
+                        buffer_size: SupportedBufferSize::Range {
                             min: self.min_quantum,
                             max: self.max_quantum,
                         },
@@ -246,36 +249,36 @@ impl DeviceTrait for Device {
             .collect::<Vec<_>>()
             .into_iter())
     }
-    fn default_input_config(&self) -> Result<crate::SupportedStreamConfig, crate::Error> {
+    fn default_input_config(&self) -> Result<SupportedStreamConfig, Error> {
         if !self.supports_input() {
-            return Err(crate::Error::with_message(
-                crate::ErrorKind::UnsupportedOperation,
+            return Err(Error::with_message(
+                ErrorKind::UnsupportedOperation,
                 "device does not support input",
             ));
         }
-        Ok(crate::SupportedStreamConfig {
+        Ok(SupportedStreamConfig {
             channels: self.channels,
-            sample_format: crate::SampleFormat::F32,
+            sample_format: SampleFormat::F32,
             sample_rate: self.rate,
-            buffer_size: crate::SupportedBufferSize::Range {
+            buffer_size: SupportedBufferSize::Range {
                 min: self.min_quantum,
                 max: self.max_quantum,
             },
         })
     }
 
-    fn default_output_config(&self) -> Result<crate::SupportedStreamConfig, crate::Error> {
+    fn default_output_config(&self) -> Result<SupportedStreamConfig, Error> {
         if !self.supports_output() {
-            return Err(crate::Error::with_message(
-                crate::ErrorKind::UnsupportedOperation,
+            return Err(Error::with_message(
+                ErrorKind::UnsupportedOperation,
                 "device does not support output",
             ));
         }
-        Ok(crate::SupportedStreamConfig {
+        Ok(SupportedStreamConfig {
             channels: self.channels,
-            sample_format: crate::SampleFormat::F32,
+            sample_format: SampleFormat::F32,
             sample_rate: self.rate,
-            buffer_size: crate::SupportedBufferSize::Range {
+            buffer_size: SupportedBufferSize::Range {
                 min: self.min_quantum,
                 max: self.max_quantum,
             },
@@ -284,15 +287,15 @@ impl DeviceTrait for Device {
 
     fn build_input_stream_raw<D, E>(
         &self,
-        config: crate::StreamConfig,
-        sample_format: crate::SampleFormat,
+        config: StreamConfig,
+        sample_format: SampleFormat,
         data_callback: D,
         error_callback: E,
         timeout: Option<std::time::Duration>,
-    ) -> Result<Self::Stream, crate::Error>
+    ) -> Result<Self::Stream, Error>
     where
-        D: FnMut(&crate::Data, &crate::InputCallbackInfo) + Send + 'static,
-        E: FnMut(crate::Error) + Send + 'static,
+        D: FnMut(&Data, &InputCallbackInfo) + Send + 'static,
+        E: FnMut(Error) + Send + 'static,
     {
         let (pw_play_tx, pw_play_rx) = pw::channel::channel::<StreamCommand>();
 
@@ -300,8 +303,8 @@ impl DeviceTrait for Device {
         let device = self.clone();
         let wait_timeout = timeout.unwrap_or(Duration::from_secs(2));
         let initial_quantum = match config.buffer_size {
-            crate::BufferSize::Fixed(n) => n as u64,
-            crate::BufferSize::Default => self.quantum as u64,
+            BufferSize::Fixed(n) => n as u64,
+            BufferSize::Default => self.quantum as u64,
         };
         let last_quantum = Arc::new(AtomicU64::new(initial_quantum));
         let last_quantum_clone = last_quantum.clone();
@@ -346,10 +349,7 @@ impl DeviceTrait for Device {
                 drop(context);
             })
             .map_err(|e| {
-                crate::Error::with_message(
-                    crate::ErrorKind::Other,
-                    format!("failed to create thread: {e}"),
-                )
+                Error::with_message(ErrorKind::Other, format!("failed to create thread: {e}"))
             })?;
         match pw_init_rx.recv_timeout(wait_timeout) {
             Ok(true) => Ok(Stream {
@@ -358,12 +358,12 @@ impl DeviceTrait for Device {
                 last_quantum,
                 start,
             }),
-            Ok(false) => Err(crate::Error::with_message(
-                crate::ErrorKind::UnsupportedConfig,
+            Ok(false) => Err(Error::with_message(
+                ErrorKind::UnsupportedConfig,
                 "stream configuration rejected by PipeWire",
             )),
-            Err(_) => Err(crate::Error::with_message(
-                crate::ErrorKind::DeviceNotAvailable,
+            Err(_) => Err(Error::with_message(
+                ErrorKind::DeviceNotAvailable,
                 "PipeWire timed out",
             )),
         }
@@ -371,15 +371,15 @@ impl DeviceTrait for Device {
 
     fn build_output_stream_raw<D, E>(
         &self,
-        config: crate::StreamConfig,
-        sample_format: crate::SampleFormat,
+        config: StreamConfig,
+        sample_format: SampleFormat,
         data_callback: D,
         error_callback: E,
         timeout: Option<std::time::Duration>,
-    ) -> Result<Self::Stream, crate::Error>
+    ) -> Result<Self::Stream, Error>
     where
-        D: FnMut(&mut crate::Data, &crate::OutputCallbackInfo) + Send + 'static,
-        E: FnMut(crate::Error) + Send + 'static,
+        D: FnMut(&mut Data, &OutputCallbackInfo) + Send + 'static,
+        E: FnMut(Error) + Send + 'static,
     {
         let (pw_play_tx, pw_play_rx) = pw::channel::channel::<StreamCommand>();
 
@@ -387,8 +387,8 @@ impl DeviceTrait for Device {
         let device = self.clone();
         let wait_timeout = timeout.unwrap_or(Duration::from_secs(2));
         let initial_quantum = match config.buffer_size {
-            crate::BufferSize::Fixed(n) => n as u64,
-            crate::BufferSize::Default => self.quantum as u64,
+            BufferSize::Fixed(n) => n as u64,
+            BufferSize::Default => self.quantum as u64,
         };
         let last_quantum = Arc::new(AtomicU64::new(initial_quantum));
         let last_quantum_clone = last_quantum.clone();
@@ -435,10 +435,7 @@ impl DeviceTrait for Device {
                 drop(context);
             })
             .map_err(|e| {
-                crate::Error::with_message(
-                    crate::ErrorKind::Other,
-                    format!("failed to create thread: {e}"),
-                )
+                Error::with_message(ErrorKind::Other, format!("failed to create thread: {e}"))
             })?;
         match pw_init_rx.recv_timeout(wait_timeout) {
             Ok(true) => Ok(Stream {
@@ -447,12 +444,12 @@ impl DeviceTrait for Device {
                 last_quantum,
                 start,
             }),
-            Ok(false) => Err(crate::Error::with_message(
-                crate::ErrorKind::UnsupportedConfig,
+            Ok(false) => Err(Error::with_message(
+                ErrorKind::UnsupportedConfig,
                 "stream configuration rejected by PipeWire",
             )),
-            Err(_) => Err(crate::Error::with_message(
-                crate::ErrorKind::DeviceNotAvailable,
+            Err(_) => Err(Error::with_message(
+                ErrorKind::DeviceNotAvailable,
                 "PipeWire timed out",
             )),
         }
@@ -831,7 +828,7 @@ pub fn init_devices() -> Option<Vec<Device>> {
     Some(devices)
 }
 
-fn parse_allow_rates(list: &str) -> Option<Vec<u32>> {
+fn parse_allow_rates(list: &str) -> Option<Vec<SampleRate>> {
     let list: Vec<&str> = list
         .trim()
         .strip_prefix("[")?

--- a/src/host/pipewire/device.rs
+++ b/src/host/pipewire/device.rs
@@ -359,7 +359,7 @@ impl DeviceTrait for Device {
                 start,
             }),
             Ok(false) => Err(crate::Error::with_message(
-                crate::ErrorKind::UnsupportedConfig,
+                ErrorKind::UnsupportedConfig,
                 "stream configuration rejected by PipeWire",
             )),
             Err(_) => Err(crate::Error::with_message(
@@ -448,7 +448,7 @@ impl DeviceTrait for Device {
                 start,
             }),
             Ok(false) => Err(crate::Error::with_message(
-                crate::ErrorKind::UnsupportedConfig,
+                ErrorKind::UnsupportedConfig,
                 "stream configuration rejected by PipeWire",
             )),
             Err(_) => Err(crate::Error::with_message(

--- a/src/host/pipewire/device.rs
+++ b/src/host/pipewire/device.rs
@@ -17,9 +17,9 @@ use pipewire::{
 use super::stream::Stream;
 use crate::{
     host::pipewire::stream::{PwInitGuard, StreamCommand, StreamData, SUPPORTED_FORMATS},
+    host::pipewire::utils::{audio, clock, node, DEVICE_ICON_NAME, METADATA_NAME},
     iter::{SupportedInputConfigs, SupportedOutputConfigs},
     traits::DeviceTrait,
-    utils::{audio, clock, node, DEVICE_ICON_NAME, METADATA_NAME},
     BufferSize, ChannelCount, Data, DeviceDescription, DeviceDescriptionBuilder, DeviceDirection,
     DeviceId, DeviceType, Error, ErrorKind, FrameCount, HostId, InputCallbackInfo, InterfaceType,
     OutputCallbackInfo, SampleFormat, SampleRate, StreamConfig, SupportedBufferSize,

--- a/src/host/pipewire/device.rs
+++ b/src/host/pipewire/device.rs
@@ -359,7 +359,7 @@ impl DeviceTrait for Device {
                 start,
             }),
             Ok(false) => Err(crate::Error::with_message(
-                ErrorKind::UnsupportedConfig,
+                crate::ErrorKind::UnsupportedConfig,
                 "stream configuration rejected by PipeWire",
             )),
             Err(_) => Err(crate::Error::with_message(
@@ -448,7 +448,7 @@ impl DeviceTrait for Device {
                 start,
             }),
             Ok(false) => Err(crate::Error::with_message(
-                ErrorKind::UnsupportedConfig,
+                crate::ErrorKind::UnsupportedConfig,
                 "stream configuration rejected by PipeWire",
             )),
             Err(_) => Err(crate::Error::with_message(

--- a/src/host/pipewire/mod.rs
+++ b/src/host/pipewire/mod.rs
@@ -23,16 +23,18 @@ impl Host {
                 "PipeWire host initialization failed",
             )
         })?;
-        Ok(Host { _pw, devices })
+        Ok(Self { _pw, devices })
     }
 }
 
 impl HostTrait for Host {
     type Devices = Devices;
     type Device = Device;
+
     fn is_available() -> bool {
         utils::find_socket_path().is_some()
     }
+
     fn devices(&self) -> Result<Self::Devices, Error> {
         Ok(self.devices.clone().into_iter())
     }
@@ -43,6 +45,7 @@ impl HostTrait for Host {
             .find(|device| matches!(device.class(), Class::DefaultInput))
             .cloned()
     }
+
     fn default_output_device(&self) -> Option<Self::Device> {
         self.devices
             .iter()

--- a/src/host/pipewire/mod.rs
+++ b/src/host/pipewire/mod.rs
@@ -1,6 +1,7 @@
-use crate::traits::HostTrait;
 use device::{init_devices, Class, Device, Devices};
 use stream::PwInitGuard;
+
+use crate::{traits::HostTrait, Error, ErrorKind};
 
 mod device;
 mod stream;
@@ -14,11 +15,11 @@ pub struct Host {
 }
 
 impl Host {
-    pub fn new() -> Result<Self, crate::Error> {
+    pub fn new() -> Result<Self, Error> {
         let _pw = PwInitGuard::new();
         let devices = init_devices().ok_or_else(|| {
-            crate::Error::with_message(
-                crate::ErrorKind::HostUnavailable,
+            Error::with_message(
+                ErrorKind::HostUnavailable,
                 "PipeWire host initialization failed",
             )
         })?;
@@ -32,7 +33,7 @@ impl HostTrait for Host {
     fn is_available() -> bool {
         utils::find_socket_path().is_some()
     }
-    fn devices(&self) -> Result<Self::Devices, crate::Error> {
+    fn devices(&self) -> Result<Self::Devices, Error> {
         Ok(self.devices.clone().into_iter())
     }
 

--- a/src/host/pipewire/stream.rs
+++ b/src/host/pipewire/stream.rs
@@ -7,10 +7,6 @@ use std::{
     time::Instant,
 };
 
-use crate::{
-    host::fill_with_equilibrium, traits::StreamTrait, Error, ErrorKind, InputCallbackInfo,
-    OutputCallbackInfo, SampleFormat, StreamConfig, StreamInstant,
-};
 use pipewire::{
     self as pw,
     context::ContextRc,
@@ -25,7 +21,13 @@ use pipewire::{
     stream::{StreamListener, StreamRc, StreamState},
 };
 
-use crate::Data;
+use crate::{
+    host::{fill_with_equilibrium, frames_to_duration},
+    traits::StreamTrait,
+    Data, Error, ErrorKind, FrameCount, InputCallbackInfo, InputStreamTimestamp,
+    OutputCallbackInfo, OutputStreamTimestamp, SampleFormat, SampleRate, StreamConfig,
+    StreamInstant,
+};
 
 /// Counts the number of live [`PwInitGuard`] instances across all threads.
 static PW_INIT_COUNT: Mutex<usize> = Mutex::new(0);
@@ -80,7 +82,7 @@ impl Drop for Stream {
 }
 
 impl StreamTrait for Stream {
-    fn play(&self) -> Result<(), crate::Error> {
+    fn play(&self) -> Result<(), Error> {
         self.controller
             .send(StreamCommand::Toggle(true))
             .map_err(|_| {
@@ -91,7 +93,7 @@ impl StreamTrait for Stream {
             })?;
         Ok(())
     }
-    fn pause(&self) -> Result<(), crate::Error> {
+    fn pause(&self) -> Result<(), Error> {
         self.controller
             .send(StreamCommand::Toggle(false))
             .map_err(|_| {
@@ -103,11 +105,11 @@ impl StreamTrait for Stream {
         Ok(())
     }
 
-    fn now(&self) -> crate::StreamInstant {
+    fn now(&self) -> StreamInstant {
         monotonic_stream_instant().unwrap_or_else(|| stream_instant_from_start(self.start))
     }
 
-    fn buffer_size(&self) -> Result<crate::FrameCount, crate::Error> {
+    fn buffer_size(&self) -> Result<FrameCount, Error> {
         Ok(self.last_quantum.load(Ordering::Relaxed) as _)
     }
 }
@@ -248,12 +250,12 @@ where
                 let cb = monotonic_stream_instant()
                     .unwrap_or_else(|| stream_instant_from_start(self.start));
                 let capture = cb
-                    .checked_sub(frames_to_duration(frames, self.format.rate()))
-                    .unwrap_or(crate::StreamInstant::ZERO);
+                    .checked_sub(frames_to_duration(frames as FrameCount, self.format.rate()))
+                    .unwrap_or(StreamInstant::ZERO);
                 (cb, capture)
             }
         };
-        let timestamp = crate::InputStreamTimestamp { callback, capture };
+        let timestamp = InputStreamTimestamp { callback, capture };
         let info = InputCallbackInfo { timestamp };
         (self.data_callback)(data, &info);
     }
@@ -273,11 +275,11 @@ where
             None => {
                 let cb = monotonic_stream_instant()
                     .unwrap_or_else(|| stream_instant_from_start(self.start));
-                let pl = cb + frames_to_duration(frames, self.format.rate());
+                let pl = cb + frames_to_duration(frames as FrameCount, self.format.rate());
                 (cb, pl)
             }
         };
-        let timestamp = crate::OutputStreamTimestamp { callback, playback };
+        let timestamp = OutputStreamTimestamp { callback, playback };
         let info = OutputCallbackInfo { timestamp };
         (self.data_callback)(data, &info);
     }

--- a/src/host/pipewire/stream.rs
+++ b/src/host/pipewire/stream.rs
@@ -25,8 +25,7 @@ use crate::{
     host::{fill_equilibrium, frames_to_duration},
     traits::StreamTrait,
     Data, Error, ErrorKind, FrameCount, InputCallbackInfo, InputStreamTimestamp,
-    OutputCallbackInfo, OutputStreamTimestamp, SampleFormat, SampleRate, StreamConfig,
-    StreamInstant,
+    OutputCallbackInfo, OutputStreamTimestamp, SampleFormat, StreamConfig, StreamInstant,
 };
 
 /// Counts the number of live [`PwInitGuard`] instances across all threads.

--- a/src/host/pipewire/stream.rs
+++ b/src/host/pipewire/stream.rs
@@ -22,7 +22,7 @@ use pipewire::{
 };
 
 use crate::{
-    host::{fill_with_equilibrium, frames_to_duration},
+    host::{fill_equilibrium, frames_to_duration},
     traits::StreamTrait,
     Data, Error, ErrorKind, FrameCount, InputCallbackInfo, InputStreamTimestamp,
     OutputCallbackInfo, OutputStreamTimestamp, SampleFormat, SampleRate, StreamConfig,
@@ -315,15 +315,6 @@ fn monotonic_stream_instant() -> Option<StreamInstant> {
     }
 }
 
-// Convert the given duration in frames at the given sample rate to a `std::time::Duration`.
-#[inline]
-fn frames_to_duration(frames: usize, rate: crate::SampleRate) -> std::time::Duration {
-    let secsf = frames as f64 / rate as f64;
-    let secs = secsf as u64;
-    let nanos = ((secsf - secs as f64) * 1_000_000_000.0) as u32;
-    std::time::Duration::new(secs, nanos)
-}
-
 fn remote_props() -> Option<pw::properties::PropertiesBox> {
     let socket = super::utils::find_socket_path()?;
     let mut props = pw::properties::PropertiesBox::new();
@@ -435,10 +426,10 @@ where
                 // samples = frames * channels or samples = data_len / sample_size
                 let n_samples = frames * n_channels as usize;
 
-                // Pre-fill only the active region with silence before handing it to the
+                // Pre-fill only the active region with equilibrium before handing it to the
                 // callback.
                 let active = &mut samples[..frames * stride];
-                fill_with_equilibrium(active, user_data.sample_format);
+                fill_equilibrium(active, user_data.sample_format);
 
                 let data = active.as_mut_ptr() as *mut ();
                 let mut data =

--- a/src/host/pipewire/stream.rs
+++ b/src/host/pipewire/stream.rs
@@ -22,7 +22,7 @@ use pipewire::{
 };
 
 use crate::{
-    host::{fill_equilibrium, frames_to_duration},
+    host::{equilibrium::fill_equilibrium, frames_to_duration},
     traits::StreamTrait,
     Data, Error, ErrorKind, FrameCount, InputCallbackInfo, InputStreamTimestamp,
     OutputCallbackInfo, OutputStreamTimestamp, SampleFormat, StreamConfig, StreamInstant,

--- a/src/host/pulseaudio/mod.rs
+++ b/src/host/pulseaudio/mod.rs
@@ -1,6 +1,7 @@
+use std::time::Duration;
+
 use futures::executor::block_on;
 use pulseaudio::protocol;
-use std::time::Duration;
 
 mod stream;
 
@@ -9,9 +10,10 @@ pub use stream::Stream;
 use crate::{
     error::ResultExt,
     traits::{DeviceTrait, HostTrait},
-    Data, DeviceDescription, DeviceDescriptionBuilder, DeviceDirection, DeviceId, Error, ErrorKind,
-    FrameCount, HostId, InputCallbackInfo, OutputCallbackInfo, SampleFormat, SampleRate,
-    StreamConfig, SupportedBufferSize, SupportedStreamConfig, SupportedStreamConfigRange,
+    BufferSize, Data, DeviceDescription, DeviceDescriptionBuilder, DeviceDirection, DeviceId,
+    Error, ErrorKind, FrameCount, HostId, InputCallbackInfo, OutputCallbackInfo, SampleFormat,
+    SampleRate, StreamConfig, SupportedBufferSize, SupportedStreamConfig,
+    SupportedStreamConfigRange,
 };
 
 const MIN_SAMPLE_RATE: SampleRate = 8000;
@@ -326,7 +328,7 @@ impl DeviceTrait for Device {
         let sample_spec = make_sample_spec(config, format);
         let channel_map = make_channel_map(config);
         let buffer_attr = make_record_buffer_attr(config, format);
-        let adjust_latency = matches!(config.buffer_size, crate::BufferSize::Fixed(_));
+        let adjust_latency = matches!(config.buffer_size, BufferSize::Fixed(_));
 
         let params = protocol::RecordStreamParams {
             sample_spec,
@@ -399,7 +401,7 @@ impl DeviceTrait for Device {
         let sample_spec = make_sample_spec(config, format);
         let channel_map = make_channel_map(config);
         let buffer_attr = make_playback_buffer_attr(config, format);
-        let adjust_latency = matches!(config.buffer_size, crate::BufferSize::Fixed(_));
+        let adjust_latency = matches!(config.buffer_size, BufferSize::Fixed(_));
 
         let params = protocol::PlaybackStreamParams {
             sink_index: Some(info.index),
@@ -557,8 +559,8 @@ fn make_playback_buffer_attr(
     format: protocol::SampleFormat,
 ) -> protocol::stream::BufferAttr {
     match config.buffer_size {
-        crate::BufferSize::Default => Default::default(),
-        crate::BufferSize::Fixed(frame_count) => {
+        BufferSize::Default => Default::default(),
+        BufferSize::Fixed(frame_count) => {
             let len =
                 (frame_count as u64 * config.channels as u64 * format.bytes_per_sample() as u64)
                     .min(u32::MAX as u64) as u32;
@@ -582,8 +584,8 @@ fn make_record_buffer_attr(
     format: protocol::SampleFormat,
 ) -> protocol::stream::BufferAttr {
     match config.buffer_size {
-        crate::BufferSize::Default => Default::default(),
-        crate::BufferSize::Fixed(frame_count) => {
+        BufferSize::Default => Default::default(),
+        BufferSize::Fixed(frame_count) => {
             let len =
                 (frame_count as u64 * config.channels as u64 * format.bytes_per_sample() as u64)
                     .min(u32::MAX as u64) as u32;

--- a/src/host/pulseaudio/stream.rs
+++ b/src/host/pulseaudio/stream.rs
@@ -93,7 +93,7 @@ impl StreamTrait for Stream {
         Ok(())
     }
 
-    fn now(&self) -> crate::StreamInstant {
+    fn now(&self) -> StreamInstant {
         let start = match &self.0 {
             StreamInner::Playback(_, start, _) | StreamInner::Record(_, start, _) => *start,
         };
@@ -136,14 +136,12 @@ impl Stream {
         let latency_clone = current_latency_micros.clone();
         let poll_clone = last_poll_micros.clone();
         let sample_spec = params.sample_spec;
+        let pa_format = sample_spec.format;
 
-        let format: SampleFormat = sample_spec.format.try_into().map_err(|_| {
+        let format: SampleFormat = pa_format.try_into().map_err(|_| {
             Error::with_message(
                 ErrorKind::UnsupportedConfig,
-                format!(
-                    "PulseAudio sample format {:?} is not supported",
-                    sample_spec.format
-                ),
+                format!("PulseAudio sample format {pa_format:?} is not supported"),
             )
         })?;
 
@@ -291,14 +289,12 @@ impl Stream {
         let latency_clone = current_latency_micros.clone();
         let poll_clone = last_poll_micros.clone();
         let sample_spec = params.sample_spec;
+        let pa_format = sample_spec.format;
 
-        let format: SampleFormat = sample_spec.format.try_into().map_err(|_| {
+        let format: SampleFormat = pa_format.try_into().map_err(|_| {
             Error::with_message(
                 ErrorKind::UnsupportedConfig,
-                format!(
-                    "PulseAudio sample format {:?} is not supported",
-                    sample_spec.format
-                ),
+                format!("PulseAudio sample format {pa_format:?} is not supported"),
             )
         })?;
 

--- a/src/host/wasapi/device.rs
+++ b/src/host/wasapi/device.rs
@@ -16,33 +16,34 @@ impl From<Audio::EDataFlow> for DeviceDirection {
         }
     }
 }
-use std::ffi::OsString;
-use std::fmt;
-use std::mem;
-use std::os::windows::ffi::OsStringExt;
-use std::ptr;
-use std::slice;
-use std::sync::OnceLock;
-use std::sync::{Arc, Mutex, MutexGuard};
-use std::time::Duration;
+use std::{
+    ffi::OsString,
+    fmt, mem,
+    os::windows::ffi::OsStringExt,
+    ptr, slice,
+    sync::{Arc, Mutex, MutexGuard, OnceLock},
+    time::Duration,
+};
 
-use crate::host::com;
-use windows::core::Interface;
-use windows::core::GUID;
-use windows::Win32::Devices::Properties;
-use windows::Win32::Foundation::PROPERTYKEY;
-use windows::Win32::Media::Audio::IAudioRenderClient;
-use windows::Win32::Media::{Audio, KernelStreaming, Multimedia};
-use windows::Win32::System::Com;
-use windows::Win32::System::Com::{StructuredStorage, STGM_READ};
-use windows::Win32::System::Threading;
-use windows::Win32::System::Variant::{VT_LPWSTR, VT_UI4};
-use windows::Win32::UI::Shell::PropertiesSystem::IPropertyStore;
+use windows::{
+    core::{Interface, GUID},
+    Win32::{
+        Devices::Properties,
+        Foundation::PROPERTYKEY,
+        Media::{Audio, Audio::IAudioRenderClient, KernelStreaming, Multimedia},
+        System::{
+            Com,
+            Com::{StructuredStorage, STGM_READ},
+            Threading,
+            Variant::{VT_LPWSTR, VT_UI4},
+        },
+        UI::Shell::PropertiesSystem::IPropertyStore,
+    },
+};
 
 use super::stream::{AudioClientFlow, Stream, StreamInner};
-use crate::traits::DeviceTrait;
-
 pub use crate::iter::{SupportedInputConfigs, SupportedOutputConfigs};
+use crate::{host::com, traits::DeviceTrait};
 
 // PKEY_AudioEndpoint properties not yet in windows-rs
 
@@ -284,7 +285,7 @@ unsafe impl Sync for Device {}
 ///
 /// The JackSubType property contains a KS node type GUID string from Ksmedia.h
 /// that specifies the physical connector type.
-fn jacksubtype_to_interface_type(guid_str: &str) -> Option<crate::InterfaceType> {
+fn jacksubtype_to_interface_type(guid_str: &str) -> Option<InterfaceType> {
     let guid_upper = guid_str.to_uppercase();
     let typ = match guid_upper.as_str() {
         "{D9E55EA0-0C89-4692-84FF-EB3C4B0D172F}" => InterfaceType::Hdmi,
@@ -297,7 +298,7 @@ fn jacksubtype_to_interface_type(guid_str: &str) -> Option<crate::InterfaceType>
 }
 
 /// Maps WASAPI FormFactor values to DeviceType and optionally InterfaceType.
-fn form_factor_to_types(form_factor: u32) -> (crate::DeviceType, Option<crate::InterfaceType>) {
+fn form_factor_to_types(form_factor: u32) -> (DeviceType, Option<InterfaceType>) {
     match form_factor {
         0 => (DeviceType::Unknown, Some(InterfaceType::Network)), // RemoteNetworkDevice
         1 => (DeviceType::Speaker, None),                         // Speakers
@@ -314,7 +315,7 @@ fn form_factor_to_types(form_factor: u32) -> (crate::DeviceType, Option<crate::I
 }
 
 /// Maps WASAPI EnumeratorName to InterfaceType.
-fn enumerator_to_interface_type(enumerator: &str) -> Option<crate::InterfaceType> {
+fn enumerator_to_interface_type(enumerator: &str) -> Option<InterfaceType> {
     let typ = match enumerator.to_uppercase().as_str() {
         "HDAUDIO" => InterfaceType::BuiltIn,
         "USB" => InterfaceType::Usb,
@@ -379,7 +380,7 @@ impl Device {
             // Determine device_type and initial interface_type from FormFactor
             let (device_type, mut interface_type) = form_factor
                 .map(form_factor_to_types)
-                .unwrap_or((crate::DeviceType::Unknown, None));
+                .unwrap_or((DeviceType::Unknown, None));
 
             // Override interface_type from EnumeratorName if available
             if let Some(ref enumerator) = enumerator_name {
@@ -1198,9 +1199,9 @@ fn config_to_waveformatextensible(
 /// Get the default device period in frames for a shared-mode stream.
 fn shared_mode_period_frames(
     audio_client: &Audio::IAudioClient,
-    sample_rate: crate::SampleRate,
-    max_frames_in_buffer: crate::FrameCount,
-) -> crate::FrameCount {
+    sample_rate: SampleRate,
+    max_frames_in_buffer: FrameCount,
+) -> FrameCount {
     let mut default_period = 0i64;
     if unsafe { audio_client.GetDevicePeriod(Some(&mut default_period), None) }.is_ok()
         && default_period > 0

--- a/src/host/wasapi/device.rs
+++ b/src/host/wasapi/device.rs
@@ -88,7 +88,7 @@ impl DeviceTrait for Device {
     }
 
     fn id(&self) -> Result<DeviceId, Error> {
-        Device::id(self)
+        Self::id(self)
     }
 
     fn supports_input(&self) -> bool {
@@ -100,19 +100,19 @@ impl DeviceTrait for Device {
     }
 
     fn supported_input_configs(&self) -> Result<Self::SupportedInputConfigs, Error> {
-        Device::supported_input_configs(self)
+        Self::supported_input_configs(self)
     }
 
     fn supported_output_configs(&self) -> Result<Self::SupportedOutputConfigs, Error> {
-        Device::supported_output_configs(self)
+        Self::supported_output_configs(self)
     }
 
     fn default_input_config(&self) -> Result<SupportedStreamConfig, Error> {
-        Device::default_input_config(self)
+        Self::default_input_config(self)
     }
 
     fn default_output_config(&self) -> Result<SupportedStreamConfig, Error> {
-        Device::default_output_config(self)
+        Self::default_output_config(self)
     }
 
     fn build_input_stream_raw<D, E>(
@@ -1062,7 +1062,7 @@ impl Devices {
                 .GetCount()
                 .context("failed to get device count")?;
 
-            Ok(Devices {
+            Ok(Self {
                 collection,
                 total_count: count,
                 next_item: 0,
@@ -1077,7 +1077,7 @@ unsafe impl Sync for Devices {}
 impl Iterator for Devices {
     type Item = Device;
 
-    fn next(&mut self) -> Option<Device> {
+    fn next(&mut self) -> Option<Self::Item> {
         if self.next_item >= self.total_count {
             return None;
         }
@@ -1085,7 +1085,7 @@ impl Iterator for Devices {
         unsafe {
             let device = self.collection.Item(self.next_item).unwrap();
             self.next_item += 1;
-            Some(Device::from_immdevice(device))
+            Some(Self::Item::from_immdevice(device))
         }
     }
 

--- a/src/host/wasapi/mod.rs
+++ b/src/host/wasapi/mod.rs
@@ -2,6 +2,10 @@
 //!
 //! Default backend on Windows.
 
+use std::io::Error as IoError;
+
+use windows::Win32::Media::Audio;
+
 #[allow(unused_imports)]
 pub use self::device::{
     default_input_device, default_output_device, Device, Devices, SupportedInputConfigs,
@@ -9,10 +13,7 @@ pub use self::device::{
 };
 #[allow(unused_imports)]
 pub use self::stream::Stream;
-use crate::traits::HostTrait;
-use crate::{Error, ErrorKind};
-use std::io::Error as IoError;
-use windows::Win32::Media::Audio;
+use crate::{traits::HostTrait, Error, ErrorKind};
 
 mod device;
 mod stream;
@@ -26,7 +27,7 @@ mod stream;
 pub struct Host;
 
 impl Host {
-    pub fn new() -> Result<Self, crate::Error> {
+    pub fn new() -> Result<Self, Error> {
         Ok(Host)
     }
 }

--- a/src/host/wasapi/stream.rs
+++ b/src/host/wasapi/stream.rs
@@ -12,7 +12,7 @@ use windows::Win32::{
 };
 
 use crate::{
-    host::{fill_equilibrium, frames_to_duration},
+    host::{equilibrium::fill_equilibrium, frames_to_duration},
     traits::StreamTrait,
     BufferSize, Data, Error, ErrorKind, FrameCount, InputCallbackInfo, InputStreamTimestamp,
     OutputCallbackInfo, OutputStreamTimestamp, ResultExt, SampleFormat, SampleRate, StreamConfig,

--- a/src/host/wasapi/stream.rs
+++ b/src/host/wasapi/stream.rs
@@ -1,19 +1,23 @@
-use crate::traits::StreamTrait;
-use crate::{
-    error::ResultExt, BufferSize, Data, Error, ErrorKind, FrameCount, InputCallbackInfo,
-    OutputCallbackInfo, SampleFormat, SampleRate, StreamInstant,
+use std::{
+    mem, ptr,
+    sync::mpsc::{channel, Receiver, SendError, Sender},
+    thread::{self, JoinHandle},
+    time::Duration,
 };
-use std::mem;
-use std::ptr;
-use std::sync::mpsc::{channel, Receiver, SendError, Sender};
-use std::thread::{self, JoinHandle};
-use std::time::Duration;
-use windows::Win32::Foundation;
-use windows::Win32::Foundation::WAIT_OBJECT_0;
-use windows::Win32::Media::Audio;
-use windows::Win32::System::Performance;
-use windows::Win32::System::SystemServices;
-use windows::Win32::System::Threading;
+
+use windows::Win32::{
+    Foundation::{self, WAIT_OBJECT_0},
+    Media::Audio,
+    System::{Performance, SystemServices, Threading},
+};
+
+use crate::{
+    host::{fill_with_equilibrium, frames_to_duration},
+    traits::StreamTrait,
+    BufferSize, Data, Error, ErrorKind, FrameCount, InputCallbackInfo, InputStreamTimestamp,
+    OutputCallbackInfo, OutputStreamTimestamp, ResultExt, SampleFormat, SampleRate, StreamConfig,
+    StreamInstant,
+};
 
 pub struct Stream {
     /// The high-priority audio processing thread calling callbacks.
@@ -103,7 +107,7 @@ pub struct StreamInner {
     // Number of bytes that each frame occupies.
     pub bytes_per_frame: u16,
     // The configuration with which the stream was created.
-    pub config: crate::StreamConfig,
+    pub config: StreamConfig,
     // The sample format with which the stream was created.
     pub sample_format: SampleFormat,
     // Hardware pipeline latency.
@@ -335,6 +339,7 @@ fn wait_for_handle_signal(handles: &[Foundation::HANDLE]) -> Result<usize, Error
 }
 
 // Get the number of available frames that are available for writing/reading.
+#[inline]
 fn get_available_frames(stream: &StreamInner) -> Result<FrameCount, Error> {
     unsafe {
         let padding = stream
@@ -569,9 +574,14 @@ fn process_output(
 
         debug_assert!(!buffer.is_null());
 
+        let byte_count = frames_available as usize * stream.bytes_per_frame as usize;
+        fill_with_equilibrium(
+            std::slice::from_raw_parts_mut(buffer, byte_count),
+            stream.sample_format,
+        );
+
         let data = buffer as *mut ();
-        let len = frames_available as usize * stream.bytes_per_frame as usize
-            / stream.sample_format.sample_size();
+        let len = byte_count / stream.sample_format.sample_size();
         let mut data = Data::from_parts(data, len, stream.sample_format);
         let sample_rate = stream.config.sample_rate;
         let timestamp = match output_timestamp(stream, frames_available, sample_rate) {
@@ -585,7 +595,7 @@ fn process_output(
         data_callback(&mut data, &info);
 
         if let Err(err) = render_client.ReleaseBuffer(frames_available, 0) {
-            error_callback(Error::from(err));
+            error_callback(err.into());
             return ControlFlow::Break;
         }
     }
@@ -593,17 +603,10 @@ fn process_output(
     ControlFlow::Continue
 }
 
-/// Convert the given duration in frames at the given sample rate to a `Duration`.
-fn frames_to_duration(frames: FrameCount, rate: SampleRate) -> Duration {
-    let secsf = frames as f64 / rate as f64;
-    let secs = secsf as u64;
-    let nanos = ((secsf - secs as f64) * 1_000_000_000.0) as u32;
-    Duration::new(secs, nanos)
-}
-
 /// Use the stream's `IAudioClock` to produce the current stream instant.
 ///
 /// Uses the QPC position produced via the `GetPosition` method.
+#[inline]
 fn stream_instant(stream: &StreamInner) -> Result<StreamInstant, Error> {
     let mut position: u64 = 0;
     let mut qpc_position: u64 = 0;
@@ -627,10 +630,11 @@ fn stream_instant(stream: &StreamInner) -> Result<StreamInstant, Error> {
 /// `buffer_qpc_position` is the `qpc_position` returned via the `GetBuffer` call on the capture
 /// client. It represents the instant at which the first sample of the retrieved buffer was
 /// captured.
+#[inline]
 fn input_timestamp(
     stream: &StreamInner,
     buffer_qpc_position: u64,
-) -> Result<crate::InputStreamTimestamp, Error> {
+) -> Result<InputStreamTimestamp, Error> {
     // The `qpc_position` is in 100-nanosecond units.
     let nanos = buffer_qpc_position as u128 * 100;
     let capture = StreamInstant::new(
@@ -638,7 +642,7 @@ fn input_timestamp(
         (nanos % 1_000_000_000) as u32,
     );
     let callback = stream_instant(stream)?;
-    Ok(crate::InputStreamTimestamp { capture, callback })
+    Ok(InputStreamTimestamp { capture, callback })
 }
 
 /// Produce the output stream timestamp.
@@ -647,15 +651,16 @@ fn input_timestamp(
 /// result of `GetCurrentPadding` from the maximum buffer size.
 ///
 /// `sample_rate` is the rate at which audio frames are processed by the device.
+#[inline]
 fn output_timestamp(
     stream: &StreamInner,
     frames_available: FrameCount,
     sample_rate: SampleRate,
-) -> Result<crate::OutputStreamTimestamp, Error> {
+) -> Result<OutputStreamTimestamp, Error> {
     let callback = stream_instant(stream)?;
     // `padding` is the number of frames already queued in the endpoint buffer ahead of the
     // frames we are about to write. Those frames must drain before ours are heard.
     let padding = stream.max_frames_in_buffer - frames_available;
     let playback = callback + (frames_to_duration(padding, sample_rate) + stream.stream_latency);
-    Ok(crate::OutputStreamTimestamp { callback, playback })
+    Ok(OutputStreamTimestamp { callback, playback })
 }

--- a/src/host/wasapi/stream.rs
+++ b/src/host/wasapi/stream.rs
@@ -12,7 +12,7 @@ use windows::Win32::{
 };
 
 use crate::{
-    host::{fill_with_equilibrium, frames_to_duration},
+    host::{fill_equilibrium, frames_to_duration},
     traits::StreamTrait,
     BufferSize, Data, Error, ErrorKind, FrameCount, InputCallbackInfo, InputStreamTimestamp,
     OutputCallbackInfo, OutputStreamTimestamp, ResultExt, SampleFormat, SampleRate, StreamConfig,
@@ -575,10 +575,8 @@ fn process_output(
         debug_assert!(!buffer.is_null());
 
         let byte_count = frames_available as usize * stream.bytes_per_frame as usize;
-        fill_with_equilibrium(
-            std::slice::from_raw_parts_mut(buffer, byte_count),
-            stream.sample_format,
-        );
+        let buffer_slice = std::slice::from_raw_parts_mut(buffer, byte_count);
+        fill_equilibrium(buffer_slice, stream.sample_format);
 
         let data = buffer as *mut ();
         let len = byte_count / stream.sample_format.sample_size();

--- a/src/host/webaudio/mod.rs
+++ b/src/host/webaudio/mod.rs
@@ -68,7 +68,7 @@ const SUPPORTED_SAMPLE_FORMAT: SampleFormat = SampleFormat::F32;
 
 impl Host {
     pub fn new() -> Result<Self, Error> {
-        Ok(Host)
+        Ok(Self)
     }
 }
 
@@ -82,7 +82,7 @@ impl HostTrait for Host {
     }
 
     fn devices(&self) -> Result<Self::Devices, Error> {
-        Devices::new()
+        Self::Devices::new()
     }
 
     fn default_input_device(&self) -> Option<Self::Device> {
@@ -162,27 +162,27 @@ impl DeviceTrait for Device {
     type Stream = Stream;
 
     fn description(&self) -> Result<DeviceDescription, Error> {
-        Device::description(self)
+        Self::description(self)
     }
 
     fn id(&self) -> Result<DeviceId, Error> {
-        Device::id(self)
+        Self::id(self)
     }
 
     fn supported_input_configs(&self) -> Result<Self::SupportedInputConfigs, Error> {
-        Device::supported_input_configs(self)
+        Self::supported_input_configs(self)
     }
 
     fn supported_output_configs(&self) -> Result<Self::SupportedOutputConfigs, Error> {
-        Device::supported_output_configs(self)
+        Self::supported_output_configs(self)
     }
 
     fn default_input_config(&self) -> Result<SupportedStreamConfig, Error> {
-        Device::default_input_config(self)
+        Self::default_input_config(self)
     }
 
     fn default_output_config(&self) -> Result<SupportedStreamConfig, Error> {
-        Device::default_output_config(self)
+        Self::default_output_config(self)
     }
 
     fn build_input_stream_raw<D, E>(
@@ -500,7 +500,7 @@ impl DeviceTrait for Device {
             on_ended_closures.push(on_ended_closure);
         }
 
-        Ok(Stream {
+        Ok(Self::Stream {
             ctx,
             on_ended_closures,
             config,
@@ -596,10 +596,10 @@ impl Default for Devices {
 impl Iterator for Devices {
     type Item = Device;
 
-    fn next(&mut self) -> Option<Device> {
+    fn next(&mut self) -> Option<Self::Item> {
         if self.0 {
             self.0 = false;
-            Some(Device)
+            Some(Self::Item)
         } else {
             None
         }

--- a/src/host/webaudio/mod.rs
+++ b/src/host/webaudio/mod.rs
@@ -6,19 +6,26 @@ extern crate js_sys;
 extern crate wasm_bindgen;
 extern crate web_sys;
 
-use self::wasm_bindgen::prelude::*;
-use self::wasm_bindgen::JsCast;
-use self::web_sys::{AudioContext, AudioContextOptions};
-use crate::traits::{DeviceTrait, HostTrait, StreamTrait};
+use std::{
+    ops::DerefMut,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc, Mutex, RwLock,
+    },
+    time::Duration,
+};
+
+use self::{
+    wasm_bindgen::{prelude::*, JsCast},
+    web_sys::{AudioContext, AudioContextOptions},
+};
 use crate::{
-    BufferSize, Data, DeviceDescription, DeviceDescriptionBuilder, DeviceId, Error, ErrorKind,
-    InputCallbackInfo, OutputCallbackInfo, SampleFormat, SampleRate, StreamConfig, StreamInstant,
+    traits::{DeviceTrait, HostTrait, StreamTrait},
+    BufferSize, ChannelCount, Data, DeviceDescription, DeviceDescriptionBuilder, DeviceDirection,
+    DeviceId, Error, ErrorKind, FrameCount, InputCallbackInfo, OutputCallbackInfo,
+    OutputStreamTimestamp, SampleFormat, SampleRate, StreamConfig, StreamInstant,
     SupportedBufferSize, SupportedStreamConfig, SupportedStreamConfigRange,
 };
-use std::ops::DerefMut;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex, RwLock};
-use std::time::Duration;
 
 /// Type alias for shared closure handles used in audio callbacks
 type ClosureHandle = Arc<RwLock<Option<Closure<dyn FnMut()>>>>;
@@ -49,8 +56,8 @@ crate::assert_stream_sync!(Stream);
 
 pub use crate::iter::{SupportedInputConfigs, SupportedOutputConfigs};
 
-const MIN_CHANNELS: u16 = 1;
-const MAX_CHANNELS: u16 = 32;
+const MIN_CHANNELS: ChannelCount = 1;
+const MAX_CHANNELS: ChannelCount = 32;
 const MIN_SAMPLE_RATE: SampleRate = 8_000;
 const MAX_SAMPLE_RATE: SampleRate = 96_000;
 const DEFAULT_SAMPLE_RATE: SampleRate = 44_100;
@@ -60,7 +67,7 @@ const DEFAULT_BUFFER_SIZE: usize = 2048;
 const SUPPORTED_SAMPLE_FORMAT: SampleFormat = SampleFormat::F32;
 
 impl Host {
-    pub fn new() -> Result<Self, crate::Error> {
+    pub fn new() -> Result<Self, Error> {
         Ok(Host)
     }
 }
@@ -96,7 +103,7 @@ impl Devices {
 impl Device {
     fn description(&self) -> Result<DeviceDescription, Error> {
         Ok(DeviceDescriptionBuilder::new("Default Device".to_string())
-            .direction(crate::DeviceDirection::Output)
+            .direction(DeviceDirection::Output)
             .build())
     }
 
@@ -363,7 +370,7 @@ impl DeviceTrait for Device {
                                 let playback = StreamInstant::from_secs_f64(
                                     time_at_start_of_buffer + total_hw_latency_secs,
                                 );
-                                let timestamp = crate::OutputStreamTimestamp { callback, playback };
+                                let timestamp = OutputStreamTimestamp { callback, playback };
                                 let info = OutputCallbackInfo { timestamp };
                                 (data_callback.deref_mut())(&mut data, &info);
                             }
@@ -568,8 +575,8 @@ impl StreamTrait for Stream {
         StreamInstant::from_secs_f64(self.ctx.current_time())
     }
 
-    fn buffer_size(&self) -> Result<crate::FrameCount, Error> {
-        Ok(self.buffer_size_frames as crate::FrameCount)
+    fn buffer_size(&self) -> Result<FrameCount, Error> {
+        Ok(self.buffer_size_frames as FrameCount)
     }
 }
 
@@ -589,7 +596,6 @@ impl Default for Devices {
 impl Iterator for Devices {
     type Item = Device;
 
-    #[inline]
     fn next(&mut self) -> Option<Device> {
         if self.0 {
             self.0 = false;

--- a/src/host/webaudio/mod.rs
+++ b/src/host/webaudio/mod.rs
@@ -599,7 +599,7 @@ impl Iterator for Devices {
     fn next(&mut self) -> Option<Self::Item> {
         if self.0 {
             self.0 = false;
-            Some(Self::Item)
+            Some(Device)
         } else {
             None
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,9 +164,6 @@ extern crate wasm_bindgen;
 #[cfg(all(target_arch = "wasm32", feature = "wasm-bindgen"))]
 extern crate web_sys;
 
-#[cfg(all(target_arch = "wasm32", feature = "wasm-bindgen"))]
-use wasm_bindgen::prelude::*;
-
 pub use device_description::{
     DeviceDescription, DeviceDescriptionBuilder, DeviceDirection, DeviceType, InterfaceType,
 };
@@ -176,6 +173,8 @@ pub use platform::{
     SupportedInputConfigs, SupportedOutputConfigs, ALL_HOSTS,
 };
 pub use samples_formats::{FromSample, Sample, SampleFormat, SizedSample, I24, U24};
+#[cfg(all(target_arch = "wasm32", feature = "wasm-bindgen"))]
+use wasm_bindgen::prelude::*;
 
 pub mod device_description;
 mod error;
@@ -691,6 +690,7 @@ impl SupportedStreamConfigRange {
     /// - Max sample rate
     pub fn cmp_default_heuristics(&self, other: &Self) -> std::cmp::Ordering {
         use std::cmp::Ordering::Equal;
+
         use SampleFormat::{F32, I16, I24, I32, U16, U24, U32};
 
         let cmp_stereo = (self.channels == 2).cmp(&(other.channels == 2));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,7 +172,7 @@ pub use platform::{
     available_hosts, default_host, host_from_id, Device, Devices, Host, HostId, Stream,
     SupportedInputConfigs, SupportedOutputConfigs, ALL_HOSTS,
 };
-pub use samples_formats::{FromSample, Sample, SampleFormat, SizedSample, I24, U24};
+pub use sample_format::{FromSample, Sample, SampleFormat, SizedSample, I24, U24};
 #[cfg(all(target_arch = "wasm32", feature = "wasm-bindgen"))]
 use wasm_bindgen::prelude::*;
 
@@ -180,7 +180,7 @@ pub mod device_description;
 mod error;
 mod host;
 pub mod platform;
-mod samples_formats;
+mod sample_format;
 mod timestamp;
 pub mod traits;
 
@@ -270,7 +270,7 @@ impl std::str::FromStr for DeviceId {
 
         let host_id = crate::platform::HostId::from_str(host_str)?;
 
-        Ok(DeviceId(host_id, device_str.to_string()))
+        Ok(Self(host_id, device_str.to_string()))
     }
 }
 
@@ -509,7 +509,7 @@ impl Data {
     /// - The `sample_format` must correctly represent the underlying sample data delivered/expected
     ///   by the stream.
     pub unsafe fn from_parts(data: *mut (), len: usize, sample_format: SampleFormat) -> Self {
-        Data {
+        Self {
             data,
             len,
             sample_format,

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -6,7 +6,6 @@
 
 #[doc(inline)]
 pub use self::platform_impl::*;
-
 #[cfg(feature = "custom")]
 pub use crate::host::custom::{Device as CustomDevice, Host as CustomHost, Stream as CustomStream};
 
@@ -860,12 +859,6 @@ mod platform_impl {
 
 #[cfg(all(target_arch = "wasm32", feature = "wasm-bindgen"))]
 mod platform_impl {
-    #[cfg_attr(
-        docsrs,
-        doc(cfg(all(target_arch = "wasm32", feature = "wasm-bindgen")))
-    )]
-    pub use crate::host::webaudio::Host as WebAudioHost;
-
     #[cfg(feature = "audioworklet")]
     #[cfg_attr(
         docsrs,
@@ -876,6 +869,11 @@ mod platform_impl {
         )))
     )]
     pub use crate::host::audioworklet::Host as AudioWorkletHost;
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(all(target_arch = "wasm32", feature = "wasm-bindgen")))
+    )]
+    pub use crate::host::webaudio::Host as WebAudioHost;
 
     impl_platform_host!(
         WebAudio => WebAudioHost,

--- a/src/sample_format.rs
+++ b/src/sample_format.rs
@@ -6,7 +6,10 @@
 //! CPAL handles any necessary conversions when interfacing with hardware that uses
 //! a different byte order.
 
-use std::{fmt::Display, mem};
+use std::{
+    fmt::{self, Display},
+    mem,
+};
 
 /// 24-bit signed integer sample type.
 ///
@@ -16,6 +19,7 @@ use std::{fmt::Display, mem};
 /// with the most significant byte unused. Use [`SampleFormat::bits_per_sample`] to get
 /// the actual bit depth (24) vs [`SampleFormat::sample_size`] for storage size (4 bytes).
 pub use dasp_sample::I24;
+
 /// 24-bit unsigned integer sample type.
 ///
 /// Represents 24-bit audio with range `0..=((1 << 24) - 1)`, with origin at `1 << 23 == 8388608`.
@@ -25,6 +29,7 @@ pub use dasp_sample::I24;
 /// the actual bit depth (24) vs [`SampleFormat::sample_size`] for storage size (4 bytes).
 pub use dasp_sample::U24;
 pub use dasp_sample::{FromSample, Sample};
+
 #[cfg(all(target_arch = "wasm32", feature = "wasm-bindgen"))]
 use wasm_bindgen::prelude::*;
 
@@ -203,7 +208,7 @@ impl SampleFormat {
 }
 
 impl Display for SampleFormat {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             SampleFormat::I8 => "i8",
             SampleFormat::I16 => "i16",

--- a/src/samples_formats.rs
+++ b/src/samples_formats.rs
@@ -7,10 +7,6 @@
 //! a different byte order.
 
 use std::{fmt::Display, mem};
-#[cfg(all(target_arch = "wasm32", feature = "wasm-bindgen"))]
-use wasm_bindgen::prelude::*;
-
-pub use dasp_sample::{FromSample, Sample};
 
 /// 24-bit signed integer sample type.
 ///
@@ -20,7 +16,6 @@ pub use dasp_sample::{FromSample, Sample};
 /// with the most significant byte unused. Use [`SampleFormat::bits_per_sample`] to get
 /// the actual bit depth (24) vs [`SampleFormat::sample_size`] for storage size (4 bytes).
 pub use dasp_sample::I24;
-
 /// 24-bit unsigned integer sample type.
 ///
 /// Represents 24-bit audio with range `0..=((1 << 24) - 1)`, with origin at `1 << 23 == 8388608`.
@@ -29,6 +24,9 @@ pub use dasp_sample::I24;
 /// with the most significant byte unused. Use [`SampleFormat::bits_per_sample`] to get
 /// the actual bit depth (24) vs [`SampleFormat::sample_size`] for storage size (4 bytes).
 pub use dasp_sample::U24;
+pub use dasp_sample::{FromSample, Sample};
+#[cfg(all(target_arch = "wasm32", feature = "wasm-bindgen"))]
+use wasm_bindgen::prelude::*;
 
 // I48 and U48 are not currently supported by cpal but available in dasp_sample:
 // pub use dasp_sample::{I48, U48};

--- a/src/timestamp.rs
+++ b/src/timestamp.rs
@@ -220,7 +220,7 @@ impl std::ops::Sub<Duration> for StreamInstant {
     #[inline]
     fn sub(self, rhs: Duration) -> Self::Output {
         self.checked_sub(rhs)
-            .expect("overflow when subtracting duration from stream instant")
+            .expect("underflow when subtracting duration from stream instant")
     }
 }
 

--- a/src/timestamp.rs
+++ b/src/timestamp.rs
@@ -108,7 +108,7 @@ impl StreamInstant {
         let total = self.as_nanos().checked_add(duration.as_nanos())?;
         let secs = u64::try_from(total / 1_000_000_000).ok()?;
         let nanos = (total % 1_000_000_000) as u32;
-        Some(StreamInstant { secs, nanos })
+        Some(Self { secs, nanos })
     }
 
     /// Returns `Some(t)` where `t` is `self - duration`, or `None` if the result cannot be
@@ -117,7 +117,7 @@ impl StreamInstant {
         let total = self.as_nanos().checked_sub(duration.as_nanos())?;
         let secs = u64::try_from(total / 1_000_000_000).ok()?;
         let nanos = (total % 1_000_000_000) as u32;
-        Some(StreamInstant { secs, nanos })
+        Some(Self { secs, nanos })
     }
 
     /// Returns the total number of nanoseconds contained by this `StreamInstant`.
@@ -182,7 +182,7 @@ impl StreamInstant {
         let secs = secs
             .checked_add(carry as u64)
             .expect("overflow in StreamInstant::new");
-        StreamInstant {
+        Self {
             secs,
             nanos: subsec_nanos,
         }
@@ -190,14 +190,14 @@ impl StreamInstant {
 }
 
 impl std::ops::Add<Duration> for StreamInstant {
-    type Output = StreamInstant;
+    type Output = Self;
 
     /// # Panics
     ///
     /// Panics if the result overflows the range of `StreamInstant`. Use
     /// [`checked_add`][StreamInstant::checked_add] for a non-panicking variant.
     #[inline]
-    fn add(self, rhs: Duration) -> StreamInstant {
+    fn add(self, rhs: Duration) -> Self::Output {
         self.checked_add(rhs)
             .expect("overflow when adding duration to stream instant")
     }
@@ -211,14 +211,14 @@ impl std::ops::AddAssign<Duration> for StreamInstant {
 }
 
 impl std::ops::Sub<Duration> for StreamInstant {
-    type Output = StreamInstant;
+    type Output = Self;
 
     /// # Panics
     ///
     /// Panics if the result underflows the range of `StreamInstant`. Use
     /// [`checked_sub`][StreamInstant::checked_sub] for a non-panicking variant.
     #[inline]
-    fn sub(self, rhs: Duration) -> StreamInstant {
+    fn sub(self, rhs: Duration) -> Self::Output {
         self.checked_sub(rhs)
             .expect("overflow when subtracting duration from stream instant")
     }
@@ -237,7 +237,7 @@ impl std::ops::Sub<StreamInstant> for StreamInstant {
     /// Returns the duration from `rhs` to `self`, saturating to [`Duration::ZERO`] if `rhs` is
     /// later than `self`.
     #[inline]
-    fn sub(self, rhs: StreamInstant) -> Duration {
+    fn sub(self, rhs: StreamInstant) -> Self::Output {
         self.saturating_duration_since(rhs)
     }
 }


### PR DESCRIPTION
Various points of code hygiene and one bug fix. Most material ones:

- Ensure output buffers are equilibrium-filled ("zero-filled") before the callback runs
- Inline helper functions in hot paths
- DRY up `frames_to_duration` across hosts

Style things:

- Import types into scope instead of repeating full paths
- Consistently use `Self` and associated types
- Consistently use `FrameCount`, `SampleRate`, and `ChannelCount` type aliases