### PR TITLE
refactor: classify ErrorKind::Other

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - Replaced `StreamInstant::add()` and `sub()` by `checked_add()`/`+` and `checked_sub()`/`-`.
+- Removed deprecated `DeviceTrait::name()`.
 - **Emscripten**: Removed broken host; use the WebAudio host instead.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `ErrorKind::BackendError` for platform audio API errors that don't map to a specific kind.
 - `ErrorKind::DeviceBusy` for retryable device access errors (e.g. EBUSY, EAGAIN).
 - `ErrorKind::DeviceChanged` signals that the audio route changed to another device.
+- `ErrorKind::InvalidInput` for invalid arguments and caller-supplied values.
 - `ErrorKind::PermissionDenied` for OS-level access denials.
+- `ErrorKind::RealtimeDenied` for when real-time scheduling is requested but not granted;
+  previously such failures were only printed to stderr and discarded.
+- `ErrorKind::ResourceExhausted` for OS resource limits such as thread or memory exhaustion.
+- `ErrorKind::UnsupportedOperation` for operations the backend or device does not implement.
 - `StreamConfig` now implements `Copy`.
 - `StreamTrait::buffer_size()` to query the stream's current buffer size in frames per callback.
 - `HostTrait::device_by_id()` is now dispatched to each backend's implementation, allowing
@@ -41,7 +47,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   See [UPGRADING.md](UPGRADING.md) for migration details.
 - `audio_thread_priority` feature renamed to `realtime-dbus` and enabled by default.
 - `audio_thread_priority` dependency bumped to 0.35.
-- `ErrorKind::ThreadPriorityUnavailable` renamed to `ErrorKind::RealtimeDenied`.
 - **AAudio**: Device names now include the device type suffix (e.g. "Speaker (Builtin Speaker)")
   for easier identification when enumerating devices.
 - **AAudio**: `supported_input_configs()` and `supported_output_configs()` now return an error for

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -56,15 +56,19 @@ The `ErrorKind` variants and their equivalents from v0.17:
 
 | `ErrorKind`            | Former equivalent                                    |
 |------------------------|------------------------------------------------------|
-| `HostUnavailable`      | `HostUnavailable` (struct)                           |
-| `DeviceNotAvailable`   | `DeviceNotAvailable` in most enums                   |
 | `DeviceBusy`           | - (new; previously mapped to `DeviceNotAvailable`)   |
+| `DeviceChanged`        | - (new)                                              |
+| `DeviceNotAvailable`   | `DeviceNotAvailable` in most enums                   |
+| `HostUnavailable`      | `HostUnavailable` (struct)                           |
+| `InvalidInput`         | - (new)                                              |
+| `PermissionDenied`     | - (new)                                              |
+| `RealtimeDenied`       | - (new; previously only printed to stderr)           |
+| `ResourceExhausted`    | - (new)                                              |
+| `StreamInvalidated`    | `StreamError::StreamInvalidated`                     |
 | `UnsupportedConfig`    | `StreamConfigNotSupported`, `StreamTypeNotSupported` |
 | `UnsupportedOperation` | - (new)                                              |
-| `InvalidInput`         | - (new)                                              |
-| `StreamInvalidated`    | `StreamError::StreamInvalidated`                     |
 | `Xrun`                 | `StreamError::BufferUnderrun`                        |
-| `PermissionDenied`     | - (new)                                              |
+| `BackendError`         | - (new; previously folded into `BackendSpecific`)    |
 | `Other`                | `BackendSpecific`                                    |
 
 The `message()` getter on `Error` returns human-readable context (formerly in

--- a/examples/custom.rs
+++ b/examples/custom.rs
@@ -66,10 +66,6 @@ impl DeviceTrait for MyDevice {
     type SupportedOutputConfigs = std::iter::Once<SupportedStreamConfigRange>;
     type Stream = MyStream;
 
-    fn name(&self) -> Result<String, Error> {
-        Ok(String::from("custom"))
-    }
-
     fn description(&self) -> Result<DeviceDescription, Error> {
         Ok(DeviceDescriptionBuilder::new("Custom Device").build())
     }

--- a/examples/ios-feedback/src/feedback.rs
+++ b/examples/ios-feedback/src/feedback.rs
@@ -31,8 +31,8 @@ pub fn run_example() -> Result<(), anyhow::Error> {
     let output_device = host
         .default_output_device()
         .expect("failed to get default output device");
-    println!("Using default input device: \"{}\"", input_device.name()?);
-    println!("Using default output device: \"{}\"", output_device.name()?);
+    println!("Using default input device: \"{}\"", input_device.description()?.name());
+    println!("Using default output device: \"{}\"", output_device.description()?.name());
 
     // We'll try and use the same configuration between streams to keep it simple.
     let config: StreamConfig = input_device.default_input_config()?.into();

--- a/src/error.rs
+++ b/src/error.rs
@@ -45,6 +45,13 @@ pub enum ErrorKind {
     /// [`DeviceNotAvailable`]: ErrorKind::DeviceNotAvailable
     PermissionDenied,
 
+    /// Real-time scheduling was requested for the audio callback thread but was not granted.
+    /// Audio will still play, but may be subject to increased latency or glitches under load.
+    RealtimeDenied,
+
+    /// An OS resource limit was reached, such as a system or process thread or memory limit.
+    ResourceExhausted,
+
     /// The stream configuration is no longer valid and must be rebuilt.
     StreamInvalidated,
 
@@ -60,9 +67,9 @@ pub enum ErrorKind {
     /// A buffer underrun or overrun occurred, causing a potential audio glitch.
     Xrun,
 
-    /// Real-time scheduling was requested for the audio callback thread but was not granted.
-    /// Audio will still play, but may be subject to increased latency or glitches under load.
-    RealtimeDenied,
+    /// The underlying platform audio API returned an error that CPAL cannot map to a more
+    /// specific error kind.
+    BackendError,
 
     /// A catch-all for errors that do not fall under any other CPAL error kind.
     ///
@@ -77,8 +84,8 @@ pub enum ErrorKind {
 impl Display for ErrorKind {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::HostUnavailable => f.write_str(
-                "The requested audio host is not available. The subsystem or daemon may not be installed or running.",
+            Self::DeviceBusy => f.write_str(
+                "The requested device is temporarily busy. Another application or stream may be using it.",
             ),
             Self::DeviceChanged => f.write_str(
                 "The audio route changed. The stream was automatically rerouted to a different device.",
@@ -86,24 +93,30 @@ impl Display for ErrorKind {
             Self::DeviceNotAvailable => f.write_str(
                 "The requested audio device is not available. It may have been disconnected.",
             ),
-            Self::DeviceBusy => f.write_str(
-                "The requested device is temporarily busy. Another application or stream may be using it.",
+            Self::HostUnavailable => f.write_str(
+                "The requested audio host is not available. The subsystem or daemon may not be installed or running.",
             ),
-            Self::UnsupportedConfig => f.write_str(
-                "The requested stream configuration is not supported by the device.",
-            ),
-            Self::UnsupportedOperation => f.write_str("The requested operation is not supported."),
             Self::InvalidInput => f.write_str("Invalid input or argument."),
-            Self::StreamInvalidated => {
-                f.write_str("The stream configuration is no longer valid and must be rebuilt.")
-            }
-            Self::Xrun => f.write_str("A buffer underrun or overrun occurred."),
             Self::PermissionDenied => f.write_str(
                 "Permission denied. Grant the required access and retry.",
             ),
             Self::RealtimeDenied => f.write_str(
                 "Real-time scheduling was requested but not granted for the audio thread. \
                  Audio may be subject to increased latency or glitches under load.",
+            ),
+            Self::ResourceExhausted => f.write_str(
+                "An OS resource limit was reached. Freeing resources and retrying may succeed.",
+            ),
+            Self::StreamInvalidated => {
+                f.write_str("The stream configuration is no longer valid and must be rebuilt.")
+            }
+            Self::UnsupportedConfig => f.write_str(
+                "The requested stream configuration is not supported by the device.",
+            ),
+            Self::UnsupportedOperation => f.write_str("The requested operation is not supported."),
+            Self::Xrun => f.write_str("A buffer underrun or overrun occurred."),
+            Self::BackendError => f.write_str(
+                "The audio backend returned an unclassified error.",
             ),
             Self::Other => f.write_str("An error occurred."),
         }

--- a/src/host/aaudio/convert.rs
+++ b/src/host/aaudio/convert.rs
@@ -62,7 +62,10 @@ impl From<ndk::audio::AudioError> for Error {
             Disconnected | Unavailable | NoService | InvalidHandle => {
                 Error::with_message(ErrorKind::DeviceNotAvailable, error.to_string())
             }
-            NoFreeHandles | NoMemory | WouldBlock | Timeout => {
+            NoFreeHandles | NoMemory => {
+                Error::with_message(ErrorKind::ResourceExhausted, error.to_string())
+            }
+            WouldBlock | Timeout => {
                 Error::with_message(ErrorKind::DeviceBusy, error.to_string())
             }
             InvalidFormat | InvalidRate => {
@@ -77,7 +80,7 @@ impl From<ndk::audio::AudioError> for Error {
             Unimplemented => {
                 Error::with_message(ErrorKind::UnsupportedOperation, error.to_string())
             }
-            _ => Error::with_message(ErrorKind::Other, error.to_string()),
+            _ => Error::with_message(ErrorKind::BackendError, error.to_string()),
         }
     }
 }

--- a/src/host/aaudio/convert.rs
+++ b/src/host/aaudio/convert.rs
@@ -65,9 +65,7 @@ impl From<ndk::audio::AudioError> for Error {
             NoFreeHandles | NoMemory => {
                 Error::with_message(ErrorKind::ResourceExhausted, error.to_string())
             }
-            WouldBlock | Timeout => {
-                Error::with_message(ErrorKind::DeviceBusy, error.to_string())
-            }
+            WouldBlock | Timeout => Error::with_message(ErrorKind::DeviceBusy, error.to_string()),
             InvalidFormat | InvalidRate => {
                 Error::with_message(ErrorKind::UnsupportedConfig, error.to_string())
             }

--- a/src/host/aaudio/mod.rs
+++ b/src/host/aaudio/mod.rs
@@ -532,23 +532,6 @@ impl DeviceTrait for Device {
     type SupportedOutputConfigs = SupportedOutputConfigs;
     type Stream = Stream;
 
-    fn name(&self) -> Result<String, Error> {
-        match &self.0 {
-            None => Ok("default".to_string()),
-            Some(info) => {
-                let name = if info.address.is_empty() {
-                    format!("{}:{:?}", info.product_name, info.device_type)
-                } else {
-                    format!(
-                        "{}:{:?}:{}",
-                        info.product_name, info.device_type, info.address
-                    )
-                };
-                Ok(name)
-            }
-        }
-    }
-
     fn description(&self) -> Result<DeviceDescription, Error> {
         match &self.0 {
             None => Ok(DeviceDescriptionBuilder::new("Default Device".to_string()).build()),

--- a/src/host/alsa/mod.rs
+++ b/src/host/alsa/mod.rs
@@ -173,11 +173,6 @@ impl DeviceTrait for Device {
     type SupportedOutputConfigs = SupportedOutputConfigs;
     type Stream = Stream;
 
-    // ALSA overrides name() to return pcm_id directly instead of from description
-    fn name(&self) -> Result<String, Error> {
-        Self::name(self)
-    }
-
     fn description(&self) -> Result<DeviceDescription, Error> {
         Self::description(self)
     }
@@ -446,10 +441,6 @@ impl Device {
         };
 
         Ok(stream_inner)
-    }
-
-    fn name(&self) -> Result<String, Error> {
-        Ok(self.pcm_id.clone())
     }
 
     fn description(&self) -> Result<DeviceDescription, Error> {

--- a/src/host/alsa/mod.rs
+++ b/src/host/alsa/mod.rs
@@ -1622,7 +1622,7 @@ impl From<alsa::Error> for Error {
             libc::EINVAL => Error::with_message(ErrorKind::InvalidInput, err.to_string()),
             libc::EPIPE => Error::with_message(ErrorKind::Xrun, err.to_string()),
             libc::ENOSYS => Error::with_message(ErrorKind::UnsupportedOperation, err.to_string()),
-            _ => Error::with_message(ErrorKind::Other, err.to_string()),
+            _ => Error::with_message(ErrorKind::BackendError, err.to_string()),
         }
     }
 }

--- a/src/host/asio/stream.rs
+++ b/src/host/asio/stream.rs
@@ -1124,7 +1124,7 @@ fn build_stream_err(e: sys::AsioError) -> Error {
             Error::with_message(ErrorKind::UnsupportedConfig, e.to_string())
         }
         sys::AsioError::HardwareStuck => Error::with_message(ErrorKind::DeviceBusy, e.to_string()),
-        err => Error::with_message(ErrorKind::Other, err.to_string()),
+        err => Error::with_message(ErrorKind::BackendError, err.to_string()),
     }
 }
 

--- a/src/host/coreaudio/macos/device.rs
+++ b/src/host/coreaudio/macos/device.rs
@@ -725,7 +725,7 @@ impl fmt::Debug for Device {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("Device")
             .field("audio_device_id", &self.audio_device_id)
-            .field("name", &self.name())
+            .field("name", &self.description().map(|d| d.name().to_owned()))
             .finish()
     }
 }

--- a/src/host/coreaudio/macos/mod.rs
+++ b/src/host/coreaudio/macos/mod.rs
@@ -362,7 +362,7 @@ mod test {
     fn test_record() {
         let host = default_host();
         let device = host.default_input_device().unwrap();
-        println!("Device: {:?}", device.name());
+        println!("Device: {:?}", device.description());
 
         let mut supported_configs_range = device.supported_input_configs().unwrap();
         println!("Supported configs:");

--- a/src/host/coreaudio/mod.rs
+++ b/src/host/coreaudio/mod.rs
@@ -131,7 +131,7 @@ impl From<coreaudio::Error> for Error {
                 Error::with_message(ErrorKind::UnsupportedOperation, msg)
             }
 
-            _ => Error::with_message(ErrorKind::Other, msg),
+            _ => Error::with_message(ErrorKind::BackendError, msg),
         }
     }
 }

--- a/src/host/custom/mod.rs
+++ b/src/host/custom/mod.rs
@@ -145,7 +145,6 @@ type InputCallback = Box<dyn FnMut(&Data, &InputCallbackInfo) + Send + 'static>;
 type OutputCallback = Box<dyn FnMut(&mut Data, &OutputCallbackInfo) + Send + 'static>;
 
 trait DeviceErased: Send + Sync {
-    fn name(&self) -> Result<String, Error>;
     fn description(&self) -> Result<DeviceDescription, Error>;
     fn id(&self) -> Result<DeviceId, Error>;
     fn supports_input(&self) -> bool;
@@ -223,11 +222,6 @@ where
     T::SupportedOutputConfigs: Clone + 'static,
     T::Stream: Send + Sync + 'static,
 {
-    #[allow(deprecated)]
-    fn name(&self) -> Result<String, Error> {
-        <T as DeviceTrait>::name(self)
-    }
-
     fn description(&self) -> Result<DeviceDescription, Error> {
         <T as DeviceTrait>::description(self)
     }
@@ -353,10 +347,6 @@ impl DeviceTrait for Device {
     type SupportedOutputConfigs = SupportedConfigs;
 
     type Stream = Stream;
-
-    fn name(&self) -> Result<String, Error> {
-        self.0.name()
-    }
 
     fn description(&self) -> Result<DeviceDescription, Error> {
         self.0.description()

--- a/src/host/jack/mod.rs
+++ b/src/host/jack/mod.rs
@@ -187,7 +187,7 @@ impl From<jack::Error> for Error {
                 Error::with_message(ErrorKind::InvalidInput, msg)
             }
 
-            _ => Error::with_message(ErrorKind::Other, msg),
+            _ => Error::with_message(ErrorKind::BackendError, msg),
         }
     }
 }

--- a/src/host/pipewire/device.rs
+++ b/src/host/pipewire/device.rs
@@ -385,7 +385,7 @@ impl DeviceTrait for Device {
                                 emit_error(
                                     &error_callback,
                                     Error::with_message(
-                                        ErrorKind::Other,
+                                        ErrorKind::BackendError,
                                         format!("PipeWire: could not acquire registry; device change notifications will be unavailable: {e}"),
                                     ),
                                 );
@@ -443,7 +443,7 @@ impl DeviceTrait for Device {
                 drop(context);
             })
             .map_err(|e| {
-                Error::with_message(ErrorKind::Other, format!("failed to create thread: {e}"))
+                Error::with_message(ErrorKind::ResourceExhausted, format!("failed to create thread: {e}"))
             })?;
         match pw_init_rx.recv_timeout(wait_timeout) {
             Ok(true) => {
@@ -548,7 +548,7 @@ impl DeviceTrait for Device {
                                 emit_error(
                                     &error_callback,
                                     Error::with_message(
-                                        ErrorKind::Other,
+                                        ErrorKind::BackendError,
                                         format!("PipeWire: could not acquire registry; device change notifications will be unavailable: {e}"),
                                     ),
                                 );
@@ -606,7 +606,7 @@ impl DeviceTrait for Device {
                 drop(context);
             })
             .map_err(|e| {
-                Error::with_message(ErrorKind::Other, format!("failed to create thread: {e}"))
+                Error::with_message(ErrorKind::ResourceExhausted, format!("failed to create thread: {e}"))
             })?;
         match pw_init_rx.recv_timeout(wait_timeout) {
             Ok(true) => {

--- a/src/host/pipewire/stream.rs
+++ b/src/host/pipewire/stream.rs
@@ -403,7 +403,7 @@ impl DefaultDeviceMonitor {
                         emit_error(
                             &error_callback,
                             Error::with_message(
-                                ErrorKind::Other,
+                                ErrorKind::BackendError,
                                 format!("PipeWire: failed to bind metadata object; device change notifications may be incomplete: {e}"),
                             ),
                         );

--- a/src/host/pulseaudio/mod.rs
+++ b/src/host/pulseaudio/mod.rs
@@ -256,15 +256,6 @@ impl DeviceTrait for Device {
     type SupportedOutputConfigs = std::vec::IntoIter<SupportedStreamConfigRange>;
     type Stream = Stream;
 
-    fn name(&self) -> Result<String, Error> {
-        let name = match self {
-            Device::Sink { info, .. } => &info.name,
-            Device::Source { info, .. } => &info.name,
-        };
-
-        Ok(String::from_utf8_lossy(name.as_bytes()).into_owned())
-    }
-
     fn supported_input_configs(&self) -> Result<Self::SupportedInputConfigs, Error> {
         let Device::Source { .. } = self else {
             return Ok(vec![].into_iter());

--- a/src/host/pulseaudio/mod.rs
+++ b/src/host/pulseaudio/mod.rs
@@ -87,7 +87,7 @@ impl From<pulseaudio::ClientError> for Error {
                     ErrorKind::StreamInvalidated
                 }
                 NoData => ErrorKind::Xrun,
-                _ => ErrorKind::Other,
+                _ => ErrorKind::BackendError,
             }
         }
 

--- a/src/host/wasapi/device.rs
+++ b/src/host/wasapi/device.rs
@@ -497,7 +497,7 @@ impl Device {
                 Ok(pwstr) => match pwstr.to_string() {
                     Ok(id_str) => Ok(DeviceId(crate::platform::HostId::Wasapi, id_str)),
                     Err(e) => Err(Error::with_message(
-                        ErrorKind::Other,
+                        ErrorKind::BackendError,
                         format!("failed to convert device ID to string: {e}"),
                     )),
                 },

--- a/src/host/wasapi/mod.rs
+++ b/src/host/wasapi/mod.rs
@@ -79,7 +79,7 @@ impl From<windows::core::Error> for Error {
             | Audio::AUDCLNT_E_NOT_INITIALIZED
             | Audio::AUDCLNT_E_NOT_STOPPED => ErrorKind::UnsupportedOperation,
 
-            _ => ErrorKind::Other,
+            _ => ErrorKind::BackendError,
         };
         Error::with_message(kind, IoError::from(e).to_string())
     }

--- a/src/host/wasapi/stream.rs
+++ b/src/host/wasapi/stream.rs
@@ -354,7 +354,10 @@ impl Stream {
                 run_input(run_context, &mut data_callback, &error_callback)
             })
             .map_err(|e| {
-                Error::with_message(ErrorKind::ResourceExhausted, format!("failed to create thread: {e}"))
+                Error::with_message(
+                    ErrorKind::ResourceExhausted,
+                    format!("failed to create thread: {e}"),
+                )
             })?;
 
         let stream = Stream {
@@ -422,7 +425,10 @@ impl Stream {
                 run_output(run_context, &mut data_callback, &error_callback)
             })
             .map_err(|e| {
-                Error::with_message(ErrorKind::ResourceExhausted, format!("failed to create thread: {e}"))
+                Error::with_message(
+                    ErrorKind::ResourceExhausted,
+                    format!("failed to create thread: {e}"),
+                )
             })?;
 
         let stream = Stream {

--- a/src/host/wasapi/stream.rs
+++ b/src/host/wasapi/stream.rs
@@ -354,7 +354,7 @@ impl Stream {
                 run_input(run_context, &mut data_callback, &error_callback)
             })
             .map_err(|e| {
-                Error::with_message(ErrorKind::Other, format!("failed to create thread: {e}"))
+                Error::with_message(ErrorKind::ResourceExhausted, format!("failed to create thread: {e}"))
             })?;
 
         let stream = Stream {
@@ -422,7 +422,7 @@ impl Stream {
                 run_output(run_context, &mut data_callback, &error_callback)
             })
             .map_err(|e| {
-                Error::with_message(ErrorKind::Other, format!("failed to create thread: {e}"))
+                Error::with_message(ErrorKind::ResourceExhausted, format!("failed to create thread: {e}"))
             })?;
 
         let stream = Stream {

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -714,10 +714,10 @@ macro_rules! impl_platform_host {
         ///
         /// - [`ErrorKind::HostUnavailable`] if the host identified by `id` is not currently
         ///   reachable (e.g. the audio daemon is not running).
-        /// - [`ErrorKind::Other`] for unclassifiable initialization failures.
+        /// - [`ErrorKind::BackendError`] for unclassifiable initialization failures.
         ///
         /// [`ErrorKind::HostUnavailable`]: crate::ErrorKind::HostUnavailable
-        /// [`ErrorKind::Other`]: crate::ErrorKind::Other
+        /// [`ErrorKind::BackendError`]: crate::ErrorKind::BackendError
         pub fn host_from_id(id: HostId) -> Result<Host, crate::Error> {
             match id {
                 $(

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -390,16 +390,6 @@ macro_rules! impl_platform_host {
             type SupportedOutputConfigs = SupportedOutputConfigs;
             type Stream = Stream;
 
-            #[allow(deprecated)]
-            fn name(&self) -> Result<String, crate::Error> {
-                match self.0 {
-                    $(
-                        $(#[cfg($feat)])?
-                        DeviceInner::$HostVariant(ref d) => d.name(),
-                    )*
-                }
-            }
-
             fn description(&self) -> Result<crate::DeviceDescription, crate::Error> {
                 match self.0 {
                     $(

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -51,10 +51,10 @@ pub trait HostTrait {
     ///
     /// - [`ErrorKind::HostUnavailable`] if the host has become unreachable (e.g. the audio
     ///   daemon crashed or was stopped).
-    /// - [`ErrorKind::Other`] for unclassifiable backend failures.
+    /// - [`ErrorKind::BackendError`] for unclassifiable backend failures.
     ///
     /// [`ErrorKind::HostUnavailable`]: crate::ErrorKind::HostUnavailable
-    /// [`ErrorKind::Other`]: crate::ErrorKind::Other
+    /// [`ErrorKind::BackendError`]: crate::ErrorKind::BackendError
     fn devices(&self) -> Result<Self::Devices, Error>;
 
     /// Fetches a [`Device`](DeviceTrait) based on a [`DeviceId`] if available
@@ -449,7 +449,7 @@ pub trait StreamTrait {
     /// # Errors
     ///
     /// - [`ErrorKind::UnsupportedOperation`] if the backend cannot query the buffer size.
-    /// - [`ErrorKind::Other`] for unclassifiable backend failures.
+    /// - [`ErrorKind::BackendError`] for unclassifiable backend failures.
     ///
     /// # Implementation notes
     ///
@@ -461,7 +461,7 @@ pub trait StreamTrait {
     /// lead to memory safety violations.
     ///
     /// [`ErrorKind::UnsupportedOperation`]: crate::ErrorKind::UnsupportedOperation
-    /// [`ErrorKind::Other`]: crate::ErrorKind::Other
+    /// [`ErrorKind::BackendError`]: crate::ErrorKind::BackendError
     fn buffer_size(&self) -> Result<crate::FrameCount, Error>;
 
     /// Returns a [`StreamInstant`] representing the current moment on the stream's clock.

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -116,17 +116,6 @@ pub trait DeviceTrait {
     /// [`build_output_stream_raw`]: Self::build_output_stream_raw
     type Stream: StreamTrait;
 
-    /// The human-readable name of the device.
-    #[deprecated(
-        since = "0.17.0",
-        note = "Use `description()` for comprehensive device information including name, \
-                manufacturer, and device type. Use `id()` for a unique, stable device identifier \
-                that persists across reboots and reconnections."
-    )]
-    fn name(&self) -> Result<String, Error> {
-        self.description().map(|desc| desc.name().to_string())
-    }
-
     /// Structured description of the device with metadata.
     ///
     /// This returns a [`DeviceDescription`] containing structured information about the device,


### PR DESCRIPTION
Reclassify remaining `ErrorKind::Other` into new `ResourceExhausted` and `BackendSpecific` where it makes sense.