### PR TITLE
feat(pipewire): monitor default device changes

### DIFF
--- a/src/host/coreaudio/ios/mod.rs
+++ b/src/host/coreaudio/ios/mod.rs
@@ -20,7 +20,7 @@ use self::enumerate::{
 };
 use super::{asbd_from_config, host_time_to_stream_instant};
 use crate::{
-    host::frames_to_duration,
+    host::{frames_to_duration, try_emit_error},
     traits::{DeviceTrait, HostTrait, StreamTrait},
     BufferSize, ChannelCount, Data, DeviceDescription, DeviceDescriptionBuilder, DeviceId, Error,
     ErrorKind, FrameCount, InputCallbackInfo, InputStreamTimestamp, OutputCallbackInfo,
@@ -184,9 +184,7 @@ impl DeviceTrait for Device {
             device_buffer_frames,
             data_callback,
             move |e| {
-                if let Ok(mut cb) = error_callback.lock() {
-                    cb(e);
-                }
+                try_emit_error(&error_callback, e);
             },
         )?;
 
@@ -231,9 +229,7 @@ impl DeviceTrait for Device {
             device_buffer_frames,
             data_callback,
             move |e| {
-                if let Ok(mut cb) = error_callback.lock() {
-                    cb(e);
-                }
+                try_emit_error(&error_callback, e);
             },
         )?;
 

--- a/src/host/coreaudio/ios/session_event_manager.rs
+++ b/src/host/coreaudio/ios/session_event_manager.rs
@@ -14,7 +14,7 @@ use objc2_avf_audio::{
 };
 use objc2_foundation::{NSNotification, NSNotificationCenter, NSNumber, NSString};
 
-use crate::{Error, ErrorKind};
+use crate::{host::emit_error, Error, ErrorKind};
 
 pub(super) type ErrorCallbackMutex = Arc<Mutex<Box<dyn FnMut(Error) + Send>>>;
 
@@ -67,9 +67,7 @@ impl SessionEventManager {
             let cb = error_callback.clone();
             let block = RcBlock::new(move |notif: NonNull<NSNotification>| {
                 if let Some(err) = unsafe { route_change_error(notif.as_ref()) } {
-                    if let Ok(mut cb) = cb.lock() {
-                        cb(err);
-                    }
+                    emit_error(&cb, err);
                 }
             });
             if let Some(name) = unsafe { AVAudioSessionRouteChangeNotification } {
@@ -83,12 +81,13 @@ impl SessionEventManager {
         {
             let cb = error_callback.clone();
             let block = RcBlock::new(move |_: NonNull<NSNotification>| {
-                if let Ok(mut cb) = cb.lock() {
-                    cb(Error::with_message(
+                emit_error(
+                    &cb,
+                    Error::with_message(
                         ErrorKind::DeviceNotAvailable,
                         "audio media services were lost",
-                    ));
-                }
+                    ),
+                );
             });
             if let Some(name) = unsafe { AVAudioSessionMediaServicesWereLostNotification } {
                 let observer = unsafe {
@@ -101,12 +100,13 @@ impl SessionEventManager {
         {
             let cb = error_callback.clone();
             let block = RcBlock::new(move |_: NonNull<NSNotification>| {
-                if let Ok(mut cb) = cb.lock() {
-                    cb(Error::with_message(
+                emit_error(
+                    &cb,
+                    Error::with_message(
                         ErrorKind::StreamInvalidated,
                         "audio media services were reset",
-                    ));
-                }
+                    ),
+                );
             });
             if let Some(name) = unsafe { AVAudioSessionMediaServicesWereResetNotification } {
                 let observer = unsafe {

--- a/src/host/coreaudio/macos/device.rs
+++ b/src/host/coreaudio/macos/device.rs
@@ -52,7 +52,7 @@ use std::sync::mpsc::{channel, RecvTimeoutError};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
-use super::invoke_error_callback;
+use crate::host::emit_error;
 use coreaudio::audio_unit::macos_helpers::get_device_name;
 
 /// Try to find a matching physical stream format on the device and apply it.
@@ -810,7 +810,7 @@ impl Device {
 
             let callback = match host_time_to_stream_instant(args.time_stamp.mHostTime) {
                 Err(err) => {
-                    invoke_error_callback(&error_callback, err);
+                    emit_error(&error_callback, err);
                     return Err(());
                 }
                 Ok(cb) => cb,
@@ -917,7 +917,7 @@ impl Device {
 
             let callback = match host_time_to_stream_instant(args.time_stamp.mHostTime) {
                 Err(err) => {
-                    invoke_error_callback(&error_callback_for_render, err);
+                    emit_error(&error_callback_for_render, err);
                     return Err(());
                 }
                 Ok(cb) => cb,

--- a/src/host/coreaudio/macos/device.rs
+++ b/src/host/coreaudio/macos/device.rs
@@ -52,7 +52,7 @@ use std::sync::mpsc::{channel, RecvTimeoutError};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
-use crate::host::emit_error;
+use crate::host::{emit_error, try_emit_error};
 use coreaudio::audio_unit::macos_helpers::get_device_name;
 
 /// Try to find a matching physical stream format on the device and apply it.
@@ -810,7 +810,7 @@ impl Device {
 
             let callback = match host_time_to_stream_instant(args.time_stamp.mHostTime) {
                 Err(err) => {
-                    emit_error(&error_callback, err);
+                    try_emit_error(&error_callback, err);
                     return Err(());
                 }
                 Ok(cb) => cb,

--- a/src/host/coreaudio/macos/device.rs
+++ b/src/host/coreaudio/macos/device.rs
@@ -52,7 +52,7 @@ use std::sync::mpsc::{channel, RecvTimeoutError};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
-use crate::host::{emit_error, try_emit_error};
+use crate::host::try_emit_error;
 use coreaudio::audio_unit::macos_helpers::get_device_name;
 
 /// Try to find a matching physical stream format on the device and apply it.
@@ -917,7 +917,7 @@ impl Device {
 
             let callback = match host_time_to_stream_instant(args.time_stamp.mHostTime) {
                 Err(err) => {
-                    emit_error(&error_callback_for_render, err);
+                    try_emit_error(&error_callback_for_render, err);
                     return Err(());
                 }
                 Ok(cb) => cb,

--- a/src/host/coreaudio/macos/mod.rs
+++ b/src/host/coreaudio/macos/mod.rs
@@ -13,7 +13,7 @@ use property_listener::AudioObjectPropertyListener;
 pub use self::enumerate::{default_input_device, default_output_device, Devices};
 use super::{asbd_from_config, check_os_status, host_time_to_stream_instant, OSStatus};
 use crate::{
-    host::{coreaudio::macos::loopback::LoopbackDevice, emit_error},
+    host::{coreaudio::macos::loopback::LoopbackDevice, emit_error, try_emit_error},
     traits::{HostTrait, StreamTrait},
     Error, ErrorKind, FrameCount, ResultExt, StreamInstant,
 };
@@ -227,7 +227,7 @@ impl DefaultOutputMonitor {
                     );
                 } else {
                     // DefaultOutput AudioUnit rerouted automatically; notify the caller.
-                    emit_error(
+                    try_emit_error(
                         &error_callback,
                         Error::with_message(
                             ErrorKind::DeviceChanged,

--- a/src/host/coreaudio/macos/mod.rs
+++ b/src/host/coreaudio/macos/mod.rs
@@ -13,7 +13,7 @@ use property_listener::AudioObjectPropertyListener;
 pub use self::enumerate::{default_input_device, default_output_device, Devices};
 use super::{asbd_from_config, check_os_status, host_time_to_stream_instant, OSStatus};
 use crate::{
-    host::coreaudio::macos::loopback::LoopbackDevice,
+    host::{coreaudio::macos::loopback::LoopbackDevice, emit_error},
     traits::{HostTrait, StreamTrait},
     Error, ErrorKind, FrameCount, ResultExt, StreamInstant,
 };
@@ -58,30 +58,6 @@ impl HostTrait for Host {
 
 /// Type alias for the error callback to reduce complexity
 type ErrorCallback = Box<dyn FnMut(Error) + Send + 'static>;
-
-/// Invoke error callback, recovering from poisoned mutex if needed.
-/// Returns true if callback was invoked, false if skipped due to WouldBlock.
-#[inline]
-fn invoke_error_callback<E>(error_callback: &Arc<Mutex<E>>, err: Error) -> bool
-where
-    E: FnMut(Error) + Send,
-{
-    match error_callback.try_lock() {
-        Ok(mut cb) => {
-            cb(err);
-            true
-        }
-        Err(std::sync::TryLockError::Poisoned(guard)) => {
-            // Recover from poisoned lock to still report this error
-            guard.into_inner()(err);
-            true
-        }
-        Err(std::sync::TryLockError::WouldBlock) => {
-            // Skip if callback is busy
-            false
-        }
-    }
-}
 
 /// Spawns a dedicated thread that registers a single property listener and signals a channel on
 /// each change. The listener is deregistered when the returned `Sender<()>` is dropped.
@@ -197,7 +173,7 @@ impl DisconnectManager {
                     if let Ok(mut stream_inner) = stream_arc.try_lock() {
                         let _ = stream_inner.pause();
                     }
-                    invoke_error_callback(&error_callback, err);
+                    emit_error(&error_callback, err);
                 } else {
                     break;
                 }
@@ -242,7 +218,7 @@ impl DefaultOutputMonitor {
                     if let Ok(mut inner) = arc.try_lock() {
                         let _ = inner.pause();
                     }
-                    invoke_error_callback(
+                    emit_error(
                         &error_callback,
                         Error::with_message(
                             ErrorKind::DeviceNotAvailable,
@@ -251,7 +227,7 @@ impl DefaultOutputMonitor {
                     );
                 } else {
                     // DefaultOutput AudioUnit rerouted automatically; notify the caller.
-                    invoke_error_callback(
+                    emit_error(
                         &error_callback,
                         Error::with_message(
                             ErrorKind::DeviceChanged,

--- a/src/host/jack/stream.rs
+++ b/src/host/jack/stream.rs
@@ -10,6 +10,8 @@ use crate::{
     ResultExt, Sample, SampleRate, StreamInstant,
 };
 
+use crate::host::emit_error;
+
 type ErrorCallbackPtr = Arc<Mutex<dyn FnMut(Error) + Send + 'static>>;
 
 pub struct Stream {
@@ -383,12 +385,13 @@ impl JackNotificationHandler {
 
 impl jack::NotificationHandler for JackNotificationHandler {
     unsafe fn shutdown(&mut self, _status: jack::ClientStatus, reason: &str) {
-        self.error_callback_ptr
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())(Error::with_message(
-            ErrorKind::DeviceNotAvailable,
-            format!("JACK server shut down: {reason}"),
-        ));
+        emit_error(
+            &self.error_callback_ptr,
+            Error::with_message(
+                ErrorKind::DeviceNotAvailable,
+                format!("JACK server shut down: {reason}"),
+            ),
+        );
     }
 
     fn sample_rate(&mut self, _: &jack::Client, srate: jack::Frames) -> jack::Control {
@@ -401,25 +404,23 @@ impl jack::NotificationHandler for JackNotificationHandler {
             true => {
                 // The JACK server has changed the sample rate, invalidating this stream.
                 // The stream configuration must be rebuilt with the new sample rate.
-                self.error_callback_ptr
-                    .lock()
-                    .unwrap_or_else(|e| e.into_inner())(Error::with_message(
-                    ErrorKind::StreamInvalidated,
-                    format!("JACK server changed sample rate to {srate} Hz"),
-                ));
+                emit_error(
+                    &self.error_callback_ptr,
+                    Error::with_message(
+                        ErrorKind::StreamInvalidated,
+                        format!("JACK server changed sample rate to {srate} Hz"),
+                    ),
+                );
                 jack::Control::Quit
             }
         }
     }
 
     fn xrun(&mut self, _: &jack::Client) -> jack::Control {
-        match self.error_callback_ptr.try_lock() {
-            Ok(mut cb) => cb(Error::with_message(ErrorKind::Xrun, "JACK xrun detected")),
-            Err(std::sync::TryLockError::Poisoned(e)) => {
-                e.into_inner()(Error::with_message(ErrorKind::Xrun, "JACK xrun detected"))
-            }
-            Err(std::sync::TryLockError::WouldBlock) => {}
-        }
+        emit_error(
+            &self.error_callback_ptr,
+            Error::with_message(ErrorKind::Xrun, "JACK xrun detected"),
+        );
         jack::Control::Continue
     }
 }

--- a/src/host/jack/stream.rs
+++ b/src/host/jack/stream.rs
@@ -10,7 +10,7 @@ use crate::{
     ResultExt, Sample, SampleRate, StreamInstant,
 };
 
-use crate::host::emit_error;
+use crate::host::{emit_error, try_emit_error};
 
 type ErrorCallbackPtr = Arc<Mutex<dyn FnMut(Error) + Send + 'static>>;
 
@@ -417,7 +417,7 @@ impl jack::NotificationHandler for JackNotificationHandler {
     }
 
     fn xrun(&mut self, _: &jack::Client) -> jack::Control {
-        emit_error(
+        try_emit_error(
             &self.error_callback_ptr,
             Error::with_message(ErrorKind::Xrun, "JACK xrun detected"),
         );

--- a/src/host/mod.rs
+++ b/src/host/mod.rs
@@ -130,7 +130,7 @@ pub(crate) mod null;
 
 /// Invoke an error callback behind a shared mutex without blocking the caller.
 #[cfg(any(
-    target_vendor = "apple",
+    target_os = "macos",
     all(
         feature = "jack",
         any(
@@ -144,11 +144,9 @@ pub(crate) mod null;
     ),
     all(feature = "pipewire", target_os = "linux"),
 ))]
-pub(crate) fn emit_error<E: ?Sized>(
-    callback: &std::sync::Arc<std::sync::Mutex<E>>,
-    error: crate::Error,
-) where
-    E: FnMut(crate::Error) + Send,
+pub(crate) fn emit_error<E>(callback: &std::sync::Arc<std::sync::Mutex<E>>, error: crate::Error)
+where
+    E: FnMut(crate::Error) + Send + ?Sized,
 {
     match callback.try_lock() {
         Ok(mut cb) => cb(error),

--- a/src/host/mod.rs
+++ b/src/host/mod.rs
@@ -131,7 +131,7 @@ pub(crate) mod null;
 /// Deliver an error that the app must not miss, blocking if the callback is currently
 /// executing on another thread. Use this for fatal or actionable errors.
 #[cfg(any(
-    target_os = "macos",
+    target_vendor = "apple",
     all(
         feature = "jack",
         any(
@@ -145,6 +145,15 @@ pub(crate) mod null;
     ),
     all(
         feature = "pipewire",
+        any(
+            target_os = "linux",
+            target_os = "dragonfly",
+            target_os = "freebsd",
+            target_os = "netbsd",
+        )
+    ),
+    all(
+        feature = "pulseaudio",
         any(
             target_os = "linux",
             target_os = "dragonfly",
@@ -167,7 +176,7 @@ where
 /// Use this only for non-fatal notifications where missing one occurrence is acceptable
 /// and blocking a real-time thread is not.
 #[cfg(any(
-    target_os = "macos",
+    target_vendor = "apple",
     all(
         feature = "jack",
         any(
@@ -181,6 +190,15 @@ where
     ),
     all(
         feature = "pipewire",
+        any(
+            target_os = "linux",
+            target_os = "dragonfly",
+            target_os = "freebsd",
+            target_os = "netbsd",
+        )
+    ),
+    all(
+        feature = "pulseaudio",
         any(
             target_os = "linux",
             target_os = "dragonfly",

--- a/src/host/mod.rs
+++ b/src/host/mod.rs
@@ -128,6 +128,35 @@ pub(crate) mod custom;
 )))]
 pub(crate) mod null;
 
+/// Invoke an error callback behind a shared mutex without blocking the caller.
+#[cfg(any(
+    target_vendor = "apple",
+    all(
+        feature = "jack",
+        any(
+            target_os = "linux",
+            target_os = "dragonfly",
+            target_os = "freebsd",
+            target_os = "netbsd",
+            target_os = "macos",
+            target_os = "windows",
+        )
+    ),
+    all(feature = "pipewire", target_os = "linux"),
+))]
+pub(crate) fn emit_error<E: ?Sized>(
+    callback: &std::sync::Arc<std::sync::Mutex<E>>,
+    error: crate::Error,
+) where
+    E: FnMut(crate::Error) + Send,
+{
+    match callback.try_lock() {
+        Ok(mut cb) => cb(error),
+        Err(std::sync::TryLockError::Poisoned(e)) => e.into_inner()(error),
+        Err(std::sync::TryLockError::WouldBlock) => {}
+    }
+}
+
 /// Convert a frame count at a given sample rate to a [`std::time::Duration`].
 #[cfg(any(
     target_os = "linux",

--- a/src/host/mod.rs
+++ b/src/host/mod.rs
@@ -128,7 +128,8 @@ pub(crate) mod custom;
 )))]
 pub(crate) mod null;
 
-/// Invoke an error callback behind a shared mutex without blocking the caller.
+/// Deliver an error that the app must not miss, blocking if the callback is currently
+/// executing on another thread. Use this for fatal or actionable errors.
 #[cfg(any(
     target_os = "macos",
     all(
@@ -142,9 +143,53 @@ pub(crate) mod null;
             target_os = "windows",
         )
     ),
-    all(feature = "pipewire", target_os = "linux"),
+    all(
+        feature = "pipewire",
+        any(
+            target_os = "linux",
+            target_os = "dragonfly",
+            target_os = "freebsd",
+            target_os = "netbsd",
+        )
+    ),
 ))]
 pub(crate) fn emit_error<E>(callback: &std::sync::Arc<std::sync::Mutex<E>>, error: crate::Error)
+where
+    E: FnMut(crate::Error) + Send + ?Sized,
+{
+    let mut cb = callback.lock().unwrap_or_else(|e| e.into_inner());
+    cb(error);
+}
+
+/// Try to deliver an error without blocking the caller.
+///
+/// Silently drops the error if the callback is currently executing on another thread.
+/// Use this only for non-fatal notifications where missing one occurrence is acceptable
+/// and blocking a real-time thread is not.
+#[cfg(any(
+    target_os = "macos",
+    all(
+        feature = "jack",
+        any(
+            target_os = "linux",
+            target_os = "dragonfly",
+            target_os = "freebsd",
+            target_os = "netbsd",
+            target_os = "macos",
+            target_os = "windows",
+        )
+    ),
+    all(
+        feature = "pipewire",
+        any(
+            target_os = "linux",
+            target_os = "dragonfly",
+            target_os = "freebsd",
+            target_os = "netbsd",
+        )
+    ),
+))]
+pub(crate) fn try_emit_error<E>(callback: &std::sync::Arc<std::sync::Mutex<E>>, error: crate::Error)
 where
     E: FnMut(crate::Error) + Send + ?Sized,
 {

--- a/src/host/pipewire/device.rs
+++ b/src/host/pipewire/device.rs
@@ -329,16 +329,18 @@ impl DeviceTrait for Device {
                     listener,
                     stream,
                     context,
-                    ..
+                    default_monitor,
                 }) = super::stream::connect_input(
-                    config,
-                    properties,
-                    sample_format,
+                    super::stream::ConnectParams {
+                        config,
+                        properties,
+                        sample_format,
+                        last_quantum: last_quantum_clone,
+                        start,
+                        default_metadata_key: device.default_metadata_key(),
+                    },
                     data_callback,
                     error_callback,
-                    last_quantum_clone,
-                    start,
-                    device.default_metadata_key(),
                 )
                 else {
                     let _ = pw_init_tx.send(false);
@@ -358,6 +360,7 @@ impl DeviceTrait for Device {
                 });
                 mainloop.run();
                 drop(listener);
+                drop(default_monitor);
                 drop(context);
             })
             .map_err(|e| {
@@ -416,16 +419,18 @@ impl DeviceTrait for Device {
                     listener,
                     stream,
                     context,
-                    ..
+                    default_monitor,
                 }) = super::stream::connect_output(
-                    config,
-                    properties,
-                    sample_format,
+                    super::stream::ConnectParams {
+                        config,
+                        properties,
+                        sample_format,
+                        last_quantum: last_quantum_clone,
+                        start,
+                        default_metadata_key: device.default_metadata_key(),
+                    },
                     data_callback,
                     error_callback,
-                    last_quantum_clone,
-                    start,
-                    device.default_metadata_key(),
                 )
                 else {
                     let _ = pw_init_tx.send(false);
@@ -446,6 +451,7 @@ impl DeviceTrait for Device {
                 });
                 mainloop.run();
                 drop(listener);
+                drop(default_monitor);
                 drop(context);
             })
             .map_err(|e| {
@@ -861,7 +867,8 @@ fn parse_allow_rates(list: &str) -> Option<Vec<SampleRate>> {
 
 #[cfg(test)]
 mod test {
-    use super::{parse_allow_rates, parse_fraction};
+    use super::{parse_allow_rates, parse_fraction, Class, Device};
+    use crate::host::pipewire::utils::default;
 
     #[test]
     fn rate_parse() {
@@ -898,5 +905,27 @@ mod test {
         assert_eq!(parse_fraction("abc/def"), None);
         assert_eq!(parse_fraction("/48000"), None);
         assert_eq!(parse_fraction("256/"), None);
+    }
+
+    #[test]
+    fn default_metadata_key_mapping() {
+        assert_eq!(
+            Device::output_default().default_metadata_key(),
+            Some(default::SINK)
+        );
+        assert_eq!(
+            Device::sink_default().default_metadata_key(),
+            Some(default::SINK)
+        );
+        assert_eq!(
+            Device::input_default().default_metadata_key(),
+            Some(default::SOURCE)
+        );
+
+        let node = Device {
+            class: Class::Node,
+            ..Default::default()
+        };
+        assert_eq!(node.default_metadata_key(), None);
     }
 }

--- a/src/host/pipewire/device.rs
+++ b/src/host/pipewire/device.rs
@@ -330,6 +330,7 @@ impl DeviceTrait for Device {
                     stream,
                     context,
                     default_monitor,
+                    core_monitor,
                 }) = super::stream::connect_input(
                     super::stream::ConnectParams {
                         config,
@@ -361,6 +362,7 @@ impl DeviceTrait for Device {
                 mainloop.run();
                 drop(listener);
                 drop(default_monitor);
+                drop(core_monitor);
                 drop(context);
             })
             .map_err(|e| {
@@ -420,6 +422,7 @@ impl DeviceTrait for Device {
                     stream,
                     context,
                     default_monitor,
+                    core_monitor,
                 }) = super::stream::connect_output(
                     super::stream::ConnectParams {
                         config,
@@ -452,6 +455,7 @@ impl DeviceTrait for Device {
                 mainloop.run();
                 drop(listener);
                 drop(default_monitor);
+                drop(core_monitor);
                 drop(context);
             })
             .map_err(|e| {

--- a/src/host/pipewire/device.rs
+++ b/src/host/pipewire/device.rs
@@ -17,7 +17,7 @@ use pipewire::{
 use super::stream::Stream;
 use crate::{
     host::pipewire::stream::{PwInitGuard, StreamCommand, StreamData, SUPPORTED_FORMATS},
-    host::pipewire::utils::{audio, clock, node, DEVICE_ICON_NAME, METADATA_NAME},
+    host::pipewire::utils::{audio, clock, default, node, DEVICE_ICON_NAME, METADATA_NAME},
     iter::{SupportedInputConfigs, SupportedOutputConfigs},
     traits::DeviceTrait,
     BufferSize, ChannelCount, Data, DeviceDescription, DeviceDescriptionBuilder, DeviceDirection,
@@ -117,6 +117,16 @@ impl Device {
             "audio-input-microphone" => DeviceType::Microphone,
             "audio-speakers" => DeviceType::Speaker,
             _ => DeviceType::Unknown,
+        }
+    }
+
+    /// Returns the WirePlumber metadata key to watch for default-device changes,
+    /// or `None` if this device is pinned to a specific node.
+    pub(crate) fn default_metadata_key(&self) -> Option<&'static str> {
+        match self.class {
+            Class::DefaultOutput | Class::DefaultSink => Some(default::SINK),
+            Class::DefaultInput => Some(default::SOURCE),
+            Class::Node => None,
         }
     }
 
@@ -319,6 +329,7 @@ impl DeviceTrait for Device {
                     listener,
                     stream,
                     context,
+                    ..
                 }) = super::stream::connect_input(
                     config,
                     properties,
@@ -327,6 +338,7 @@ impl DeviceTrait for Device {
                     error_callback,
                     last_quantum_clone,
                     start,
+                    device.default_metadata_key(),
                 )
                 else {
                     let _ = pw_init_tx.send(false);
@@ -404,6 +416,7 @@ impl DeviceTrait for Device {
                     listener,
                     stream,
                     context,
+                    ..
                 }) = super::stream::connect_output(
                     config,
                     properties,
@@ -412,6 +425,7 @@ impl DeviceTrait for Device {
                     error_callback,
                     last_quantum_clone,
                     start,
+                    device.default_metadata_key(),
                 )
                 else {
                     let _ = pw_init_tx.send(false);

--- a/src/host/pipewire/stream.rs
+++ b/src/host/pipewire/stream.rs
@@ -1,4 +1,6 @@
 use std::{
+    cell::{Cell, RefCell},
+    rc::Rc,
     sync::{
         atomic::{AtomicU64, Ordering},
         Arc, Mutex,
@@ -11,6 +13,8 @@ use pipewire::{
     self as pw,
     context::ContextRc,
     main_loop::MainLoopRc,
+    metadata::{Metadata, MetadataListener},
+    registry::{Listener as RegistryListener, RegistryRc},
     spa::{
         param::{
             format::{MediaSubtype, MediaType},
@@ -175,28 +179,29 @@ impl From<SampleFormat> for pw::spa::param::audio::AudioFormat {
     }
 }
 
-pub struct UserData<D, E> {
+type ErrorCallback = Arc<Mutex<Box<dyn FnMut(Error) + Send + 'static>>>;
+
+pub struct UserData<D> {
     data_callback: D,
-    error_callback: E,
+    error_callback: ErrorCallback,
     sample_format: SampleFormat,
     format: pw::spa::param::audio::AudioInfoRaw,
     last_quantum: Arc<AtomicU64>,
     start: Instant,
 }
-impl<D, E> UserData<D, E>
-where
-    E: FnMut(Error) + Send + 'static,
-{
+
+impl<D> UserData<D> {
+    fn emit_error(&self, error: Error) {
+        let mut cb = self
+            .error_callback
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        cb(error);
+    }
+
     fn state_changed(&mut self, new: StreamState) {
-        match new {
-            pipewire::stream::StreamState::Error(e) => {
-                (self.error_callback)(Error::with_message(ErrorKind::StreamInvalidated, e))
-            }
-            // TODO: maybe we need to log information when every new state comes?
-            pipewire::stream::StreamState::Paused => {}
-            pipewire::stream::StreamState::Streaming => {}
-            pipewire::stream::StreamState::Connecting => {}
-            pipewire::stream::StreamState::Unconnected => {}
+        if let StreamState::Error(e) = new {
+            self.emit_error(Error::with_message(ErrorKind::StreamInvalidated, e));
         }
     }
 }
@@ -233,10 +238,9 @@ fn pw_stream_time(stream: &pw::stream::Stream) -> Option<PwTime> {
     })
 }
 
-impl<D, E> UserData<D, E>
+impl<D> UserData<D>
 where
     D: FnMut(&Data, &InputCallbackInfo) + Send + 'static,
-    E: FnMut(Error) + Send + 'static,
 {
     fn publish_data_in(&mut self, stream: &pw::stream::Stream, frames: usize, data: &Data) {
         self.last_quantum.store(frames as u64, Ordering::Relaxed);
@@ -259,10 +263,10 @@ where
         (self.data_callback)(data, &info);
     }
 }
-impl<D, E> UserData<D, E>
+
+impl<D> UserData<D>
 where
     D: FnMut(&mut Data, &OutputCallbackInfo) + Send + 'static,
-    E: FnMut(Error) + Send + 'static,
 {
     fn publish_data_out(&mut self, stream: &pw::stream::Stream, frames: usize, data: &mut Data) {
         self.last_quantum.store(frames as u64, Ordering::Relaxed);
@@ -283,11 +287,13 @@ where
         (self.data_callback)(data, &info);
     }
 }
-pub struct StreamData<D, E> {
+
+pub struct StreamData<D> {
     pub mainloop: MainLoopRc,
-    pub listener: StreamListener<UserData<D, E>>,
+    pub listener: StreamListener<UserData<D>>,
     pub stream: StreamRc,
     pub context: ContextRc,
+    pub _default_monitor: Option<DefaultDeviceMonitor>,
 }
 
 /// Fallback timestamp using elapsed time since stream creation.
@@ -321,6 +327,81 @@ fn remote_props() -> Option<pw::properties::PropertiesBox> {
     Some(props)
 }
 
+/// Holds the metadata proxy and its listener alive for the duration of the stream, so that
+/// default-device changes are delivered via `error_callback`.
+struct MetadataObjects {
+    _listener: MetadataListener,
+    _metadata: Metadata,
+}
+
+pub struct DefaultDeviceMonitor {
+    _registry: RegistryRc,
+    _registry_listener: RegistryListener,
+    _meta_objects: Rc<RefCell<Option<MetadataObjects>>>,
+}
+
+impl DefaultDeviceMonitor {
+    /// Subscribe to the `"default"` metadata object and fire `error_callback` with
+    /// [`ErrorKind::DeviceChanged`] whenever its key changes.
+    fn new(registry: RegistryRc, key: &'static str, error_callback: ErrorCallback) -> Self {
+        let meta_objects: Rc<RefCell<Option<MetadataObjects>>> = Rc::new(RefCell::new(None));
+        let meta_objects_ref = meta_objects.clone();
+        let registry_ref = registry.clone();
+
+        let registry_listener = registry
+            .add_listener_local()
+            .global(move |global| {
+                if global.type_ != pipewire::types::ObjectType::Metadata {
+                    return;
+                }
+                if !global.props.is_some_and(|props| {
+                    props
+                        .get(super::utils::METADATA_NAME)
+                        .is_some_and(|v| v == super::utils::default::NAME)
+                }) {
+                    return;
+                }
+                let metadata: Metadata = match registry_ref.bind(global) {
+                    Ok(m) => m,
+                    Err(_) => return,
+                };
+                let error_callback_cb = error_callback.clone();
+
+                // Skip the initial catchup delivery; only fire on actual changes.
+                let seen_first = Cell::new(false);
+                let listener = metadata
+                    .add_listener_local()
+                    .property(move |_subject, prop_key, _type, value| {
+                        if prop_key == Some(key) && value.is_some() {
+                            if seen_first.get() {
+                                let mut cb =
+                                    error_callback_cb.lock().unwrap_or_else(|e| e.into_inner());
+                                cb(Error::with_message(
+                                    ErrorKind::DeviceChanged,
+                                    "default device changed",
+                                ));
+                            } else {
+                                seen_first.set(true);
+                            }
+                        }
+                        0
+                    })
+                    .register();
+                *meta_objects_ref.borrow_mut() = Some(MetadataObjects {
+                    _listener: listener,
+                    _metadata: metadata,
+                });
+            })
+            .register();
+
+        DefaultDeviceMonitor {
+            _registry: registry,
+            _registry_listener: registry_listener,
+            _meta_objects: meta_objects,
+        }
+    }
+}
+
 pub fn connect_output<D, E>(
     config: StreamConfig,
     properties: pw::properties::PropertiesBox,
@@ -329,7 +410,8 @@ pub fn connect_output<D, E>(
     error_callback: E,
     last_quantum: Arc<AtomicU64>,
     start: Instant,
-) -> Result<StreamData<D, E>, pw::Error>
+    default_metadata_key: Option<&'static str>,
+) -> Result<StreamData<D>, pw::Error>
 where
     D: FnMut(&mut Data, &OutputCallbackInfo) + Send + 'static,
     E: FnMut(Error) + Send + 'static,
@@ -337,6 +419,14 @@ where
     let mainloop = pw::main_loop::MainLoopRc::new(None)?;
     let context = pw::context::ContextRc::new(&mainloop, None)?;
     let core = context.connect_rc(remote_props())?;
+
+    let error_callback: ErrorCallback = Arc::new(Mutex::new(Box::new(error_callback)));
+
+    let default_monitor = default_metadata_key.and_then(|key| {
+        core.get_registry_rc()
+            .ok()
+            .map(|registry| DefaultDeviceMonitor::new(registry, key, error_callback.clone()))
+    });
 
     let data = UserData {
         data_callback,
@@ -381,13 +471,13 @@ where
                     || current_rate != rate
                     || current_fmt != expected_fmt;
                 if mismatch {
-                    (user_data.error_callback)(Error::with_message(
+                    user_data.emit_error(Error::with_message(
                         ErrorKind::UnsupportedConfig,
                         format!("negotiated format mismatch: expected channels={channels} rate={rate} format={expected_fmt:?}, got channels={current_channels} rate={current_rate} format={current_fmt:?}"),
                     ));
                     // if the format does not match, we stop the stream
                     if let Err(e) = stream.set_active(false) {
-                        (user_data.error_callback)(Error::with_message(
+                        user_data.emit_error(Error::with_message(
                             ErrorKind::StreamInvalidated,
                             format!("failed to stop the stream, reason: {e}"),
                         ));
@@ -477,8 +567,10 @@ where
         listener,
         stream,
         context,
+        _default_monitor: default_monitor,
     })
 }
+
 pub fn connect_input<D, E>(
     config: StreamConfig,
     properties: pw::properties::PropertiesBox,
@@ -487,7 +579,8 @@ pub fn connect_input<D, E>(
     error_callback: E,
     last_quantum: Arc<AtomicU64>,
     start: Instant,
-) -> Result<StreamData<D, E>, pw::Error>
+    default_metadata_key: Option<&'static str>,
+) -> Result<StreamData<D>, pw::Error>
 where
     D: FnMut(&Data, &InputCallbackInfo) + Send + 'static,
     E: FnMut(Error) + Send + 'static,
@@ -495,6 +588,14 @@ where
     let mainloop = pw::main_loop::MainLoopRc::new(None)?;
     let context = pw::context::ContextRc::new(&mainloop, None)?;
     let core = context.connect_rc(remote_props())?;
+
+    let error_callback: ErrorCallback = Arc::new(Mutex::new(Box::new(error_callback)));
+
+    let default_monitor = default_metadata_key.and_then(|key| {
+        core.get_registry_rc()
+            .ok()
+            .map(|registry| DefaultDeviceMonitor::new(registry, key, error_callback.clone()))
+    });
 
     let data = UserData {
         data_callback,
@@ -542,13 +643,13 @@ where
                     || current_rate != rate
                     || current_fmt != expected_fmt;
                 if mismatch {
-                    (user_data.error_callback)(Error::with_message(
+                    user_data.emit_error(Error::with_message(
                         ErrorKind::UnsupportedConfig,
                         format!("negotiated format mismatch: expected channels={channels} rate={rate} format={expected_fmt:?}, got channels={current_channels} rate={current_rate} format={current_fmt:?}"),
                     ));
                     // if the format does not match, we stop the stream
                     if let Err(e) = stream.set_active(false) {
-                        (user_data.error_callback)(Error::with_message(
+                        user_data.emit_error(Error::with_message(
                             ErrorKind::StreamInvalidated,
                             format!("failed to stop the stream, reason: {e}"),
                         ));
@@ -619,5 +720,6 @@ where
         listener,
         stream,
         context,
+        _default_monitor: default_monitor,
     })
 }

--- a/src/host/pipewire/stream.rs
+++ b/src/host/pipewire/stream.rs
@@ -26,7 +26,7 @@ use pipewire::{
 };
 
 use crate::{
-    host::{equilibrium::fill_equilibrium, frames_to_duration},
+    host::{emit_error, equilibrium::fill_equilibrium, frames_to_duration},
     traits::StreamTrait,
     Data, Error, ErrorKind, FrameCount, InputCallbackInfo, InputStreamTimestamp,
     OutputCallbackInfo, OutputStreamTimestamp, SampleFormat, StreamConfig, StreamInstant,
@@ -191,17 +191,12 @@ pub struct UserData<D> {
 }
 
 impl<D> UserData<D> {
-    fn emit_error(&self, error: Error) {
-        let mut cb = self
-            .error_callback
-            .lock()
-            .unwrap_or_else(|e| e.into_inner());
-        cb(error);
-    }
-
     fn state_changed(&mut self, new: StreamState) {
         if let StreamState::Error(e) = new {
-            self.emit_error(Error::with_message(ErrorKind::StreamInvalidated, e));
+            emit_error(
+                &self.error_callback,
+                Error::with_message(ErrorKind::StreamInvalidated, e),
+            );
         }
     }
 }
@@ -372,14 +367,22 @@ impl DefaultDeviceMonitor {
                 let listener = metadata
                     .add_listener_local()
                     .property(move |_subject, prop_key, _type, value| {
-                        if prop_key == Some(key) && value.is_some() {
+                        // The first delivery for this key is catchup of existing state;
+                        // only subsequent ones are real changes worth reporting.
+                        if prop_key == Some(key) {
                             if seen_first.get() {
-                                let mut cb =
-                                    error_callback_cb.lock().unwrap_or_else(|e| e.into_inner());
-                                cb(Error::with_message(
-                                    ErrorKind::DeviceChanged,
-                                    "default device changed",
-                                ));
+                                let error = if value.is_some() {
+                                    Error::with_message(
+                                        ErrorKind::DeviceChanged,
+                                        "default device changed",
+                                    )
+                                } else {
+                                    Error::with_message(
+                                        ErrorKind::DeviceNotAvailable,
+                                        "default device removed",
+                                    )
+                                };
+                                emit_error(&error_callback_cb, error);
                             } else {
                                 seen_first.set(true);
                             }
@@ -484,13 +487,13 @@ where
                     || current_rate != rate
                     || current_fmt != expected_fmt;
                 if mismatch {
-                    user_data.emit_error(Error::with_message(
+                    emit_error(&user_data.error_callback, Error::with_message(
                         ErrorKind::UnsupportedConfig,
                         format!("negotiated format mismatch: expected channels={channels} rate={rate} format={expected_fmt:?}, got channels={current_channels} rate={current_rate} format={current_fmt:?}"),
                     ));
                     // if the format does not match, we stop the stream
                     if let Err(e) = stream.set_active(false) {
-                        user_data.emit_error(Error::with_message(
+                        emit_error(&user_data.error_callback, Error::with_message(
                             ErrorKind::StreamInvalidated,
                             format!("failed to stop the stream, reason: {e}"),
                         ));
@@ -660,13 +663,13 @@ where
                     || current_rate != rate
                     || current_fmt != expected_fmt;
                 if mismatch {
-                    user_data.emit_error(Error::with_message(
+                    emit_error(&user_data.error_callback, Error::with_message(
                         ErrorKind::UnsupportedConfig,
                         format!("negotiated format mismatch: expected channels={channels} rate={rate} format={expected_fmt:?}, got channels={current_channels} rate={current_rate} format={current_fmt:?}"),
                     ));
                     // if the format does not match, we stop the stream
                     if let Err(e) = stream.set_active(false) {
-                        user_data.emit_error(Error::with_message(
+                        emit_error(&user_data.error_callback, Error::with_message(
                             ErrorKind::StreamInvalidated,
                             format!("failed to stop the stream, reason: {e}"),
                         ));

--- a/src/host/pipewire/stream.rs
+++ b/src/host/pipewire/stream.rs
@@ -293,7 +293,7 @@ pub struct StreamData<D> {
     pub listener: StreamListener<UserData<D>>,
     pub stream: StreamRc,
     pub context: ContextRc,
-    pub _default_monitor: Option<DefaultDeviceMonitor>,
+    pub default_monitor: Option<DefaultDeviceMonitor>,
 }
 
 /// Fallback timestamp using elapsed time since stream creation.
@@ -402,20 +402,33 @@ impl DefaultDeviceMonitor {
     }
 }
 
+pub struct ConnectParams {
+    pub config: StreamConfig,
+    pub properties: pw::properties::PropertiesBox,
+    pub sample_format: SampleFormat,
+    pub last_quantum: Arc<AtomicU64>,
+    pub start: Instant,
+    pub default_metadata_key: Option<&'static str>,
+}
+
 pub fn connect_output<D, E>(
-    config: StreamConfig,
-    properties: pw::properties::PropertiesBox,
-    sample_format: SampleFormat,
+    params: ConnectParams,
     data_callback: D,
     error_callback: E,
-    last_quantum: Arc<AtomicU64>,
-    start: Instant,
-    default_metadata_key: Option<&'static str>,
 ) -> Result<StreamData<D>, pw::Error>
 where
     D: FnMut(&mut Data, &OutputCallbackInfo) + Send + 'static,
     E: FnMut(Error) + Send + 'static,
 {
+    let ConnectParams {
+        config,
+        properties,
+        sample_format,
+        last_quantum,
+        start,
+        default_metadata_key,
+    } = params;
+
     let mainloop = pw::main_loop::MainLoopRc::new(None)?;
     let context = pw::context::ContextRc::new(&mainloop, None)?;
     let core = context.connect_rc(remote_props())?;
@@ -567,24 +580,28 @@ where
         listener,
         stream,
         context,
-        _default_monitor: default_monitor,
+        default_monitor,
     })
 }
 
 pub fn connect_input<D, E>(
-    config: StreamConfig,
-    properties: pw::properties::PropertiesBox,
-    sample_format: SampleFormat,
+    params: ConnectParams,
     data_callback: D,
     error_callback: E,
-    last_quantum: Arc<AtomicU64>,
-    start: Instant,
-    default_metadata_key: Option<&'static str>,
 ) -> Result<StreamData<D>, pw::Error>
 where
     D: FnMut(&Data, &InputCallbackInfo) + Send + 'static,
     E: FnMut(Error) + Send + 'static,
 {
+    let ConnectParams {
+        config,
+        properties,
+        sample_format,
+        last_quantum,
+        start,
+        default_metadata_key,
+    } = params;
+
     let mainloop = pw::main_loop::MainLoopRc::new(None)?;
     let context = pw::context::ContextRc::new(&mainloop, None)?;
     let core = context.connect_rc(remote_props())?;
@@ -720,6 +737,6 @@ where
         listener,
         stream,
         context,
-        _default_monitor: default_monitor,
+        default_monitor,
     })
 }

--- a/src/host/pipewire/stream.rs
+++ b/src/host/pipewire/stream.rs
@@ -1,5 +1,5 @@
 use std::{
-    cell::{Cell, RefCell},
+    cell::RefCell,
     rc::Rc,
     sync::{
         atomic::{AtomicBool, AtomicU64, Ordering},
@@ -27,7 +27,7 @@ use pipewire::{
 };
 
 use crate::{
-    host::{emit_error, equilibrium::fill_equilibrium, frames_to_duration},
+    host::{emit_error, equilibrium::fill_equilibrium, frames_to_duration, try_emit_error},
     traits::StreamTrait,
     Data, Error, ErrorKind, FrameCount, InputCallbackInfo, InputStreamTimestamp,
     OutputCallbackInfo, OutputStreamTimestamp, SampleFormat, StreamConfig, StreamInstant,
@@ -202,7 +202,7 @@ impl<D> UserData<D> {
                 // Let the metadata monitor fire for default-device streams
                 if self.has_connected
                     && !self.is_default_device
-                    && !self.invalidated.swap(true, Ordering::AcqRel)
+                    && !self.invalidated.swap(true, Ordering::Relaxed)
                 {
                     emit_error(
                         &self.error_callback,
@@ -211,7 +211,7 @@ impl<D> UserData<D> {
                 }
             }
             StreamState::Error(e) => {
-                if !self.invalidated.swap(true, Ordering::AcqRel) {
+                if !self.invalidated.swap(true, Ordering::Relaxed) {
                     emit_error(
                         &self.error_callback,
                         Error::with_message(ErrorKind::StreamInvalidated, e),
@@ -391,34 +391,35 @@ impl DefaultDeviceMonitor {
                 let error_callback_cb = error_callback.clone();
                 let invalidated_cb = invalidated.clone();
 
-                // Skip the initial catchup delivery; only fire on actual changes.
-                let seen_first = Cell::new(false);
+                let last_value: RefCell<Option<Option<String>>> = RefCell::new(None);
                 let listener = metadata
                     .add_listener_local()
                     .property(move |_subject, prop_key, _type, value| {
-                        // The first delivery for this key is catchup of existing state;
-                        // only subsequent ones are real changes worth reporting.
                         if prop_key == Some(key) {
-                            if seen_first.get() {
-                                if value.is_some() {
-                                    emit_error(
-                                        &error_callback_cb,
-                                        Error::with_message(
-                                            ErrorKind::DeviceChanged,
-                                            "default device changed",
-                                        ),
-                                    );
-                                } else if !invalidated_cb.swap(true, Ordering::AcqRel) {
-                                    emit_error(
-                                        &error_callback_cb,
-                                        Error::with_message(
-                                            ErrorKind::DeviceNotAvailable,
-                                            "default device removed",
-                                        ),
-                                    );
+                            let prev = std::mem::replace(
+                                &mut *last_value.borrow_mut(),
+                                Some(value.map(str::to_owned)),
+                            );
+                            if let Some(old) = prev {
+                                if old.as_deref() != value {
+                                    if value.is_some() {
+                                        try_emit_error(
+                                            &error_callback_cb,
+                                            Error::with_message(
+                                                ErrorKind::DeviceChanged,
+                                                "default device changed",
+                                            ),
+                                        );
+                                    } else if !invalidated_cb.swap(true, Ordering::Relaxed) {
+                                        emit_error(
+                                            &error_callback_cb,
+                                            Error::with_message(
+                                                ErrorKind::DeviceNotAvailable,
+                                                "default device removed",
+                                            ),
+                                        );
+                                    }
                                 }
-                            } else {
-                                seen_first.set(true);
                             }
                         }
                         0
@@ -485,7 +486,7 @@ where
         let error_callback_core = error_callback.clone();
         core.add_listener_local()
             .error(move |id, _seq, _res, message| {
-                if id == pw::core::PW_ID_CORE && !invalidated_core.swap(true, Ordering::AcqRel) {
+                if id == pw::core::PW_ID_CORE && !invalidated_core.swap(true, Ordering::Relaxed) {
                     emit_error(
                         &error_callback_core,
                         Error::with_message(
@@ -543,7 +544,7 @@ where
                 let mismatch = current_channels != channels
                     || current_rate != rate
                     || current_fmt != expected_fmt;
-                if mismatch && !user_data.invalidated.swap(true, Ordering::AcqRel) {
+                if mismatch && !user_data.invalidated.swap(true, Ordering::Relaxed) {
                     emit_error(
                         &user_data.error_callback,
                         Error::with_message(
@@ -686,7 +687,7 @@ where
         let error_callback_core = error_callback.clone();
         core.add_listener_local()
             .error(move |id, _seq, _res, message| {
-                if id == pw::core::PW_ID_CORE && !invalidated_core.swap(true, Ordering::AcqRel) {
+                if id == pw::core::PW_ID_CORE && !invalidated_core.swap(true, Ordering::Relaxed) {
                     emit_error(
                         &error_callback_core,
                         Error::with_message(
@@ -747,9 +748,7 @@ where
                 let mismatch = current_channels != channels
                     || current_rate != rate
                     || current_fmt != expected_fmt;
-                if mismatch
-                    && !user_data.invalidated.swap(true, Ordering::AcqRel)
-                {
+                if mismatch && !user_data.invalidated.swap(true, Ordering::Relaxed) {
                     emit_error(
                         &user_data.error_callback,
                         Error::with_message(
@@ -758,7 +757,9 @@ where
                         ),
                     );
                     if let Err(e) = stream.set_active(false) {
-                        emit_error(&user_data.error_callback, Error::with_message(
+                        emit_error(
+                            &user_data.error_callback,
+                            Error::with_message(
                                 ErrorKind::StreamInvalidated,
                                 format!("failed to stop the stream, reason: {e}"),
                             ),

--- a/src/host/pipewire/stream.rs
+++ b/src/host/pipewire/stream.rs
@@ -396,10 +396,7 @@ impl DefaultDeviceMonitor {
                     .add_listener_local()
                     .property(move |_subject, prop_key, _type, value| {
                         if prop_key == Some(key) {
-                            let prev = std::mem::replace(
-                                &mut *last_value.borrow_mut(),
-                                Some(value.map(str::to_owned)),
-                            );
+                            let prev = last_value.borrow_mut().replace(value.map(str::to_owned));
                             if let Some(old) = prev {
                                 if old.as_deref() != value {
                                     if value.is_some() {

--- a/src/host/pipewire/stream.rs
+++ b/src/host/pipewire/stream.rs
@@ -2,7 +2,7 @@ use std::{
     cell::{Cell, RefCell},
     rc::Rc,
     sync::{
-        atomic::{AtomicU64, Ordering},
+        atomic::{AtomicBool, AtomicU64, Ordering},
         Arc, Mutex,
     },
     thread::JoinHandle,
@@ -12,6 +12,7 @@ use std::{
 use pipewire::{
     self as pw,
     context::ContextRc,
+    core::Listener as CoreListener,
     main_loop::MainLoopRc,
     metadata::{Metadata, MetadataListener},
     registry::{Listener as RegistryListener, RegistryRc},
@@ -188,15 +189,36 @@ pub struct UserData<D> {
     format: pw::spa::param::audio::AudioInfoRaw,
     last_quantum: Arc<AtomicU64>,
     start: Instant,
+    is_default_device: bool,
+    has_connected: bool,
+    invalidated: Arc<AtomicBool>,
 }
 
 impl<D> UserData<D> {
     fn state_changed(&mut self, new: StreamState) {
-        if let StreamState::Error(e) = new {
-            emit_error(
-                &self.error_callback,
-                Error::with_message(ErrorKind::StreamInvalidated, e),
-            );
+        match new {
+            StreamState::Streaming => self.has_connected = true,
+            StreamState::Unconnected => {
+                // Let the metadata monitor fire for default-device streams
+                if self.has_connected
+                    && !self.is_default_device
+                    && !self.invalidated.swap(true, Ordering::AcqRel)
+                {
+                    emit_error(
+                        &self.error_callback,
+                        Error::with_message(ErrorKind::DeviceNotAvailable, "device disconnected"),
+                    );
+                }
+            }
+            StreamState::Error(e) => {
+                if !self.invalidated.swap(true, Ordering::AcqRel) {
+                    emit_error(
+                        &self.error_callback,
+                        Error::with_message(ErrorKind::StreamInvalidated, e),
+                    );
+                }
+            }
+            StreamState::Paused | StreamState::Connecting => {}
         }
     }
 }
@@ -289,6 +311,7 @@ pub struct StreamData<D> {
     pub stream: StreamRc,
     pub context: ContextRc,
     pub default_monitor: Option<DefaultDeviceMonitor>,
+    pub core_monitor: CoreListener,
 }
 
 /// Fallback timestamp using elapsed time since stream creation.
@@ -338,7 +361,12 @@ pub struct DefaultDeviceMonitor {
 impl DefaultDeviceMonitor {
     /// Subscribe to the `"default"` metadata object and fire `error_callback` with
     /// [`ErrorKind::DeviceChanged`] whenever its key changes.
-    fn new(registry: RegistryRc, key: &'static str, error_callback: ErrorCallback) -> Self {
+    fn new(
+        registry: RegistryRc,
+        key: &'static str,
+        error_callback: ErrorCallback,
+        invalidated: Arc<AtomicBool>,
+    ) -> Self {
         let meta_objects: Rc<RefCell<Option<MetadataObjects>>> = Rc::new(RefCell::new(None));
         let meta_objects_ref = meta_objects.clone();
         let registry_ref = registry.clone();
@@ -361,6 +389,7 @@ impl DefaultDeviceMonitor {
                     Err(_) => return,
                 };
                 let error_callback_cb = error_callback.clone();
+                let invalidated_cb = invalidated.clone();
 
                 // Skip the initial catchup delivery; only fire on actual changes.
                 let seen_first = Cell::new(false);
@@ -371,18 +400,23 @@ impl DefaultDeviceMonitor {
                         // only subsequent ones are real changes worth reporting.
                         if prop_key == Some(key) {
                             if seen_first.get() {
-                                let error = if value.is_some() {
-                                    Error::with_message(
-                                        ErrorKind::DeviceChanged,
-                                        "default device changed",
-                                    )
-                                } else {
-                                    Error::with_message(
-                                        ErrorKind::DeviceNotAvailable,
-                                        "default device removed",
-                                    )
-                                };
-                                emit_error(&error_callback_cb, error);
+                                if value.is_some() {
+                                    emit_error(
+                                        &error_callback_cb,
+                                        Error::with_message(
+                                            ErrorKind::DeviceChanged,
+                                            "default device changed",
+                                        ),
+                                    );
+                                } else if !invalidated_cb.swap(true, Ordering::AcqRel) {
+                                    emit_error(
+                                        &error_callback_cb,
+                                        Error::with_message(
+                                            ErrorKind::DeviceNotAvailable,
+                                            "default device removed",
+                                        ),
+                                    );
+                                }
                             } else {
                                 seen_first.set(true);
                             }
@@ -437,12 +471,32 @@ where
     let core = context.connect_rc(remote_props())?;
 
     let error_callback: ErrorCallback = Arc::new(Mutex::new(Box::new(error_callback)));
+    let invalidated = Arc::new(AtomicBool::new(false));
 
     let default_monitor = default_metadata_key.and_then(|key| {
-        core.get_registry_rc()
-            .ok()
-            .map(|registry| DefaultDeviceMonitor::new(registry, key, error_callback.clone()))
+        core.get_registry_rc().ok().map(|registry| {
+            DefaultDeviceMonitor::new(registry, key, error_callback.clone(), invalidated.clone())
+        })
     });
+    let is_default = default_monitor.is_some();
+
+    let core_monitor = {
+        let invalidated_core = invalidated.clone();
+        let error_callback_core = error_callback.clone();
+        core.add_listener_local()
+            .error(move |id, _seq, _res, message| {
+                if id == pw::core::PW_ID_CORE && !invalidated_core.swap(true, Ordering::AcqRel) {
+                    emit_error(
+                        &error_callback_core,
+                        Error::with_message(
+                            ErrorKind::StreamInvalidated,
+                            format!("PipeWire server error: {message}"),
+                        ),
+                    );
+                }
+            })
+            .register()
+    };
 
     let data = UserData {
         data_callback,
@@ -451,13 +505,16 @@ where
         format: Default::default(),
         last_quantum,
         start,
+        invalidated,
+        is_default_device: is_default,
+        has_connected: false,
     };
     let channels = config.channels as _;
     let rate = config.sample_rate as _;
     let stream = pw::stream::StreamRc::new(core, "cpal-playback", properties)?;
     let listener = stream
         .add_local_listener_with_user_data(data)
-        .param_changed(move|stream, user_data, id, param| {
+        .param_changed(move |stream, user_data, id, param| {
             let Some(param) = param else {
                 return;
             };
@@ -486,20 +543,24 @@ where
                 let mismatch = current_channels != channels
                     || current_rate != rate
                     || current_fmt != expected_fmt;
-                if mismatch {
-                    emit_error(&user_data.error_callback, Error::with_message(
-                        ErrorKind::UnsupportedConfig,
-                        format!("negotiated format mismatch: expected channels={channels} rate={rate} format={expected_fmt:?}, got channels={current_channels} rate={current_rate} format={current_fmt:?}"),
-                    ));
-                    // if the format does not match, we stop the stream
+                if mismatch && !user_data.invalidated.swap(true, Ordering::AcqRel) {
+                    emit_error(
+                        &user_data.error_callback,
+                        Error::with_message(
+                            ErrorKind::UnsupportedConfig,
+                            format!("negotiated format mismatch: expected channels={channels} rate={rate} format={expected_fmt:?}, got channels={current_channels} rate={current_rate} format={current_fmt:?}"),
+                        ),
+                    );
                     if let Err(e) = stream.set_active(false) {
-                        emit_error(&user_data.error_callback, Error::with_message(
-                            ErrorKind::StreamInvalidated,
-                            format!("failed to stop the stream, reason: {e}"),
-                        ));
+                        emit_error(
+                            &user_data.error_callback,
+                            Error::with_message(
+                                ErrorKind::StreamInvalidated,
+                                format!("failed to stop the stream, reason: {e}"),
+                            ),
+                        );
                     }
                 }
-
             }
         })
         .state_changed(|_stream, user_data, _old, new| {
@@ -584,6 +645,7 @@ where
         stream,
         context,
         default_monitor,
+        core_monitor,
     })
 }
 
@@ -610,12 +672,32 @@ where
     let core = context.connect_rc(remote_props())?;
 
     let error_callback: ErrorCallback = Arc::new(Mutex::new(Box::new(error_callback)));
+    let invalidated = Arc::new(AtomicBool::new(false));
 
     let default_monitor = default_metadata_key.and_then(|key| {
-        core.get_registry_rc()
-            .ok()
-            .map(|registry| DefaultDeviceMonitor::new(registry, key, error_callback.clone()))
+        core.get_registry_rc().ok().map(|registry| {
+            DefaultDeviceMonitor::new(registry, key, error_callback.clone(), invalidated.clone())
+        })
     });
+    let is_default = default_monitor.is_some();
+
+    let core_monitor = {
+        let invalidated_core = invalidated.clone();
+        let error_callback_core = error_callback.clone();
+        core.add_listener_local()
+            .error(move |id, _seq, _res, message| {
+                if id == pw::core::PW_ID_CORE && !invalidated_core.swap(true, Ordering::AcqRel) {
+                    emit_error(
+                        &error_callback_core,
+                        Error::with_message(
+                            ErrorKind::StreamInvalidated,
+                            format!("PipeWire server error: {message}"),
+                        ),
+                    );
+                }
+            })
+            .register()
+    };
 
     let data = UserData {
         data_callback,
@@ -624,6 +706,9 @@ where
         format: Default::default(),
         last_quantum,
         start,
+        invalidated,
+        is_default_device: is_default,
+        has_connected: false,
     };
 
     let channels = config.channels as _;
@@ -662,17 +747,22 @@ where
                 let mismatch = current_channels != channels
                     || current_rate != rate
                     || current_fmt != expected_fmt;
-                if mismatch {
-                    emit_error(&user_data.error_callback, Error::with_message(
-                        ErrorKind::UnsupportedConfig,
-                        format!("negotiated format mismatch: expected channels={channels} rate={rate} format={expected_fmt:?}, got channels={current_channels} rate={current_rate} format={current_fmt:?}"),
-                    ));
-                    // if the format does not match, we stop the stream
+                if mismatch
+                    && !user_data.invalidated.swap(true, Ordering::AcqRel)
+                {
+                    emit_error(
+                        &user_data.error_callback,
+                        Error::with_message(
+                            ErrorKind::UnsupportedConfig,
+                            format!("negotiated format mismatch: expected channels={channels} rate={rate} format={expected_fmt:?}, got channels={current_channels} rate={current_rate} format={current_fmt:?}"),
+                        ),
+                    );
                     if let Err(e) = stream.set_active(false) {
                         emit_error(&user_data.error_callback, Error::with_message(
-                            ErrorKind::StreamInvalidated,
-                            format!("failed to stop the stream, reason: {e}"),
-                        ));
+                                ErrorKind::StreamInvalidated,
+                                format!("failed to stop the stream, reason: {e}"),
+                            ),
+                        );
                     }
                 }
             }
@@ -741,5 +831,6 @@ where
         stream,
         context,
         default_monitor,
+        core_monitor,
     })
 }

--- a/src/host/pipewire/utils.rs
+++ b/src/host/pipewire/utils.rs
@@ -23,6 +23,12 @@ pub mod node {
     pub const LATENCY: &str = "node.latency";
 }
 
+pub mod default {
+    pub const NAME: &str = "default";
+    pub const SINK: &str = "default.audio.sink";
+    pub const SOURCE: &str = "default.audio.source";
+}
+
 pub mod audio {
     pub const SINK: &str = "Audio/Sink";
     pub const SOURCE: &str = "Audio/Source";

--- a/src/host/pulseaudio/stream.rs
+++ b/src/host/pulseaudio/stream.rs
@@ -10,7 +10,7 @@ use futures::executor::block_on;
 use pulseaudio::{protocol, AsPlaybackSource};
 
 use crate::{
-    traits::StreamTrait, Data, Error, ErrorKind, FrameCount, InputCallbackInfo,
+    host::emit_error, traits::StreamTrait, Data, Error, ErrorKind, FrameCount, InputCallbackInfo,
     InputStreamTimestamp, OutputCallbackInfo, OutputStreamTimestamp, SampleFormat, StreamInstant,
 };
 
@@ -221,9 +221,7 @@ impl Stream {
         let error_callback_clone = error_callback.clone();
         std::thread::spawn(move || {
             if let Err(e) = block_on(stream_clone.play_all()) {
-                error_callback_clone
-                    .lock()
-                    .unwrap_or_else(|e| e.into_inner())(Error::from(e));
+                emit_error(&error_callback_clone, Error::from(e));
             }
         });
 
@@ -241,7 +239,7 @@ impl Stream {
             let timing_info = match block_on(stream_clone.timing_info()) {
                 Ok(timing_info) => timing_info,
                 Err(e) => {
-                    error_callback.lock().unwrap_or_else(|e| e.into_inner())(Error::from(e));
+                    emit_error(&error_callback, Error::from(e));
                     break;
                 }
             };


### PR DESCRIPTION
Monitor the "default" device metadata and emit `DeviceChanged` when the session manager reroutes.