### PR TITLE
refactor: prefer 48 kHz for default stream configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `HostTrait::device_by_id()` is now dispatched to each backend's implementation, allowing
   backends to override it.
 - `StreamTrait::now()` to query the current instant on the stream's clock.
+- `SAMPLE_RATE_CD` (44100 Hz) and `SAMPLE_RATE_BROADCAST` (48000 Hz) constants.
+- `SupportedStreamConfigRange::contains_rate()` to test whether a sample rate falls within a range.
+- `SupportedStreamConfigRange::try_with_standard_sample_rate()` and `with_standard_sample_rate()`
+  to select 48 kHz or 44.1 kHz from a range.
 - **ALSA**: `device_by_id()` now accepts PCM shorthand names such as `hw:0,0` and `plughw:foo`.
 - **CoreAudio**: tvOS target support (Tier 3, requires nightly).
 - **PipeWire**: New host for Linux and some BSDs using the PipeWire API.
@@ -29,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `HostId::name()` now returns a more human-friendly name instead of the raw backend identifier.
 - `StreamInstant` API changed and extended to mirror `std::time::Instant`/`Duration`. See
   [UPGRADING.md](UPGRADING.md) for migration details.
+- `SupportedStreamConfigRange::cmp_default_heuristics` now ranks all `SampleFormat` variants.
 - **AAudio**: Device names now include the device type suffix (e.g. "Speaker (Builtin Speaker)")
   for easier identification when enumerating devices.
 - **AAudio**: `supported_input_configs()` and `supported_output_configs()` now return an error for
@@ -37,6 +42,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **AAudio**: Bump MSRV to 1.85.
 - **AAudio**: Buffers with default sizes are now dynamically tuned.
 - **AAudio**: `SupportedBufferSize` now reports `min: 1`.
+- **AAudio**: `default_input_config()` and `default_output_config()` now prefer 48 kHz, then
+  44.1 kHz, then the maximum supported sample rate, instead of always taking the maximum.
 - **ALSA**: Device disconnection now stops the stream with `ErrorKind::DeviceNotAvailable`.
 - **ALSA**: Polling errors trigger underrun recovery instead of looping.
 - **ALSA**: Try to resume from hardware after a system suspend.
@@ -44,6 +51,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **ALSA**: Prevent reentrancy issues with non-reentrant plugins and devices.
 - **ALSA**: Callback timestamps use `LinkSynchronized` hardware cross-timestamps for lower jitter
   on supported devices.
+- **ALSA**: `default_input_config()` and `default_output_config()` now prefer 48 kHz, then
+  44.1 kHz, then the maximum supported sample rate, instead of preferring 44.1 kHz.
 - **ASIO**: `Device::driver`, `asio_streams`, and `current_callback_flag` are no longer `pub`.
 - **ASIO**: Timestamps now include driver-reported hardware latency.
 - **ASIO**: Hardware latency is now re-queried when the driver reports `kAsioLatenciesChanged`.
@@ -51,6 +60,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **ASIO**: Stream error callback now receives `ErrorKind::StreamInvalidated` when the driver
   reports a sample rate change (`sampleRateDidChange`) of 1 Hz or more from the configured rate.
 - **AudioWorklet**: `BufferSize::Fixed` now sets `renderSizeHint` on the `AudioContext`.
+- **AudioWorklet**: `default_output_config()` now uses 48 kHz as the default sample rate instead
+  of 44.1 kHz, reflecting the dominant native rate on modern hardware.
 - **CoreAudio**: Bump MSRV to 1.85.
 - **CoreAudio**: Bump `mach2` to 0.6 (uses `core::ffi` instead of `libc`, enables tvOS builds).
 - **CoreAudio**: Timestamps now include device latency and safety offset.
@@ -60,6 +71,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **CoreAudio**: Stream error callback now receives `ErrorKind::DeviceNotAvailable` on iOS
   when media services are lost.
 - **CoreAudio**: User timeouts are now respected when building a stream.
+- **CoreAudio (iOS)**: `default_input_config()` and `default_output_config()` now prefer 48 kHz,
+  then 44.1 kHz, then the maximum supported sample rate, instead of always taking the maximum.
 - **JACK**: Timestamps now use the precise hardware deadline.
 - **JACK**: Buffer size change no longer fires an error callback; internal buffers are resized
   without error.
@@ -73,6 +86,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **WebAudio**: Bump MSRV to 1.85.
 - **WebAudio**: Timestamps now include base and output latency.
 - **WebAudio**: Initial buffer scheduling offset now scales with buffer duration.
+- **WebAudio**: `default_output_config()` now uses 48 kHz as the default sample rate instead of
+  44.1 kHz, reflecting the dominant native rate on modern hardware.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `StreamInstant` API changed and extended to mirror `std::time::Instant`/`Duration`. See
   [UPGRADING.md](UPGRADING.md) for migration details.
 - `SupportedStreamConfigRange::cmp_default_heuristics` now ranks all `SampleFormat` variants.
+  See [UPGRADING.md](UPGRADING.md) for migration details.
 - **AAudio**: Device names now include the device type suffix (e.g. "Speaker (Builtin Speaker)")
   for easier identification when enumerating devices.
 - **AAudio**: `supported_input_configs()` and `supported_output_configs()` now return an error for

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -15,6 +15,7 @@ This guide covers breaking changes requiring code updates. See [CHANGELOG.md](CH
 - [ ] Update `StreamInstant::from_nanos(nanos)` call sites: `nanos` is now `u64`.
 - [ ] Update `duration_since` call sites to pass by value (drop the `&`).
 - [ ] Migrate `wasm32-unknown-emscripten` to `wasm32-unknown-unknown` if possible.
+- [ ] If you relied on the default config returning 44.1 kHz, pin the sample rate explicitly.
 
 ## 1. Unified `Error` and `ErrorKind` type
 
@@ -151,7 +152,24 @@ StreamInstant::new(0_u64, 0);
 
 **Why:** All audio host clocks are positive and monotonic; they are never negative.
 
-## 4. `wasm32-unknown-emscripten` target removed
+## 4. Default sample rate changed to 48 kHz
+
+**What changed:** `default_input_config()` and `default_output_config()` now prefer 48 kHz over
+44.1 kHz on backends that apply a heuristic. The new selection order is 48 kHz, then 44.1 kHz, then the device maximum.
+
+If your pipeline requires 44.1 kHz, request it explicitly:
+
+```rust
+let config = device
+    .supported_output_configs()?
+    .find_map(|r| r.try_with_sample_rate(44_100))
+    .expect("device does not support 44.1 kHz");
+```
+
+**Why:** 48 kHz is the native rate of virtually all modern hardware; the old default caused
+unnecessary resampling on such devices.
+
+## 5. `wasm32-unknown-emscripten` target removed
 
 **What changed:** The `emscripten` audio host and the `wasm32-unknown-emscripten` build target are no longer supported.
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -16,6 +16,7 @@ This guide covers breaking changes requiring code updates. See [CHANGELOG.md](CH
 - [ ] Update `duration_since` call sites to pass by value (drop the `&`).
 - [ ] Migrate `wasm32-unknown-emscripten` to `wasm32-unknown-unknown` if possible.
 - [ ] If you relied on the default config returning 44.1 kHz, pin the sample rate explicitly.
+- [ ] If you relied on the default config returning `F32`, pin the sample format explicitly.
 
 ## 1. Unified `Error` and `ErrorKind` type
 
@@ -169,7 +170,31 @@ let config = device
 **Why:** 48 kHz is the native rate of virtually all modern hardware; the old default caused
 unnecessary resampling on such devices.
 
-## 5. `wasm32-unknown-emscripten` target removed
+## 5. Default sample format selection changed
+
+**What changed:** `default_input_config()` and `default_output_config()` now use a fully-ranked
+format ordering across all `SampleFormat` variants.
+
+Previously only `F32`, `I16`, and `U16` were explicitly ranked; all other formats compared as
+equal. On hosts that expose higher-precision formats, the default config may now return a
+different format than before. Likely candidates are `I32`, `I24`, or even `F64` if the device 
+or plugin supports it.
+
+If your code assumes the default format is `F32`, request the format explicitly:
+
+```rust
+// Request F32 explicitly instead of relying on the default
+let configs = device
+    .supported_output_configs()?
+    .filter(|r| r.sample_format() == SampleFormat::F32);
+```
+
+**Why:** The previous heuristic only explicitly ranked three formats, making selection
+unpredictable for any other format the device reported. The new ordering is complete and
+consistent: floats before integers (F64 > F32 for maximum fidelity), integers by bit-depth
+descending with signed above unsigned at each width, and DSD last.
+
+## 6. `wasm32-unknown-emscripten` target removed
 
 **What changed:** The `emscripten` audio host and the `wasm32-unknown-emscripten` build target are no longer supported.
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -163,7 +163,7 @@ If your pipeline requires 44.1 kHz, request it explicitly:
 ```rust
 let config = device
     .supported_output_configs()?
-    .find_map(|r| r.try_with_sample_rate(44_100))
+    .find_map(|r| r.try_with_sample_rate(cpal::SAMPLE_RATE_CD))
     .expect("device does not support 44.1 kHz");
 ```
 

--- a/src/host/aaudio/mod.rs
+++ b/src/host/aaudio/mod.rs
@@ -553,32 +553,30 @@ impl DeviceTrait for Device {
     fn default_input_config(&self) -> Result<SupportedStreamConfig, Error> {
         let mut configs: Vec<_> = self.supported_input_configs()?.collect();
         configs.sort_by(|a, b| b.cmp_default_heuristics(a));
-        let config = configs
-            .into_iter()
-            .next()
-            .ok_or_else(|| {
-                Error::with_message(
-                    ErrorKind::UnsupportedConfig,
-                    "no supported input configuration",
-                )
-            })?
-            .with_max_sample_rate();
+        let range = configs.into_iter().next().ok_or_else(|| {
+            Error::with_message(
+                ErrorKind::UnsupportedConfig,
+                "no supported input configuration",
+            )
+        })?;
+        let config = range
+            .try_with_standard_sample_rate()
+            .unwrap_or_else(|| range.with_max_sample_rate());
         Ok(config)
     }
 
     fn default_output_config(&self) -> Result<SupportedStreamConfig, Error> {
         let mut configs: Vec<_> = self.supported_output_configs()?.collect();
         configs.sort_by(|a, b| b.cmp_default_heuristics(a));
-        let config = configs
-            .into_iter()
-            .next()
-            .ok_or_else(|| {
-                Error::with_message(
-                    ErrorKind::UnsupportedConfig,
-                    "no supported output configuration",
-                )
-            })?
-            .with_max_sample_rate();
+        let range = configs.into_iter().next().ok_or_else(|| {
+            Error::with_message(
+                ErrorKind::UnsupportedConfig,
+                "no supported output configuration",
+            )
+        })?;
+        let config = range
+            .try_with_standard_sample_rate()
+            .unwrap_or_else(|| range.with_max_sample_rate());
         Ok(config)
     }
 

--- a/src/host/alsa/mod.rs
+++ b/src/host/alsa/mod.rs
@@ -639,16 +639,9 @@ impl Device {
         formats.sort_by(|a, b| a.cmp_default_heuristics(b));
 
         match formats.into_iter().next_back() {
-            Some(f) => {
-                let min_r = f.min_sample_rate;
-                let max_r = f.max_sample_rate;
-                let mut format = f.with_max_sample_rate();
-                const HZ_44100: SampleRate = 44_100;
-                if min_r <= HZ_44100 && HZ_44100 <= max_r {
-                    format.sample_rate = HZ_44100;
-                }
-                Ok(format)
-            }
+            Some(f) => Ok(f
+                .try_with_standard_sample_rate()
+                .unwrap_or_else(|| f.with_max_sample_rate())),
             None => Err(Error::with_message(
                 ErrorKind::UnsupportedConfig,
                 "no supported configuration for this device",

--- a/src/host/audioworklet/mod.rs
+++ b/src/host/audioworklet/mod.rs
@@ -45,7 +45,7 @@ const MIN_CHANNELS: ChannelCount = 1;
 const MAX_CHANNELS: ChannelCount = 32;
 const MIN_SAMPLE_RATE: SampleRate = 8_000;
 const MAX_SAMPLE_RATE: SampleRate = 96_000;
-const DEFAULT_SAMPLE_RATE: SampleRate = 44_100;
+
 const SUPPORTED_SAMPLE_FORMAT: SampleFormat = SampleFormat::F32;
 
 // https://webaudio.github.io/web-audio-api/#render-quantum-size
@@ -154,13 +154,18 @@ impl DeviceTrait for Device {
     }
 
     fn default_output_config(&self) -> Result<SupportedStreamConfig, Error> {
-        const EXPECT: &str = "expected at least one valid webaudio stream config";
-        let config = self
-            .supported_output_configs()
-            .expect(EXPECT)
+        let range = self
+            .supported_output_configs()?
             .max_by(|a, b| a.cmp_default_heuristics(b))
-            .unwrap()
-            .with_sample_rate(DEFAULT_SAMPLE_RATE);
+            .ok_or_else(|| {
+                Error::with_message(
+                    ErrorKind::UnsupportedConfig,
+                    "AudioWorklet has no supported output configurations",
+                )
+            })?;
+        let config = range
+            .try_with_standard_sample_rate()
+            .unwrap_or_else(|| range.with_max_sample_rate());
 
         Ok(config)
     }

--- a/src/host/coreaudio/ios/mod.rs
+++ b/src/host/coreaudio/ios/mod.rs
@@ -101,28 +101,28 @@ impl Device {
 
     fn default_input_config(&self) -> Result<SupportedStreamConfig, Error> {
         // Get the primary (exact channel count) config from supported configs
-        get_supported_stream_configs(true)
-            .next()
-            .map(|range| range.with_max_sample_rate())
-            .ok_or_else(|| {
-                Error::with_message(
-                    ErrorKind::UnsupportedConfig,
-                    "no supported input configuration",
-                )
-            })
+        let range = get_supported_stream_configs(true).next().ok_or_else(|| {
+            Error::with_message(
+                ErrorKind::UnsupportedConfig,
+                "no supported input configuration",
+            )
+        })?;
+        Ok(range
+            .try_with_standard_sample_rate()
+            .unwrap_or_else(|| range.with_max_sample_rate()))
     }
 
     fn default_output_config(&self) -> Result<SupportedStreamConfig, Error> {
         // Get the maximum channel count config from supported configs
-        get_supported_stream_configs(false)
-            .last()
-            .map(|range| range.with_max_sample_rate())
-            .ok_or_else(|| {
-                Error::with_message(
-                    ErrorKind::UnsupportedConfig,
-                    "no supported output configuration",
-                )
-            })
+        let range = get_supported_stream_configs(false).last().ok_or_else(|| {
+            Error::with_message(
+                ErrorKind::UnsupportedConfig,
+                "no supported output configuration",
+            )
+        })?;
+        Ok(range
+            .try_with_standard_sample_rate()
+            .unwrap_or_else(|| range.with_max_sample_rate()))
     }
 }
 

--- a/src/host/webaudio/mod.rs
+++ b/src/host/webaudio/mod.rs
@@ -60,7 +60,7 @@ const MIN_CHANNELS: ChannelCount = 1;
 const MAX_CHANNELS: ChannelCount = 32;
 const MIN_SAMPLE_RATE: SampleRate = 8_000;
 const MAX_SAMPLE_RATE: SampleRate = 96_000;
-const DEFAULT_SAMPLE_RATE: SampleRate = 44_100;
+
 const MIN_BUFFER_SIZE: u32 = 1;
 const MAX_BUFFER_SIZE: u32 = u32::MAX;
 const DEFAULT_BUFFER_SIZE: usize = 2048;
@@ -144,13 +144,18 @@ impl Device {
     }
 
     fn default_output_config(&self) -> Result<SupportedStreamConfig, Error> {
-        const EXPECT: &str = "expected at least one valid webaudio stream config";
-        let config = self
-            .supported_output_configs()
-            .expect(EXPECT)
+        let range = self
+            .supported_output_configs()?
             .max_by(|a, b| a.cmp_default_heuristics(b))
-            .unwrap()
-            .with_sample_rate(DEFAULT_SAMPLE_RATE);
+            .ok_or_else(|| {
+                Error::with_message(
+                    ErrorKind::UnsupportedConfig,
+                    "WebAudio has no supported output configurations",
+                )
+            })?;
+        let config = range
+            .try_with_standard_sample_rate()
+            .unwrap_or_else(|| range.with_max_sample_rate());
 
         Ok(config)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -737,7 +737,6 @@ impl SupportedStreamConfigRange {
     /// 3. Highest supported sample rate
     pub fn cmp_default_heuristics(&self, other: &Self) -> std::cmp::Ordering {
         use std::cmp::Ordering::Equal;
-        use SampleFormat::*;
 
         let cmp_stereo = (self.channels == 2).cmp(&(other.channels == 2));
         if cmp_stereo != Equal {
@@ -754,79 +753,27 @@ impl SupportedStreamConfigRange {
             return cmp_channels;
         }
 
-        let cmp_f64 = (self.sample_format == F64).cmp(&(other.sample_format == F64));
-        if cmp_f64 != Equal {
-            return cmp_f64;
+        // Returns a (category, depth, signed) rank for a sample format.
+        fn format_rank(fmt: SampleFormat) -> (u8, u32, u8) {
+            let category = if fmt.is_float() {
+                2
+            } else if fmt.is_int() || fmt.is_uint() {
+                1
+            } else {
+                0
+            };
+            let depth = if fmt.is_dsd() {
+                fmt.sample_size() as u32
+            } else {
+                fmt.bits_per_sample()
+            };
+            let signed = u8::from(fmt.is_float() || fmt.is_int());
+            (category, depth, signed)
         }
 
-        let cmp_f32 = (self.sample_format == F32).cmp(&(other.sample_format == F32));
-        if cmp_f32 != Equal {
-            return cmp_f32;
-        }
-
-        let cmp_i64 = (self.sample_format == I64).cmp(&(other.sample_format == I64));
-        if cmp_i64 != Equal {
-            return cmp_i64;
-        }
-
-        let cmp_u64 = (self.sample_format == U64).cmp(&(other.sample_format == U64));
-        if cmp_u64 != Equal {
-            return cmp_u64;
-        }
-
-        let cmp_i32 = (self.sample_format == I32).cmp(&(other.sample_format == I32));
-        if cmp_i32 != Equal {
-            return cmp_i32;
-        }
-
-        let cmp_u32 = (self.sample_format == U32).cmp(&(other.sample_format == U32));
-        if cmp_u32 != Equal {
-            return cmp_u32;
-        }
-
-        let cmp_i24 = (self.sample_format == I24).cmp(&(other.sample_format == I24));
-        if cmp_i24 != Equal {
-            return cmp_i24;
-        }
-
-        let cmp_u24 = (self.sample_format == U24).cmp(&(other.sample_format == U24));
-        if cmp_u24 != Equal {
-            return cmp_u24;
-        }
-
-        let cmp_i16 = (self.sample_format == I16).cmp(&(other.sample_format == I16));
-        if cmp_i16 != Equal {
-            return cmp_i16;
-        }
-
-        let cmp_u16 = (self.sample_format == U16).cmp(&(other.sample_format == U16));
-        if cmp_u16 != Equal {
-            return cmp_u16;
-        }
-
-        let cmp_i8 = (self.sample_format == I8).cmp(&(other.sample_format == I8));
-        if cmp_i8 != Equal {
-            return cmp_i8;
-        }
-
-        let cmp_u8 = (self.sample_format == U8).cmp(&(other.sample_format == U8));
-        if cmp_u8 != Equal {
-            return cmp_u8;
-        }
-
-        let cmp_dsd_u32 = (self.sample_format == DsdU32).cmp(&(other.sample_format == DsdU32));
-        if cmp_dsd_u32 != Equal {
-            return cmp_dsd_u32;
-        }
-
-        let cmp_dsd_u16 = (self.sample_format == DsdU16).cmp(&(other.sample_format == DsdU16));
-        if cmp_dsd_u16 != Equal {
-            return cmp_dsd_u16;
-        }
-
-        let cmp_dsd_u8 = (self.sample_format == DsdU8).cmp(&(other.sample_format == DsdU8));
-        if cmp_dsd_u8 != Equal {
-            return cmp_dsd_u8;
+        let cmp_format = format_rank(self.sample_format).cmp(&format_rank(other.sample_format));
+        if cmp_format != Equal {
+            return cmp_format;
         }
 
         let cmp_broadcast = self

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -200,6 +200,12 @@ pub type ChannelCount = u16;
 /// The number of samples processed per second for a single channel of audio.
 pub type SampleRate = u32;
 
+/// 44.1 kHz: the CD standard, widely used in music production and consumer audio.
+pub const SAMPLE_RATE_CD: SampleRate = 44_100;
+
+/// 48 kHz: the EBU/SMPTE broadcast standard, default on most modern hardware.
+pub const SAMPLE_RATE_BROADCAST: SampleRate = 48_000;
+
 /// A frame represents one sample for each channel. For example, with stereo audio,
 /// one frame contains two samples (left and right channels).
 pub type FrameCount = u32;
@@ -625,7 +631,7 @@ impl SupportedStreamConfigRange {
         self.sample_format
     }
 
-    /// Retrieve a [`SupportedStreamConfig`] with the given sample rate and buffer size.
+    /// Retrieve a [`SupportedStreamConfig`] with the given sample rate.
     ///
     /// # Panics
     ///
@@ -637,7 +643,7 @@ impl SupportedStreamConfigRange {
             .expect("sample rate out of range")
     }
 
-    /// Retrieve a [`SupportedStreamConfig`] with the given sample rate and buffer size.
+    /// Retrieve a [`SupportedStreamConfig`] with the given sample rate.
     ///
     /// Returns `None` if the given sample rate is outside the range specified
     /// within this [`SupportedStreamConfigRange`] instance.
@@ -665,34 +671,73 @@ impl SupportedStreamConfigRange {
         }
     }
 
-    /// A comparison function which compares two [`SupportedStreamConfigRange`]s in terms of their priority of
-    /// use as a default stream format.
+    /// Returns `true` if `rate` falls within `[min_sample_rate, max_sample_rate]`.
+    pub fn contains_rate(&self, rate: SampleRate) -> bool {
+        self.min_sample_rate <= rate && rate <= self.max_sample_rate
+    }
+
+    /// Retrieve a [`SupportedStreamConfig`] with a standard sample rate.
+    ///
+    /// The preferred rate is selected in order:
+    /// 1. 48 kHz as the dominant native rate on modern hardware.
+    /// 2. 44.1 kHz as the standard CD/consumer rate.
+    ///
+    /// Returns `None` if neither standard rate falls within the range specified within this
+    /// [`SupportedStreamConfigRange`] instance.
+    pub fn try_with_standard_sample_rate(self) -> Option<SupportedStreamConfig> {
+        for rate in [SAMPLE_RATE_BROADCAST, SAMPLE_RATE_CD] {
+            if self.contains_rate(rate) {
+                return Some(self.with_sample_rate(rate));
+            }
+        }
+        None
+    }
+
+    /// Retrieve a [`SupportedStreamConfig`] with a standard sample rate.
+    ///
+    /// The preferred rate is selected in order:
+    /// 1. 48 kHz as the dominant native rate on modern hardware.
+    /// 2. 44.1 kHz as the standard CD/consumer rate.
+    ///
+    /// # Panics
+    ///
+    /// Panics if neither standard rate falls within the range specified within this
+    /// [`SupportedStreamConfigRange`] instance. For a non-panicking variant, use
+    /// [`try_with_standard_sample_rate`](Self::try_with_standard_sample_rate).
+    pub fn with_standard_sample_rate(self) -> SupportedStreamConfig {
+        self.try_with_standard_sample_rate()
+            .expect("no standard sample rate (48000 or 44100 Hz) in supported range")
+    }
+
+    /// A comparison function which compares two [`SupportedStreamConfigRange`]s in terms of their
+    /// priority of use as a default stream format.
     ///
     /// Some backends do not provide a default stream format for their audio devices. In these
     /// cases, CPAL attempts to decide on a reasonable default format for the user. To do this we
     /// use the "greatest" of all supported stream formats when compared with this method.
     ///
-    /// SupportedStreamConfigs are prioritised by the following heuristics:
+    /// [`SupportedStreamConfig`]s are prioritised by the following heuristics, applied in order:
     ///
     /// **Channels**:
     ///
-    /// - Stereo
-    /// - Mono
-    /// - Max available channels
+    /// 1. Stereo
+    /// 2. Mono
+    /// 3. Highest available channel count
     ///
-    /// **Sample format**:
-    /// - f32
-    /// - i16
-    /// - u16
+    /// **Sample format** (most preferred first):
+    ///
+    /// Float formats are preferred over integers. Within each category, formats are ranked by
+    /// bit-depth descending (higher is better), with signed integers ranked above unsigned at
+    /// the same width. DSD formats are ranked last as non-PCM.
     ///
     /// **Sample rate**:
     ///
-    /// - 44100 (cd quality)
-    /// - Max sample rate
+    /// 1. 48 kHz (EBU/SMPTE broadcast standard)
+    /// 2. 44.1 kHz (CD standard)
+    /// 3. Highest supported sample rate
     pub fn cmp_default_heuristics(&self, other: &Self) -> std::cmp::Ordering {
         use std::cmp::Ordering::Equal;
-
-        use SampleFormat::{F32, I16, I24, I32, U16, U24, U32};
+        use SampleFormat::*;
 
         let cmp_stereo = (self.channels == 2).cmp(&(other.channels == 2));
         if cmp_stereo != Equal {
@@ -709,9 +754,24 @@ impl SupportedStreamConfigRange {
             return cmp_channels;
         }
 
+        let cmp_f64 = (self.sample_format == F64).cmp(&(other.sample_format == F64));
+        if cmp_f64 != Equal {
+            return cmp_f64;
+        }
+
         let cmp_f32 = (self.sample_format == F32).cmp(&(other.sample_format == F32));
         if cmp_f32 != Equal {
             return cmp_f32;
+        }
+
+        let cmp_i64 = (self.sample_format == I64).cmp(&(other.sample_format == I64));
+        if cmp_i64 != Equal {
+            return cmp_i64;
+        }
+
+        let cmp_u64 = (self.sample_format == U64).cmp(&(other.sample_format == U64));
+        if cmp_u64 != Equal {
+            return cmp_u64;
         }
 
         let cmp_i32 = (self.sample_format == I32).cmp(&(other.sample_format == I32));
@@ -744,86 +804,182 @@ impl SupportedStreamConfigRange {
             return cmp_u16;
         }
 
-        const HZ_44100: SampleRate = 44_100;
-        let r44100_in_self = self.min_sample_rate <= HZ_44100 && HZ_44100 <= self.max_sample_rate;
-        let r44100_in_other =
-            other.min_sample_rate <= HZ_44100 && HZ_44100 <= other.max_sample_rate;
-        let cmp_r44100 = r44100_in_self.cmp(&r44100_in_other);
-        if cmp_r44100 != Equal {
-            return cmp_r44100;
+        let cmp_i8 = (self.sample_format == I8).cmp(&(other.sample_format == I8));
+        if cmp_i8 != Equal {
+            return cmp_i8;
+        }
+
+        let cmp_u8 = (self.sample_format == U8).cmp(&(other.sample_format == U8));
+        if cmp_u8 != Equal {
+            return cmp_u8;
+        }
+
+        let cmp_dsd_u32 = (self.sample_format == DsdU32).cmp(&(other.sample_format == DsdU32));
+        if cmp_dsd_u32 != Equal {
+            return cmp_dsd_u32;
+        }
+
+        let cmp_dsd_u16 = (self.sample_format == DsdU16).cmp(&(other.sample_format == DsdU16));
+        if cmp_dsd_u16 != Equal {
+            return cmp_dsd_u16;
+        }
+
+        let cmp_dsd_u8 = (self.sample_format == DsdU8).cmp(&(other.sample_format == DsdU8));
+        if cmp_dsd_u8 != Equal {
+            return cmp_dsd_u8;
+        }
+
+        let cmp_broadcast = self
+            .contains_rate(SAMPLE_RATE_BROADCAST)
+            .cmp(&other.contains_rate(SAMPLE_RATE_BROADCAST));
+        if cmp_broadcast != Equal {
+            return cmp_broadcast;
+        }
+
+        let cmp_cd = self
+            .contains_rate(SAMPLE_RATE_CD)
+            .cmp(&other.contains_rate(SAMPLE_RATE_CD));
+        if cmp_cd != Equal {
+            return cmp_cd;
         }
 
         self.max_sample_rate.cmp(&other.max_sample_rate)
     }
 }
 
+#[cfg(test)]
+fn make_range(
+    channels: ChannelCount,
+    format: SampleFormat,
+    min: SampleRate,
+    max: SampleRate,
+) -> SupportedStreamConfigRange {
+    SupportedStreamConfigRange {
+        buffer_size: SupportedBufferSize::Range { min: 256, max: 512 },
+        channels,
+        min_sample_rate: min,
+        max_sample_rate: max,
+        sample_format: format,
+    }
+}
+
 #[test]
-fn test_cmp_default_heuristics() {
-    let mut formats = [
-        SupportedStreamConfigRange {
-            buffer_size: SupportedBufferSize::Range { min: 256, max: 512 },
-            channels: 2,
-            min_sample_rate: 1,
-            max_sample_rate: 96000,
-            sample_format: SampleFormat::F32,
-        },
-        SupportedStreamConfigRange {
-            buffer_size: SupportedBufferSize::Range { min: 256, max: 512 },
-            channels: 1,
-            min_sample_rate: 1,
-            max_sample_rate: 96000,
-            sample_format: SampleFormat::F32,
-        },
-        SupportedStreamConfigRange {
-            buffer_size: SupportedBufferSize::Range { min: 256, max: 512 },
-            channels: 2,
-            min_sample_rate: 1,
-            max_sample_rate: 96000,
-            sample_format: SampleFormat::I16,
-        },
-        SupportedStreamConfigRange {
-            buffer_size: SupportedBufferSize::Range { min: 256, max: 512 },
-            channels: 2,
-            min_sample_rate: 1,
-            max_sample_rate: 96000,
-            sample_format: SampleFormat::U16,
-        },
-        SupportedStreamConfigRange {
-            buffer_size: SupportedBufferSize::Range { min: 256, max: 512 },
-            channels: 2,
-            min_sample_rate: 1,
-            max_sample_rate: 22050,
-            sample_format: SampleFormat::F32,
-        },
+fn test_with_standard_sample_rate() {
+    let r = |min, max| make_range(2, SampleFormat::F32, min, max);
+
+    assert_eq!(
+        r(1, 96_000).with_standard_sample_rate().sample_rate(),
+        SAMPLE_RATE_BROADCAST
+    );
+    assert_eq!(
+        r(1, 44_100).with_standard_sample_rate().sample_rate(),
+        SAMPLE_RATE_CD
+    );
+}
+
+#[test]
+#[should_panic(expected = "no standard sample rate")]
+fn test_with_standard_sample_rate_panics_when_no_standard_rate() {
+    make_range(2, SampleFormat::F32, 8_000, 32_000).with_standard_sample_rate();
+}
+
+#[test]
+fn test_try_with_standard_sample_rate() {
+    let r = |min, max| make_range(2, SampleFormat::F32, min, max);
+
+    // 48 kHz available; first choice
+    assert_eq!(
+        r(1, 96_000)
+            .try_with_standard_sample_rate()
+            .map(|c| c.sample_rate()),
+        Some(SAMPLE_RATE_BROADCAST)
+    );
+
+    // 48 kHz not available but 44.1 kHz is; second choice
+    assert_eq!(
+        r(1, 44_100)
+            .try_with_standard_sample_rate()
+            .map(|c| c.sample_rate()),
+        Some(SAMPLE_RATE_CD)
+    );
+
+    // Neither preferred rate available
+    assert_eq!(r(8_000, 32_000).try_with_standard_sample_rate(), None);
+}
+
+#[test]
+fn test_cmp_default_heuristics_format_order() {
+    use SampleFormat::*;
+
+    // Input is deliberately not sorted to prove the sort works.
+    let unsorted = [
+        F32, I16, DsdU32, U64, I32, DsdU8, F64, U8, I24, U16, I64, U24, U32, I8, DsdU16,
     ];
 
-    formats.sort_by(|a, b| a.cmp_default_heuristics(b));
+    let mut ranges: Vec<_> = unsorted
+        .iter()
+        .map(|&fmt| make_range(2, fmt, 1, 96_000))
+        .collect();
+    ranges.sort_by(|a, b| a.cmp_default_heuristics(b));
 
-    // lowest-priority first:
-    assert_eq!(formats[0].sample_format(), SampleFormat::F32);
-    assert_eq!(formats[0].min_sample_rate(), 1);
-    assert_eq!(formats[0].max_sample_rate(), 96000);
-    assert_eq!(formats[0].channels(), 1);
+    let sorted_formats: Vec<SampleFormat> = ranges.iter().map(|r| r.sample_format()).collect();
 
-    assert_eq!(formats[1].sample_format(), SampleFormat::U16);
-    assert_eq!(formats[1].min_sample_rate(), 1);
-    assert_eq!(formats[1].max_sample_rate(), 96000);
-    assert_eq!(formats[1].channels(), 2);
+    // Expected order from lowest to highest priority:
+    assert_eq!(
+        sorted_formats,
+        vec![DsdU8, DsdU16, DsdU32, U8, I8, U16, I16, U24, I24, U32, I32, U64, I64, F32, F64,]
+    );
+}
 
-    assert_eq!(formats[2].sample_format(), SampleFormat::I16);
-    assert_eq!(formats[2].min_sample_rate(), 1);
-    assert_eq!(formats[2].max_sample_rate(), 96000);
-    assert_eq!(formats[2].channels(), 2);
+#[test]
+fn test_cmp_default_heuristics() {
+    let mut configs = [
+        make_range(1, SampleFormat::F64, 1, 96_000), // mono; loses to all stereo
+        make_range(2, SampleFormat::DsdU8, 1, 96_000), // DSD; lowest format priority
+        make_range(2, SampleFormat::U8, 1, 96_000),
+        make_range(2, SampleFormat::I8, 1, 96_000),
+        make_range(2, SampleFormat::U16, 1, 96_000),
+        make_range(2, SampleFormat::I16, 1, 96_000),
+        make_range(2, SampleFormat::F32, 1, 22_050), // neither standard rate
+        make_range(2, SampleFormat::F32, 1, 44_100), // 44.1 kHz only
+        make_range(2, SampleFormat::F32, 48_000, 96_000), // 48 kHz only
+        make_range(2, SampleFormat::F32, 1, 96_000), // both standard rates
+        make_range(2, SampleFormat::F64, 1, 96_000), // F64; highest format priority
+    ];
 
-    assert_eq!(formats[3].sample_format(), SampleFormat::F32);
-    assert_eq!(formats[3].min_sample_rate(), 1);
-    assert_eq!(formats[3].max_sample_rate(), 22050);
-    assert_eq!(formats[3].channels(), 2);
+    configs.sort_by(|a, b| a.cmp_default_heuristics(b));
 
-    assert_eq!(formats[4].sample_format(), SampleFormat::F32);
-    assert_eq!(formats[4].min_sample_rate(), 1);
-    assert_eq!(formats[4].max_sample_rate(), 96000);
-    assert_eq!(formats[4].channels(), 2);
+    // Results in ascending priority order (lowest first):
+
+    // [0] Mono loses to every stereo entry regardless of format or rate.
+    assert_eq!(configs[0].channels(), 1);
+    assert_eq!(configs[0].sample_format(), SampleFormat::F64);
+
+    // [1]–[5] Stereo entries ranked by format (DSD < 8-bit < 16-bit).
+    assert_eq!(configs[1].sample_format(), SampleFormat::DsdU8);
+    assert_eq!(configs[2].sample_format(), SampleFormat::U8);
+    assert_eq!(configs[3].sample_format(), SampleFormat::I8);
+    assert_eq!(configs[4].sample_format(), SampleFormat::U16);
+    assert_eq!(configs[5].sample_format(), SampleFormat::I16);
+
+    // [6]–[9] Stereo F32 entries ranked by rate coverage (F32 < F64).
+    assert_eq!(configs[6].sample_format(), SampleFormat::F32);
+    assert_eq!(configs[6].max_sample_rate(), 22_050); // neither standard rate
+
+    assert_eq!(configs[7].sample_format(), SampleFormat::F32);
+    assert_eq!(configs[7].max_sample_rate(), 44_100); // 44.1 kHz only
+
+    assert_eq!(configs[8].sample_format(), SampleFormat::F32);
+    assert_eq!(configs[8].min_sample_rate(), 48_000); // 48 kHz only (no 44.1 kHz)
+    assert_eq!(configs[8].max_sample_rate(), 96_000);
+
+    assert_eq!(configs[9].sample_format(), SampleFormat::F32);
+    assert_eq!(configs[9].min_sample_rate(), 1);
+    assert_eq!(configs[9].max_sample_rate(), 96_000); // both standard rates
+
+    // [10] F64 outranks all F32 entries regardless of rate coverage.
+    assert_eq!(configs[10].sample_format(), SampleFormat::F64);
+    assert_eq!(configs[10].channels(), 2);
 }
 
 impl From<SupportedStreamConfig> for StreamConfig {


### PR DESCRIPTION
- Introduce `SAMPLE_RATE_CD` and `SAMPLE_RATE_BROADCAST` constants
- Add `try_with_standard_sample_rate`, `with_standard_sample_rate` and `contains_rate` helpers
- Update applicable hosts to prefer 48 kHz, then 44.1 kHz, then the device maximum
- Fix `cmp_default_heuristics` to take into account all sample formats