### PR TITLE
fix(pulseaudio): release server-side stream on Stream::drop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -173,6 +173,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **WASAPI**: Fix callbacks firing before `build_*_stream` returns the `Stream` handle.
 - **WebAudio**: Fix duplicated callbacks on repeated `play()` calls.
 - **WebAudio**: Report errors through the callback instead of panicking.
+- **PulseAudio**: Poisoned locks now exit the thread gracefully instead of panicking.
 
 ## [0.17.3] - 2026-02-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -173,9 +173,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **WASAPI**: Fix callbacks firing before `build_*_stream` returns the `Stream` handle.
 - **WebAudio**: Fix duplicated callbacks on repeated `play()` calls.
 - **WebAudio**: Report errors through the callback instead of panicking.
-- **PulseAudio**: Poisoned locks now exit the thread gracefully instead of panicking.
-- **PulseAudio**: Fix server-side stream leak when a `Stream` is dropped.
-- **PulseAudio**: Remove spurious "PulseAudio client disconnected" warnings during stream cleanup.
 
 ## [0.17.3] - 2026-02-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -174,6 +174,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **WebAudio**: Fix duplicated callbacks on repeated `play()` calls.
 - **WebAudio**: Report errors through the callback instead of panicking.
 - **PulseAudio**: Poisoned locks now exit the thread gracefully instead of panicking.
+- **PulseAudio**: Fix server-side stream leak when a `Stream` is dropped.
 
 ## [0.17.3] - 2026-02-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -175,6 +175,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **WebAudio**: Report errors through the callback instead of panicking.
 - **PulseAudio**: Poisoned locks now exit the thread gracefully instead of panicking.
 - **PulseAudio**: Fix server-side stream leak when a `Stream` is dropped.
+- **PulseAudio**: Remove spurious "PulseAudio client disconnected" warnings during stream cleanup.
 
 ## [0.17.3] - 2026-02-18
 

--- a/src/host/pulseaudio/stream.rs
+++ b/src/host/pulseaudio/stream.rs
@@ -67,7 +67,7 @@ impl Drop for Stream {
                 // Help the play_all driver thread terminate by
                 // queueing a delete, which causes the reactor to drop
                 // the source's eof_tx. We need to do this because
-                // pool_read always reports a non-empty buffer.
+                // poll_read always reports a non-empty buffer.
                 let _ = stream.clone().delete().now_or_never();
             }
             StreamInner::Record(_, _, handle) => {

--- a/src/host/pulseaudio/stream.rs
+++ b/src/host/pulseaudio/stream.rs
@@ -7,6 +7,7 @@ use std::{
 };
 
 use futures::executor::block_on;
+use futures::FutureExt as _;
 use pulseaudio::{protocol, AsPlaybackSource};
 
 use crate::{
@@ -58,8 +59,16 @@ pub struct Stream(StreamInner);
 impl Drop for Stream {
     fn drop(&mut self) {
         match &mut self.0 {
-            StreamInner::Playback(_, _, handle) | StreamInner::Record(_, _, handle) => {
-                handle.cancel()
+            StreamInner::Playback(stream, _, handle) => {
+                handle.cancel();
+                // Help the play_all driver thread terminate by
+                // queueing a delete, which causes the reactor to drop
+                // the source's eof_tx. We need to do this because
+                // pool_read always reports a non-empty buffer.
+                let _ = stream.clone().delete().now_or_never();
+            }
+            StreamInner::Record(_, _, handle) => {
+                handle.cancel();
             }
         }
     }

--- a/src/host/pulseaudio/stream.rs
+++ b/src/host/pulseaudio/stream.rs
@@ -54,11 +54,14 @@ enum StreamInner {
     Record(pulseaudio::RecordStream, Instant, LatencyHandle),
 }
 
-pub struct Stream(StreamInner);
+pub struct Stream {
+    inner: StreamInner,
+    workers: Vec<std::thread::JoinHandle<()>>,
+}
 
 impl Drop for Stream {
     fn drop(&mut self) {
-        match &mut self.0 {
+        match &mut self.inner {
             StreamInner::Playback(stream, _, handle) => {
                 handle.cancel();
                 // Help the play_all driver thread terminate by
@@ -71,12 +74,20 @@ impl Drop for Stream {
                 handle.cancel();
             }
         }
+        for handle in self.workers.drain(..) {
+            // Prevent self-join: a worker thread may surface an error
+            // through the user's error_callback, and that callback may
+            // drop the Stream — in which case we'd be joining ourselves.
+            if handle.thread().id() != std::thread::current().id() {
+                let _ = handle.join();
+            }
+        }
     }
 }
 
 impl StreamTrait for Stream {
     fn play(&self) -> Result<(), Error> {
-        match &self.0 {
+        match &self.inner {
             StreamInner::Playback(stream, _, handle) => {
                 block_on(stream.uncork()).map_err(Error::from)?;
                 handle.notify();
@@ -91,12 +102,12 @@ impl StreamTrait for Stream {
     }
 
     fn pause(&self) -> Result<(), Error> {
-        let res = match &self.0 {
+        let res = match &self.inner {
             StreamInner::Playback(stream, _, _) => block_on(stream.cork()),
             StreamInner::Record(stream, _, _) => block_on(stream.cork()),
         };
         res.map_err(Error::from)?;
-        match &self.0 {
+        match &self.inner {
             StreamInner::Playback(_, _, handle) | StreamInner::Record(_, _, handle) => {
                 handle.notify()
             }
@@ -105,7 +116,7 @@ impl StreamTrait for Stream {
     }
 
     fn now(&self) -> StreamInstant {
-        let start = match &self.0 {
+        let start = match &self.inner {
             StreamInner::Playback(_, start, _) | StreamInner::Record(_, start, _) => *start,
         };
         let elapsed = start.elapsed();
@@ -113,7 +124,7 @@ impl StreamTrait for Stream {
     }
 
     fn buffer_size(&self) -> Result<FrameCount, Error> {
-        let (spec, bytes) = match &self.0 {
+        let (spec, bytes) = match &self.inner {
             StreamInner::Playback(s, _, _) => (
                 s.sample_spec(),
                 s.buffer_attr().minimum_request_length as usize,
@@ -236,7 +247,7 @@ impl Stream {
         let ready = std::sync::Arc::new(std::sync::Barrier::new(3));
 
         let ready_worker = ready.clone();
-        std::thread::spawn(move || {
+        let driver_handle = std::thread::spawn(move || {
             ready_worker.wait();
             if let Err(e) = block_on(stream_clone.play_all()) {
                 emit_error(&error_callback_clone, Error::from(e));
@@ -250,7 +261,7 @@ impl Stream {
         let poll_clone = last_poll_micros.clone();
 
         let ready_latency = ready.clone();
-        std::thread::spawn(move || {
+        let latency_handle = std::thread::spawn(move || {
             ready_latency.wait();
             loop {
                 if cancel_thread.load(atomic::Ordering::Relaxed) {
@@ -288,7 +299,10 @@ impl Stream {
         });
 
         ready.wait();
-        Ok(Self(StreamInner::Playback(stream, start, handle)))
+        Ok(Self {
+            inner: StreamInner::Playback(stream, start, handle),
+            workers: vec![driver_handle, latency_handle],
+        })
     }
 
     pub fn new_record<D, E>(
@@ -375,7 +389,7 @@ impl Stream {
         let stream_clone = stream.clone();
         let latency_clone = current_latency_micros.clone();
         let poll_clone = last_poll_micros.clone();
-        std::thread::spawn(move || loop {
+        let latency_handle = std::thread::spawn(move || loop {
             if cancel_thread.load(atomic::Ordering::Relaxed) {
                 break;
             }
@@ -409,7 +423,10 @@ impl Stream {
             *guard = false;
         });
 
-        Ok(Self(StreamInner::Record(stream, start, handle)))
+        Ok(Self {
+            inner: StreamInner::Record(stream, start, handle),
+            workers: vec![latency_handle],
+        })
     }
 }
 

--- a/src/host/pulseaudio/stream.rs
+++ b/src/host/pulseaudio/stream.rs
@@ -241,6 +241,7 @@ impl Stream {
         // when the stream is stopped by the user.
         let stream_clone = stream.clone();
         let error_callback_clone = error_callback.clone();
+        let cancel_driver = handle.cancel.clone();
 
         // The barrier prevents the worker and latency threads from firing callbacks before the
         // caller has received the Stream handle.
@@ -250,7 +251,12 @@ impl Stream {
         let driver_handle = std::thread::spawn(move || {
             ready_worker.wait();
             if let Err(e) = block_on(stream_clone.play_all()) {
-                emit_error(&error_callback_clone, Error::from(e));
+                // A server playback error is expected when the client
+                // closes their stream. No need to report it back to
+                // the client.
+                if !cancel_driver.load(atomic::Ordering::Relaxed) {
+                    emit_error(&error_callback_clone, Error::from(e));
+                }
             }
         });
 


### PR DESCRIPTION
The PulseAudio backend spawns a driver thread that calls `pulseaudio::PlaybackStream::play_all`, which awaits source EOF before draining and exiting. EOF for a `PlaybackSource` is signalled by `poll_read` returning `0`, but the data-callback wrapper used by `new_playback` always reports the full buffer length to satisfy cpal's no-short-write contract. The driver thread therefore parks in `source_eof` for the lifetime of the process.

Because that thread holds a `PlaybackStream` clone (an `Arc<InnerPlaybackStream>`), the inner Arc count never drops to zero, `InnerPlaybackStream::drop` never fires, and the `DeletePlaybackStream` command it would otherwise queue is never sent. Each `Stream` created and dropped by the user thus leaks one server-side stream and one OS thread; long-running clients accumulate `pactl list short sink-inputs` entries until PulseAudio runs out of channels.

Queue a `DeletePlaybackStream` from `Stream::drop` so the reactor removes the stream state, drops the source's `eof_tx` channel, and wakes the driver thread with a cancellation error. `now_or_never` mirrors `InnerPlaybackStream::drop` and avoids blocking in `Drop`.

Fixes #1188.