### PR TITLE
refactor: use specific error kinds

### DIFF
--- a/src/host/asio/stream.rs
+++ b/src/host/asio/stream.rs
@@ -1109,6 +1109,10 @@ fn build_stream_err(e: sys::AsioError) -> Error {
         sys::AsioError::InvalidInput | sys::AsioError::BadMode => {
             Error::with_message(ErrorKind::InvalidInput, e.to_string())
         }
+        sys::AsioError::InvalidBufferSize | sys::AsioError::NoRate => {
+            Error::with_message(ErrorKind::UnsupportedConfig, e.to_string())
+        }
+        sys::AsioError::HardwareStuck => Error::with_message(ErrorKind::DeviceBusy, e.to_string()),
         err => Error::with_message(ErrorKind::Other, err.to_string()),
     }
 }

--- a/src/host/coreaudio/macos/device.rs
+++ b/src/host/coreaudio/macos/device.rs
@@ -200,7 +200,7 @@ fn set_sample_rate(
                 }
                 Err(RecvTimeoutError::Disconnected) => {
                     return Err(Error::with_message(
-                        ErrorKind::Other,
+                        ErrorKind::StreamInvalidated,
                         "sample rate listener channel disconnected unexpectedly",
                     ));
                 }

--- a/src/host/coreaudio/macos/mod.rs
+++ b/src/host/coreaudio/macos/mod.rs
@@ -110,7 +110,7 @@ fn spawn_property_listener_thread(
 
     ready_rx.recv().map_err(|_| {
         Error::with_message(
-            ErrorKind::Other,
+            ErrorKind::StreamInvalidated,
             "property listener thread terminated unexpectedly",
         )
     })??;
@@ -186,7 +186,7 @@ impl DisconnectManager {
 
         ready_rx.recv().map_err(|_| {
             Error::with_message(
-                ErrorKind::Other,
+                ErrorKind::StreamInvalidated,
                 "disconnect listener thread terminated unexpectedly",
             )
         })??;

--- a/src/host/pipewire/stream.rs
+++ b/src/host/pipewire/stream.rs
@@ -388,7 +388,7 @@ where
                     // if the format does not match, we stop the stream
                     if let Err(e) = stream.set_active(false) {
                         (user_data.error_callback)(Error::with_message(
-                            ErrorKind::Other,
+                            ErrorKind::StreamInvalidated,
                             format!("failed to stop the stream, reason: {e}"),
                         ));
                     }
@@ -549,7 +549,7 @@ where
                     // if the format does not match, we stop the stream
                     if let Err(e) = stream.set_active(false) {
                         (user_data.error_callback)(Error::with_message(
-                            ErrorKind::Other,
+                            ErrorKind::StreamInvalidated,
                             format!("failed to stop the stream, reason: {e}"),
                         ));
                     }

--- a/src/host/wasapi/device.rs
+++ b/src/host/wasapi/device.rs
@@ -442,11 +442,10 @@ impl Device {
     /// Ensures that `future_audio_client` contains a `Some` and returns a locked mutex to it.
     fn ensure_future_audio_client(
         &self,
-    ) -> Result<MutexGuard<'_, Option<IAudioClientWrapper>>, windows::core::Error> {
-        let mut lock = self
-            .future_audio_client
-            .lock()
-            .map_err(|_| windows::core::Error::from(windows::Win32::Foundation::E_UNEXPECTED))?;
+    ) -> Result<MutexGuard<'_, Option<IAudioClientWrapper>>, Error> {
+        let mut lock = self.future_audio_client.lock().map_err(|_| {
+            Error::with_message(ErrorKind::StreamInvalidated, "audio client lock poisoned")
+        })?;
         if lock.is_some() {
             return Ok(lock);
         }
@@ -454,7 +453,9 @@ impl Device {
         let audio_client: Audio::IAudioClient = unsafe {
             // can fail if the device has been disconnected since we enumerated it, or if
             // the device doesn't support playback for some reason
-            self.device.Activate(Com::CLSCTX_ALL, None)?
+            self.device
+                .Activate(Com::CLSCTX_ALL, None)
+                .map_err(Error::from)?
         };
 
         *lock = Some(IAudioClientWrapper(audio_client));
@@ -462,7 +463,7 @@ impl Device {
     }
 
     /// Returns an uninitialized `IAudioClient`.
-    pub(crate) fn build_audioclient(&self) -> Result<Audio::IAudioClient, windows::core::Error> {
+    pub(crate) fn build_audioclient(&self) -> Result<Audio::IAudioClient, Error> {
         let mut lock = self.ensure_future_audio_client()?;
         Ok(lock.take().unwrap().0)
     }


### PR DESCRIPTION
- Replace generic `Other` error variants in CoreAudio and PipeWire listeners with `StreamInvalidated` to better signal stream termination.

- Add ASIO mappings: `InvalidBufferSize`/`NoRate` -> `UnsupportedConfig` and `HardwareStuck` -> `DeviceBusy`. 

- Update WASAPI to map mutex poison and `Activate` failures to `StreamInvalidated`.