### PR TITLE
fix(coreaudio): reroute when default output changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `ErrorKind::DeviceBusy` for retryable device access errors (e.g. EBUSY, EAGAIN).
+- `ErrorKind::DeviceChanged` signals that the audio route changed to another device.
 - `ErrorKind::PermissionDenied` for OS-level access denials.
 - `StreamConfig` now implements `Copy`.
 - `StreamTrait::buffer_size()` to query the stream's current buffer size in frames per callback.
@@ -57,6 +58,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   rate change on macOS, and on iOS on route changes that require a stream rebuild.
 - **CoreAudio**: Stream error callback now receives `ErrorKind::DeviceNotAvailable` on iOS
   when media services are lost.
+- **CoreAudio**: Default output streams now receive `ErrorKind::DeviceChanged` when the system
+  default output device changes.
+- **CoreAudio**: On iOS, unplugging headphones now emits `ErrorKind::DeviceChanged` (stream
+  rerouted to speaker).
 - **CoreAudio**: User timeouts are now respected when building a stream.
 - **JACK**: Timestamps now use the precise hardware deadline.
 - **JACK**: Buffer size change no longer fires an error callback; internal buffers are resized
@@ -106,6 +111,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   update.
 - **ASIO**: Poisoned stream locks now return `ErrorKind::StreamInvalidated` instead of panicking.
 - **ASIO**: Output buffers are now zero-filled before the callback runs.
+- **CoreAudio**: Fix default output streams silently stopping when the system default output
+  device is unplugged; they now reroute automatically or report `ErrorKind::DeviceNotAvailable`.
 - **CoreAudio**: Fix undefined behaviour and silent failure in loopback device creation.
 - **CoreAudio**: Poisoned stream locks now return `ErrorKind::StreamInvalidated` instead of 
   panicking.

--- a/src/error.rs
+++ b/src/error.rs
@@ -12,6 +12,10 @@ pub enum ErrorKind {
     /// is using the device. Retrying after a short delay may succeed.
     DeviceBusy,
 
+    /// The active audio route changed and the stream was automatically rerouted.
+    /// The stream remains active and no rebuild is required.
+    DeviceChanged,
+
     /// The requested audio device is not available.
     ///
     /// This can happen if the device has been disconnected while the program is running, or if
@@ -71,6 +75,9 @@ impl Display for ErrorKind {
         match self {
             Self::HostUnavailable => f.write_str(
                 "The requested audio host is not available. The subsystem or daemon may not be installed or running.",
+            ),
+            Self::DeviceChanged => f.write_str(
+                "The audio route changed. The stream was automatically rerouted to a different device.",
             ),
             Self::DeviceNotAvailable => f.write_str(
                 "The requested audio device is not available. It may have been disconnected.",

--- a/src/host/coreaudio/ios/session_event_manager.rs
+++ b/src/host/coreaudio/ios/session_event_manager.rs
@@ -28,7 +28,7 @@ unsafe fn route_change_error(notification: &NSNotification) -> Option<Error> {
     match reason {
         AVAudioSessionRouteChangeReason::OldDeviceUnavailable => Some(Error::with_message(
             ErrorKind::DeviceChanged,
-            "audio output device changed",
+            "audio route changed",
         )),
 
         AVAudioSessionRouteChangeReason::CategoryChange

--- a/src/host/coreaudio/ios/session_event_manager.rs
+++ b/src/host/coreaudio/ios/session_event_manager.rs
@@ -26,8 +26,12 @@ unsafe fn route_change_error(notification: &NSNotification) -> Option<Error> {
     let number = value.downcast_ref::<NSNumber>()?;
     let reason = AVAudioSessionRouteChangeReason(number.unsignedIntegerValue());
     match reason {
-        AVAudioSessionRouteChangeReason::OldDeviceUnavailable
-        | AVAudioSessionRouteChangeReason::CategoryChange
+        AVAudioSessionRouteChangeReason::OldDeviceUnavailable => Some(Error::with_message(
+            ErrorKind::DeviceChanged,
+            "audio output device changed",
+        )),
+
+        AVAudioSessionRouteChangeReason::CategoryChange
         | AVAudioSessionRouteChangeReason::Override
         | AVAudioSessionRouteChangeReason::RouteConfigurationChange => Some(Error::with_message(
             ErrorKind::StreamInvalidated,

--- a/src/host/coreaudio/macos/device.rs
+++ b/src/host/coreaudio/macos/device.rs
@@ -1,5 +1,5 @@
-use super::Stream;
 use super::{asbd_from_config, check_os_status, host_time_to_stream_instant};
+use super::{DefaultOutputMonitor, DisconnectManager, Stream};
 
 use crate::{
     host::{
@@ -44,9 +44,7 @@ use objc2_core_audio_types::{
 use objc2_core_foundation::CFString;
 use objc2_core_foundation::Type;
 
-pub use super::enumerate::{
-    default_input_device, default_output_device, SupportedInputConfigs, SupportedOutputConfigs,
-};
+pub use super::enumerate::{default_output_device, SupportedInputConfigs, SupportedOutputConfigs};
 use std::fmt;
 use std::mem::{self, size_of};
 use std::ptr::{null, NonNull};
@@ -216,43 +214,57 @@ fn set_sample_rate(
     Ok(())
 }
 
-fn audio_unit_from_device(device: &Device, input: bool) -> Result<AudioUnit, coreaudio::Error> {
-    let output_type = if !input && is_default_output_device(device) {
-        coreaudio::audio_unit::IOType::DefaultOutput
-    } else {
-        coreaudio::audio_unit::IOType::HalOutput
-    };
-    let mut audio_unit = AudioUnit::new(output_type)?;
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+enum AudioUnitMode {
+    /// HAL Output AudioUnit with input enabled, pinned to a specific device.
+    Input,
+    /// HAL Output AudioUnit for output, pinned to a specific device.
+    Output,
+    /// DefaultOutput AudioUnit; follows the system default output device automatically.
+    DefaultOutput,
+}
 
-    if input {
-        // Enable input processing.
-        let enable_input = 1u32;
-        audio_unit.set_property(
-            kAudioOutputUnitProperty_EnableIO,
-            Scope::Input,
-            Element::Input,
-            Some(&enable_input),
-        )?;
+fn audio_unit_from_device(
+    device: &Device,
+    mode: AudioUnitMode,
+) -> Result<AudioUnit, coreaudio::Error> {
+    match mode {
+        AudioUnitMode::DefaultOutput => {
+            AudioUnit::new(coreaudio::audio_unit::IOType::DefaultOutput)
+        }
+        AudioUnitMode::Input | AudioUnitMode::Output => {
+            let mut audio_unit = AudioUnit::new(coreaudio::audio_unit::IOType::HalOutput)?;
 
-        // Disable output processing.
-        let disable_output = 0u32;
-        audio_unit.set_property(
-            kAudioOutputUnitProperty_EnableIO,
-            Scope::Output,
-            Element::Output,
-            Some(&disable_output),
-        )?;
+            if matches!(mode, AudioUnitMode::Input) {
+                let enable_input = 1u32;
+                audio_unit.set_property(
+                    kAudioOutputUnitProperty_EnableIO,
+                    Scope::Input,
+                    Element::Input,
+                    Some(&enable_input),
+                )?;
+
+                let disable_output = 0u32;
+                audio_unit.set_property(
+                    kAudioOutputUnitProperty_EnableIO,
+                    Scope::Output,
+                    Element::Output,
+                    Some(&disable_output),
+                )?;
+            }
+
+            // Device selection is a device-level property:
+            // always use Scope::Global + Element::Output
+            audio_unit.set_property(
+                kAudioOutputUnitProperty_CurrentDevice,
+                Scope::Global,
+                Element::Output,
+                Some(&device.audio_device_id),
+            )?;
+
+            Ok(audio_unit)
+        }
     }
-
-    // Device selection is a device-level property: always use Scope::Global + Element::Output
-    audio_unit.set_property(
-        kAudioOutputUnitProperty_CurrentDevice,
-        Scope::Global,
-        Element::Output,
-        Some(&device.audio_device_id),
-    )?;
-
-    Ok(audio_unit)
 }
 
 fn get_io_buffer_frame_size_range(
@@ -349,10 +361,6 @@ impl DeviceTrait for Device {
 #[derive(Clone, Eq, Hash, PartialEq)]
 pub struct Device {
     pub(crate) audio_device_id: AudioDeviceID,
-}
-
-fn is_default_input_device(device: &Device) -> bool {
-    default_input_device().is_some_and(|d| d.audio_device_id == device.audio_device_id)
 }
 
 fn is_default_output_device(device: &Device) -> bool {
@@ -554,9 +562,9 @@ impl Device {
             ranges.set_len(n_ranges);
 
             #[allow(non_upper_case_globals)]
-            let input = match scope {
-                kAudioObjectPropertyScopeInput => true,
-                kAudioObjectPropertyScopeOutput => false,
+            let mode = match scope {
+                kAudioObjectPropertyScopeInput => AudioUnitMode::Input,
+                kAudioObjectPropertyScopeOutput => AudioUnitMode::Output,
                 _ => {
                     return Err(Error::with_message(
                         ErrorKind::UnsupportedOperation,
@@ -564,7 +572,7 @@ impl Device {
                     ))
                 }
             };
-            let audio_unit = audio_unit_from_device(self, input)?;
+            let audio_unit = audio_unit_from_device(self, mode)?;
             let buffer_size = get_io_buffer_frame_size_range(&audio_unit)?;
 
             // Collect the supported formats for the device.
@@ -665,9 +673,9 @@ impl Device {
                 };
 
             #[allow(non_upper_case_globals)]
-            let input = match scope {
-                kAudioObjectPropertyScopeInput => true,
-                kAudioObjectPropertyScopeOutput => false,
+            let mode = match scope {
+                kAudioObjectPropertyScopeInput => AudioUnitMode::Input,
+                kAudioObjectPropertyScopeOutput => AudioUnitMode::Output,
                 _ => {
                     return Err(Error::with_message(
                         ErrorKind::UnsupportedOperation,
@@ -675,7 +683,7 @@ impl Device {
                     ))
                 }
             };
-            let audio_unit = audio_unit_from_device(self, input)?;
+            let audio_unit = audio_unit_from_device(self, mode)?;
             let buffer_size = get_io_buffer_frame_size_range(&audio_unit)?;
 
             let config = SupportedStreamConfig {
@@ -750,16 +758,20 @@ impl Device {
 
         let mut loopback_aggregate: Option<LoopbackDevice> = None;
         let mut audio_unit = if self.supports_input() {
-            audio_unit_from_device(self, true)?
+            audio_unit_from_device(self, AudioUnitMode::Input)?
         } else {
             loopback_aggregate.replace(LoopbackDevice::from_device(self)?);
-            audio_unit_from_device(&loopback_aggregate.as_ref().unwrap().aggregate_device, true)?
+            audio_unit_from_device(
+                &loopback_aggregate.as_ref().unwrap().aggregate_device,
+                AudioUnitMode::Input,
+            )?
         };
 
         // Configure stream format and buffer size for predictable callback behavior.
         configure_stream_format_and_buffer(&mut audio_unit, config, sample_format, scope, element)?;
 
-        let error_callback = Arc::new(Mutex::new(error_callback));
+        let error_callback: Arc<Mutex<super::ErrorCallback>> =
+            Arc::new(Mutex::new(Box::new(error_callback)));
         let error_callback_disconnect = error_callback.clone();
 
         // Register the callback that is being called by coreaudio whenever it needs data to be
@@ -801,25 +813,19 @@ impl Device {
             Ok(())
         })?;
 
-        // Create error callback for stream - either dummy or real based on device type
-        let error_callback_for_stream: super::ErrorCallback = if is_default_input_device(self) {
-            Box::new(|_: Error| {})
-        } else {
-            let error_callback_clone = error_callback_disconnect.clone();
-            Box::new(move |err: Error| {
-                invoke_error_callback(&error_callback_clone, err);
-            })
-        };
-
-        let stream = Stream::new(
-            StreamInner {
-                playing: true,
-                audio_unit,
-                device_id: self.audio_device_id,
-                _loopback_device: loopback_aggregate,
-            },
-            error_callback_for_stream,
-        )?;
+        let inner_arc = Arc::new(Mutex::new(StreamInner {
+            playing: true,
+            audio_unit,
+            device_id: self.audio_device_id,
+            _loopback_device: loopback_aggregate,
+        }));
+        let weak_inner = Arc::downgrade(&inner_arc);
+        let monitor: Box<dyn Send + Sync> = Box::new(DisconnectManager::new(
+            self.audio_device_id,
+            weak_inner,
+            error_callback_disconnect,
+        )?);
+        let stream = Stream::new(inner_arc, monitor);
 
         stream
             .inner
@@ -857,7 +863,12 @@ impl Device {
             set_sample_rate(self.audio_device_id, config.sample_rate, timeout)?;
         }
 
-        let mut audio_unit = audio_unit_from_device(self, false)?;
+        let mode = if is_default_output_device(self) {
+            AudioUnitMode::DefaultOutput
+        } else {
+            AudioUnitMode::Output
+        };
+        let mut audio_unit = audio_unit_from_device(self, mode)?;
 
         // The scope and element for working with a device's output stream.
         let scope = Scope::Input;
@@ -866,8 +877,9 @@ impl Device {
         // Configure device buffer (see comprehensive documentation in input stream above)
         configure_stream_format_and_buffer(&mut audio_unit, config, sample_format, scope, element)?;
 
-        let error_callback = Arc::new(Mutex::new(error_callback));
-        let error_callback_disconnect = error_callback.clone();
+        let error_callback: Arc<Mutex<super::ErrorCallback>> =
+            Arc::new(Mutex::new(Box::new(error_callback)));
+        let error_callback_for_render = error_callback.clone();
 
         // Register the callback that is being called by coreaudio whenever it needs data to be
         // fed to the audio buffer.
@@ -891,7 +903,7 @@ impl Device {
 
             let callback = match host_time_to_stream_instant(args.time_stamp.mHostTime) {
                 Err(err) => {
-                    invoke_error_callback(&error_callback, err);
+                    invoke_error_callback(&error_callback_for_render, err);
                     return Err(());
                 }
                 Ok(cb) => cb,
@@ -909,25 +921,23 @@ impl Device {
             Ok(())
         })?;
 
-        // Create error callback for stream - either dummy or real based on device type
-        let error_callback_for_stream: super::ErrorCallback = if is_default_output_device(self) {
-            Box::new(|_: Error| {})
+        let inner_arc = Arc::new(Mutex::new(StreamInner {
+            playing: true,
+            audio_unit,
+            device_id: self.audio_device_id,
+            _loopback_device: None,
+        }));
+        let weak_inner = Arc::downgrade(&inner_arc);
+        let monitor: Box<dyn Send + Sync> = if matches!(mode, AudioUnitMode::DefaultOutput) {
+            Box::new(DefaultOutputMonitor::new(weak_inner, error_callback)?)
         } else {
-            let error_callback_clone = error_callback_disconnect.clone();
-            Box::new(move |err: Error| {
-                invoke_error_callback(&error_callback_clone, err);
-            })
+            Box::new(DisconnectManager::new(
+                self.audio_device_id,
+                weak_inner,
+                error_callback,
+            )?)
         };
-
-        let stream = Stream::new(
-            StreamInner {
-                playing: true,
-                audio_unit,
-                device_id: self.audio_device_id,
-                _loopback_device: None,
-            },
-            error_callback_for_stream,
-        )?;
+        let stream = Stream::new(inner_arc, monitor);
 
         stream
             .inner

--- a/src/host/coreaudio/macos/device.rs
+++ b/src/host/coreaudio/macos/device.rs
@@ -44,7 +44,7 @@ use objc2_core_audio_types::{
 use objc2_core_foundation::CFString;
 use objc2_core_foundation::Type;
 
-pub use super::enumerate::{default_output_device, SupportedInputConfigs, SupportedOutputConfigs};
+pub use super::enumerate::{SupportedInputConfigs, SupportedOutputConfigs};
 use std::fmt;
 use std::mem::{self, size_of};
 use std::ptr::{null, NonNull};
@@ -358,20 +358,34 @@ impl DeviceTrait for Device {
     }
 }
 
-#[derive(Clone, Eq, Hash, PartialEq)]
+#[derive(Clone)]
 pub struct Device {
     pub(crate) audio_device_id: AudioDeviceID,
+    pub(crate) is_default_output: bool,
 }
 
-fn is_default_output_device(device: &Device) -> bool {
-    default_output_device().is_some_and(|d| d.audio_device_id == device.audio_device_id)
+impl PartialEq for Device {
+    fn eq(&self, other: &Self) -> bool {
+        self.audio_device_id == other.audio_device_id
+    }
+}
+
+impl Eq for Device {}
+
+impl std::hash::Hash for Device {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.audio_device_id.hash(state);
+    }
 }
 
 impl Device {
     /// Construct a new device given its ID.
     /// Useful for constructing hidden devices.
     pub fn new(audio_device_id: AudioDeviceID) -> Self {
-        Self { audio_device_id }
+        Self {
+            audio_device_id,
+            is_default_output: false,
+        }
     }
 
     /// Checks if this device is an aggregate device.
@@ -863,7 +877,7 @@ impl Device {
             set_sample_rate(self.audio_device_id, config.sample_rate, timeout)?;
         }
 
-        let mode = if is_default_output_device(self) {
+        let mode = if self.is_default_output {
             AudioUnitMode::DefaultOutput
         } else {
             AudioUnitMode::Output

--- a/src/host/coreaudio/macos/enumerate.rs
+++ b/src/host/coreaudio/macos/enumerate.rs
@@ -75,6 +75,7 @@ impl Iterator for Devices {
     fn next(&mut self) -> Option<Self::Item> {
         self.0.next().map(|id| Self::Item {
             audio_device_id: id,
+            is_default_output: false,
         })
     }
 }
@@ -102,7 +103,10 @@ pub fn default_input_device() -> Option<Device> {
         return None;
     }
 
-    let device = Device { audio_device_id };
+    let device = Device {
+        audio_device_id,
+        is_default_output: false,
+    };
     Some(device)
 }
 
@@ -129,6 +133,9 @@ pub fn default_output_device() -> Option<Device> {
         return None;
     }
 
-    let device = Device { audio_device_id };
+    let device = Device {
+        audio_device_id,
+        is_default_output: true,
+    };
     Some(device)
 }

--- a/src/host/coreaudio/macos/mod.rs
+++ b/src/host/coreaudio/macos/mod.rs
@@ -4,7 +4,8 @@ use std::sync::{mpsc, Arc, Mutex, Weak};
 use coreaudio::audio_unit::AudioUnit;
 use objc2_core_audio::{
     kAudioDevicePropertyDeviceIsAlive, kAudioDevicePropertyNominalSampleRate,
-    kAudioObjectPropertyElementMain, kAudioObjectPropertyScopeGlobal, AudioDeviceID,
+    kAudioHardwarePropertyDefaultOutputDevice, kAudioObjectPropertyElementMain,
+    kAudioObjectPropertyScopeGlobal, kAudioObjectSystemObject, AudioDeviceID, AudioObjectID,
     AudioObjectPropertyAddress,
 };
 use property_listener::AudioObjectPropertyListener;
@@ -82,6 +83,41 @@ where
     }
 }
 
+/// Spawns a dedicated thread that registers a single property listener and signals a channel on
+/// each change. The listener is deregistered when the returned `Sender<()>` is dropped.
+fn spawn_property_listener_thread(
+    object_id: AudioObjectID,
+    address: AudioObjectPropertyAddress,
+) -> Result<(mpsc::Receiver<()>, mpsc::Sender<()>), Error> {
+    let (shutdown_tx, shutdown_rx) = mpsc::channel::<()>();
+    let (change_tx, change_rx) = mpsc::channel::<()>();
+    let (ready_tx, ready_rx) = mpsc::channel();
+
+    std::thread::spawn(move || {
+        let listener = AudioObjectPropertyListener::new(object_id, address, move || {
+            let _ = change_tx.send(());
+        });
+        match listener {
+            Ok(_l) => {
+                let _ = ready_tx.send(Ok(()));
+                let _ = shutdown_rx.recv();
+            }
+            Err(e) => {
+                let _ = ready_tx.send(Err(e));
+            }
+        }
+    });
+
+    ready_rx.recv().map_err(|_| {
+        Error::with_message(
+            ErrorKind::Other,
+            "property listener thread terminated unexpectedly",
+        )
+    })??;
+
+    Ok((change_rx, shutdown_tx))
+}
+
 /// Manages device disconnection listener on a dedicated thread to ensure the
 /// AudioObjectPropertyListener is always created and dropped on the same thread.
 /// This avoids potential threading issues with CoreAudio APIs.
@@ -96,7 +132,6 @@ struct DisconnectManager {
 }
 
 impl DisconnectManager {
-    /// Create a new DisconnectManager that monitors device disconnection on a dedicated thread
     fn new(
         device_id: AudioDeviceID,
         stream_weak: Weak<Mutex<StreamInner>>,
@@ -149,24 +184,20 @@ impl DisconnectManager {
             }
         });
 
-        // Wait for listener creation to complete or fail
         ready_rx.recv().map_err(|_| {
             Error::with_message(
-                ErrorKind::StreamInvalidated,
+                ErrorKind::Other,
                 "disconnect listener thread terminated unexpectedly",
             )
         })??;
 
-        // Handle disconnect events on the main thread pool
-        let stream_weak_clone = stream_weak.clone();
-        let error_callback_clone = error_callback.clone();
         std::thread::spawn(move || {
             while let Ok(err) = disconnect_rx.recv() {
-                if let Some(stream_arc) = stream_weak_clone.upgrade() {
+                if let Some(stream_arc) = stream_weak.upgrade() {
                     if let Ok(mut stream_inner) = stream_arc.try_lock() {
                         let _ = stream_inner.pause();
                     }
-                    invoke_error_callback(&error_callback_clone, err);
+                    invoke_error_callback(&error_callback, err);
                 } else {
                     break;
                 }
@@ -174,6 +205,64 @@ impl DisconnectManager {
         });
 
         Ok(DisconnectManager {
+            _shutdown_tx: shutdown_tx,
+        })
+    }
+}
+
+/// Manages the system default output device change listener on a dedicated thread.
+///
+/// When the system default output device changes:
+/// - If a new valid default exists, AudioUnit reroutes and `DeviceChanged` is reported.
+/// - If there is no new default, the stream is paused and `DeviceNotAvailable` is reported.
+struct DefaultOutputMonitor {
+    _shutdown_tx: mpsc::Sender<()>,
+}
+
+impl DefaultOutputMonitor {
+    fn new(
+        stream_weak: Weak<Mutex<StreamInner>>,
+        error_callback: Arc<Mutex<ErrorCallback>>,
+    ) -> Result<Self, Error> {
+        let (change_rx, shutdown_tx) = spawn_property_listener_thread(
+            kAudioObjectSystemObject as AudioObjectID,
+            AudioObjectPropertyAddress {
+                mSelector: kAudioHardwarePropertyDefaultOutputDevice,
+                mScope: kAudioObjectPropertyScopeGlobal,
+                mElement: kAudioObjectPropertyElementMain,
+            },
+        )?;
+
+        std::thread::spawn(move || {
+            while let Ok(()) = change_rx.recv() {
+                let Some(arc) = stream_weak.upgrade() else {
+                    break;
+                };
+                if default_output_device().is_none() {
+                    if let Ok(mut inner) = arc.try_lock() {
+                        let _ = inner.pause();
+                    }
+                    invoke_error_callback(
+                        &error_callback,
+                        Error::with_message(
+                            ErrorKind::DeviceNotAvailable,
+                            "no default output device",
+                        ),
+                    );
+                } else {
+                    // DefaultOutput AudioUnit rerouted automatically; notify the caller.
+                    invoke_error_callback(
+                        &error_callback,
+                        Error::with_message(
+                            ErrorKind::DeviceChanged,
+                            "default output device changed",
+                        ),
+                    );
+                }
+            }
+        });
+
+        Ok(DefaultOutputMonitor {
             _shutdown_tx: shutdown_tx,
         })
     }
@@ -217,24 +306,17 @@ impl StreamInner {
 
 pub struct Stream {
     inner: Arc<Mutex<StreamInner>>,
-    // Manages the device disconnection listener separately to allow Stream to be Send.
-    // The DisconnectManager contains the non-Send AudioObjectPropertyListener.
-    _disconnect_manager: DisconnectManager,
+    // Holds the device monitor (either DisconnectManager or DefaultOutputMonitor) to keep it
+    // alive for the lifetime of the stream.
+    _monitor: Box<dyn Send + Sync>,
 }
 
 impl Stream {
-    fn new(inner: StreamInner, error_callback: ErrorCallback) -> Result<Self, Error> {
-        let device_id = inner.device_id;
-        let inner_arc = Arc::new(Mutex::new(inner));
-        let weak_inner = Arc::downgrade(&inner_arc);
-
-        let error_callback = Arc::new(Mutex::new(error_callback));
-        let disconnect_manager = DisconnectManager::new(device_id, weak_inner, error_callback)?;
-
-        Ok(Self {
-            inner: inner_arc,
-            _disconnect_manager: disconnect_manager,
-        })
+    fn new(inner: Arc<Mutex<StreamInner>>, monitor: Box<dyn Send + Sync>) -> Self {
+        Self {
+            inner,
+            _monitor: monitor,
+        }
     }
 }
 


### PR DESCRIPTION
For streams opened on the default output device, when that default device changes, reroute to it and emit `DeviceChanged` or `DeviceNotAvailable` if no default device is available anymore.

For streams opened on specific devices, pin to that device even if it was the default.

Fixes:
- #1012
- #1175