### PR TITLE
feat: implement PartialEq, Eq, Hash, Debug, Display on Device

### DIFF
--- a/.github/workflows/platforms.yml
+++ b/.github/workflows/platforms.yml
@@ -614,7 +614,7 @@ jobs:
 
   docs-asio-sys:
     if: github.event_name == 'release' && startsWith(github.ref, 'refs/tags/asio-sys-v')
-    name: docs (asio-sys)
+    name: docs-asio-sys
     runs-on: ubuntu-latest
     env:
       DOCS_RS: "1"

--- a/.github/workflows/platforms.yml
+++ b/.github/workflows/platforms.yml
@@ -586,7 +586,6 @@ jobs:
             target: wasm32-unknown-unknown
           - name: Android
             target: aarch64-linux-android
-    name: docs-${{ matrix.name }}
     runs-on: ubuntu-latest
     env:
       DOCS_RS: "1"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `Device` now implements `PartialEq`, `Eq`, `Hash`, `Display`, and `Debug`.
 - `ErrorKind::BackendError` for platform audio API errors that don't map to a specific kind.
 - `ErrorKind::DeviceBusy` for retryable device access errors (e.g. EBUSY, EAGAIN).
 - `ErrorKind::DeviceChanged` signals that the audio route changed to another device.
@@ -31,10 +32,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `CODE_OF_CONDUCT.md`, `CONTRIBUTING.md` and `SECURITY.md`.
 - **AAudio**: Streams now request `PERFORMANCE_MODE_LOW_LATENCY` when the `realtime` feature is
   enabled; stream error callback receives `ErrorKind::RealtimeDenied` if not granted.
+- **AAudio**: `Device` now implements `PartialEq`, `Eq`, `Hash`, and `Debug`.
 - **ALSA**: `device_by_id()` now accepts PCM shorthand names such as `hw:0,0` and `plughw:foo`.
+- **ASIO**: `Device` now implements `Debug`.
 - **CoreAudio**: tvOS target support (Tier 3, requires nightly).
+- **CoreAudio**: `Device` now implements `PartialEq`, `Eq`, and `Hash`.
+- **JACK**: `Device` now implements `PartialEq`, `Eq`, and `Hash`.
 - **PipeWire**: New host for Linux and some BSDs using the PipeWire API.
 - **PulseAudio**: New host for Linux and some BSDs using the PulseAudio API.
+- **WASAPI**: `Device` now implements `PartialEq`, `Eq`, `Hash`, and `Debug`.
 
 ### Changed
 
@@ -48,6 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   See [UPGRADING.md](UPGRADING.md) for migration details.
 - `audio_thread_priority` feature renamed to `realtime-dbus` and enabled by default.
 - `audio_thread_priority` dependency bumped to 0.35.
+- `DeviceTrait` now requires `PartialEq + Eq + Hash + Debug + Display` with a stable device ID.
 - **AAudio**: Device names now include the device type suffix (e.g. "Speaker (Builtin Speaker)")
   for easier identification when enumerating devices.
 - **AAudio**: `supported_input_configs()` and `supported_output_configs()` now return an error for

--- a/examples/custom.rs
+++ b/examples/custom.rs
@@ -1,4 +1,5 @@
 use std::{
+    fmt,
     sync::{
         atomic::{AtomicBool, Ordering},
         Arc,
@@ -18,10 +19,10 @@ use cpal::{
 #[derive(Clone)] // Clone, Send+Sync are required
 struct MyHost;
 
-#[derive(Clone)] // Clone, Send+Sync are required
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 struct MyDevice;
 
-// Only Send+Sync is needed
+// Needs to be Send+Sync
 struct MyStream {
     controls: Arc<StreamControls>,
     // The instant the audio thread was started; shared with now() so that
@@ -182,6 +183,13 @@ impl DeviceTrait for MyDevice {
             start,
             handle: Some(handle),
         })
+    }
+}
+
+impl fmt::Display for MyDevice {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let desc = self.description().map_err(|_| fmt::Error)?;
+        f.write_str(desc.name())
     }
 }
 

--- a/src/host/aaudio/mod.rs
+++ b/src/host/aaudio/mod.rs
@@ -5,6 +5,8 @@
 use std::{
     cmp,
     convert::TryInto,
+    fmt,
+    hash::{Hash, Hasher},
     sync::{
         atomic::{AtomicI32, Ordering},
         Arc, Mutex,
@@ -120,7 +122,7 @@ const SAMPLE_RATES: [i32; 15] = [
 const DEFAULT_TIMEOUT_NANOS: i64 = 2_000_000_000;
 
 pub struct Host;
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Device(Option<AudioDeviceInfo>);
 
 /// Stream wraps AudioStream in Arc<Mutex<>> to provide Send + Sync semantics.
@@ -716,6 +718,31 @@ impl DeviceTrait for Device {
             builder,
             sample_format,
         )
+    }
+}
+
+impl PartialEq for Device {
+    fn eq(&self, other: &Self) -> bool {
+        match (&self.0, &other.0) {
+            (None, None) => true,
+            (Some(a), Some(b)) => a.id == b.id,
+            _ => false,
+        }
+    }
+}
+
+impl Eq for Device {}
+
+impl fmt::Display for Device {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let desc = self.description().map_err(|_| fmt::Error)?;
+        f.write_str(desc.name())
+    }
+}
+
+impl Hash for Device {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.0.as_ref().map(|i| i.id).hash(state);
     }
 }
 

--- a/src/host/alsa/mod.rs
+++ b/src/host/alsa/mod.rs
@@ -8,7 +8,7 @@ extern crate alsa_sys;
 extern crate libc;
 
 use std::{
-    cmp,
+    cmp, fmt,
     sync::{
         atomic::{AtomicBool, Ordering},
         Arc, Mutex,
@@ -342,20 +342,6 @@ pub struct Device {
     _context: Arc<AlsaContext>,
 }
 
-impl PartialEq for Device {
-    fn eq(&self, other: &Self) -> bool {
-        self.pcm_id == other.pcm_id
-    }
-}
-
-impl Eq for Device {}
-
-impl std::hash::Hash for Device {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.pcm_id.hash(state);
-    }
-}
-
 impl Device {
     fn build_stream_inner(
         &self,
@@ -658,6 +644,27 @@ impl Device {
 
     fn default_output_config(&self) -> Result<SupportedStreamConfig, Error> {
         self.default_config(alsa::Direction::Playback)
+    }
+}
+
+impl PartialEq for Device {
+    fn eq(&self, other: &Self) -> bool {
+        self.pcm_id == other.pcm_id
+    }
+}
+
+impl Eq for Device {}
+
+impl fmt::Display for Device {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let desc = self.description().map_err(|_| fmt::Error)?;
+        f.write_str(desc.name())
+    }
+}
+
+impl std::hash::Hash for Device {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.pcm_id.hash(state);
     }
 }
 

--- a/src/host/asio/device.rs
+++ b/src/host/asio/device.rs
@@ -1,4 +1,5 @@
 use std::{
+    fmt,
     hash::{Hash, Hasher},
     sync::{atomic::AtomicU32, Arc, Mutex},
 };
@@ -38,20 +39,6 @@ pub struct Devices {
     asio: Arc<sys::Asio>,
     drivers: std::vec::IntoIter<String>,
     current_driver: Option<sys::Driver>,
-}
-
-impl PartialEq for Device {
-    fn eq(&self, other: &Self) -> bool {
-        self.name == other.name
-    }
-}
-
-impl Eq for Device {}
-
-impl Hash for Device {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.name.hash(state);
-    }
 }
 
 impl Device {
@@ -139,6 +126,35 @@ impl Device {
             }
         }
         configs
+    }
+}
+
+impl PartialEq for Device {
+    fn eq(&self, other: &Self) -> bool {
+        self.name == other.name
+    }
+}
+
+impl Eq for Device {}
+
+impl Hash for Device {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.name.hash(state);
+    }
+}
+
+impl fmt::Display for Device {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let desc = self.description().map_err(|_| fmt::Error)?;
+        f.write_str(desc.name())
+    }
+}
+
+impl fmt::Debug for Device {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Device")
+            .field("name", &self.name)
+            .finish_non_exhaustive()
     }
 }
 

--- a/src/host/audioworklet/mod.rs
+++ b/src/host/audioworklet/mod.rs
@@ -426,11 +426,7 @@ type AudioProcessorCallback = Box<dyn FnMut(&mut [f32], u32, u32, f64)>;
 /// running in the AudioWorklet to interact with Rust.
 #[wasm_bindgen]
 pub struct WasmAudioProcessor {
-    #[allow(unused_variables)]
-    #[wasm_bindgen(skip)]
     interleaved_buffer: Vec<f32>,
-    #[allow(unused_variables)]
-    #[wasm_bindgen(skip)]
     // Passes in an interleaved scratch buffer, frame size, sample rate, and current time.
     callback: AudioProcessorCallback,
 }

--- a/src/host/audioworklet/mod.rs
+++ b/src/host/audioworklet/mod.rs
@@ -4,6 +4,7 @@
 //! See the `audioworklet-beep` example for setup instructions.
 
 use std::{
+    fmt,
     sync::{
         atomic::{AtomicU64, Ordering},
         Arc,
@@ -31,6 +32,13 @@ pub struct Devices(bool);
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Device;
+
+impl fmt::Display for Device {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let desc = self.description().map_err(|_| fmt::Error)?;
+        f.write_str(desc.name())
+    }
+}
 
 pub struct Host;
 

--- a/src/host/audioworklet/mod.rs
+++ b/src/host/audioworklet/mod.rs
@@ -425,10 +425,11 @@ type AudioProcessorCallback = Box<dyn FnMut(&mut [f32], u32, u32, f64)>;
 /// WasmAudioProcessor provides an interface for the Javascript code
 /// running in the AudioWorklet to interact with Rust.
 #[wasm_bindgen]
-#[allow(unused_variables)]
 pub struct WasmAudioProcessor {
+    #[allow(unused_variables)]
     #[wasm_bindgen(skip)]
     interleaved_buffer: Vec<f32>,
+    #[allow(unused_variables)]
     #[wasm_bindgen(skip)]
     // Passes in an interleaved scratch buffer, frame size, sample rate, and current time.
     callback: AudioProcessorCallback,

--- a/src/host/coreaudio/ios/mod.rs
+++ b/src/host/coreaudio/ios/mod.rs
@@ -1,6 +1,7 @@
 //! CoreAudio implementation for iOS using AVAudioSession and RemoteIO Audio Units.
 
 use std::{
+    fmt,
     ptr::NonNull,
     sync::{Arc, Mutex},
     time::Duration,
@@ -37,6 +38,13 @@ const SUPPORTED_SAMPLE_FORMAT: SampleFormat = SampleFormat::F32;
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Device;
+
+impl fmt::Display for Device {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let desc = self.description().map_err(|_| fmt::Error)?;
+        f.write_str(desc.name())
+    }
+}
 
 pub struct Host;
 

--- a/src/host/coreaudio/macos/device.rs
+++ b/src/host/coreaudio/macos/device.rs
@@ -362,20 +362,6 @@ pub struct Device {
     pub(crate) is_default_output: bool,
 }
 
-impl PartialEq for Device {
-    fn eq(&self, other: &Self) -> bool {
-        self.audio_device_id == other.audio_device_id
-    }
-}
-
-impl Eq for Device {}
-
-impl std::hash::Hash for Device {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.audio_device_id.hash(state);
-    }
-}
-
 impl Device {
     /// Construct a new device given its ID.
     /// Useful for constructing hidden devices.
@@ -721,15 +707,6 @@ impl Device {
     }
 }
 
-impl fmt::Debug for Device {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_struct("Device")
-            .field("audio_device_id", &self.audio_device_id)
-            .field("name", &self.description().map(|d| d.name().to_owned()))
-            .finish()
-    }
-}
-
 impl Device {
     #[allow(clippy::cast_ptr_alignment)]
     #[allow(clippy::while_immutable_condition)]
@@ -947,6 +924,36 @@ impl Device {
         let stream = Stream::new(inner_arc, monitor);
         stream.signal_ready();
         Ok(stream)
+    }
+}
+
+impl PartialEq for Device {
+    fn eq(&self, other: &Self) -> bool {
+        self.audio_device_id == other.audio_device_id
+    }
+}
+
+impl Eq for Device {}
+
+impl fmt::Display for Device {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let desc = self.description().map_err(|_| fmt::Error)?;
+        f.write_str(desc.name())
+    }
+}
+
+impl std::hash::Hash for Device {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.audio_device_id.hash(state);
+    }
+}
+
+impl fmt::Debug for Device {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("Device")
+            .field("audio_device_id", &self.audio_device_id)
+            .field("name", &self.description().map(|d| d.name().to_owned()))
+            .finish()
     }
 }
 

--- a/src/host/custom/mod.rs
+++ b/src/host/custom/mod.rs
@@ -4,6 +4,7 @@
 //! See `examples/custom.rs` for usage.
 
 use core::time::Duration;
+use std::fmt;
 
 use crate::{
     traits::{DeviceTrait, HostTrait, StreamTrait},
@@ -83,6 +84,35 @@ impl Device {
 impl Clone for Device {
     fn clone(&self) -> Self {
         self.0.clone()
+    }
+}
+
+impl PartialEq for Device {
+    fn eq(&self, other: &Self) -> bool {
+        DeviceTrait::id(self).ok() == DeviceTrait::id(other).ok()
+    }
+}
+
+impl Eq for Device {}
+
+impl std::hash::Hash for Device {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        DeviceTrait::id(self).ok().hash(state);
+    }
+}
+
+impl fmt::Display for Device {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let desc = DeviceTrait::description(self).map_err(|_| fmt::Error)?;
+        f.write_str(desc.name())
+    }
+}
+
+impl fmt::Debug for Device {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("Device")
+            .field(&DeviceTrait::description(self).map(|d| d.name().to_owned()))
+            .finish()
     }
 }
 

--- a/src/host/jack/device.rs
+++ b/src/host/jack/device.rs
@@ -1,4 +1,5 @@
 use std::{
+    fmt,
     hash::{Hash, Hasher},
     time::Duration,
 };
@@ -334,6 +335,13 @@ impl PartialEq for Device {
 }
 
 impl Eq for Device {}
+
+impl fmt::Display for Device {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let desc = self.description().map_err(|_| fmt::Error)?;
+        f.write_str(desc.name())
+    }
+}
 
 impl Hash for Device {
     fn hash<H: Hasher>(&self, state: &mut H) {

--- a/src/host/null/mod.rs
+++ b/src/host/null/mod.rs
@@ -2,6 +2,7 @@
 //!
 //! Fallback no-op backend for unsupported platforms.
 
+use std::fmt;
 use std::time::Duration;
 
 use crate::{
@@ -16,6 +17,13 @@ pub struct Devices;
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Device;
+
+impl fmt::Display for Device {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let desc = self.description().map_err(|_| fmt::Error)?;
+        f.write_str(desc.name())
+    }
+}
 
 pub struct Host;
 

--- a/src/host/pipewire/device.rs
+++ b/src/host/pipewire/device.rs
@@ -1,5 +1,7 @@
 use std::{
     cell::RefCell,
+    fmt,
+    hash::{Hash, Hasher},
     rc::Rc,
     sync::{
         atomic::{AtomicU64, Ordering},
@@ -176,6 +178,28 @@ impl Device {
         properties
     }
 }
+
+impl PartialEq for Device {
+    fn eq(&self, other: &Self) -> bool {
+        self.node_name == other.node_name
+    }
+}
+
+impl Eq for Device {}
+
+impl fmt::Display for Device {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let desc = self.description().map_err(|_| fmt::Error)?;
+        f.write_str(desc.name())
+    }
+}
+
+impl Hash for Device {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.node_name.hash(state);
+    }
+}
+
 impl DeviceTrait for Device {
     type Stream = Stream;
     type SupportedInputConfigs = SupportedInputConfigs;

--- a/src/host/pulseaudio/mod.rs
+++ b/src/host/pulseaudio/mod.rs
@@ -1,4 +1,10 @@
-use std::{sync::mpsc, time::Duration};
+use std::{
+    fmt,
+    hash::{Hash, Hasher},
+    mem::discriminant,
+    sync::mpsc,
+    time::Duration,
+};
 
 use futures::executor::block_on;
 use pulseaudio::protocol;
@@ -606,6 +612,35 @@ fn make_record_buffer_attr(
                 fragment_size: len,
                 ..Default::default()
             }
+        }
+    }
+}
+
+impl PartialEq for Device {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Device::Sink { info: a, .. }, Device::Sink { info: b, .. }) => a.index == b.index,
+            (Device::Source { info: a, .. }, Device::Source { info: b, .. }) => a.index == b.index,
+            _ => false,
+        }
+    }
+}
+
+impl Eq for Device {}
+
+impl fmt::Display for Device {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let desc = self.description().map_err(|_| fmt::Error)?;
+        f.write_str(desc.name())
+    }
+}
+
+impl Hash for Device {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        discriminant(self).hash(state);
+        match self {
+            Device::Sink { info, .. } => info.index.hash(state),
+            Device::Source { info, .. } => info.index.hash(state),
         }
     }
 }

--- a/src/host/wasapi/device.rs
+++ b/src/host/wasapi/device.rs
@@ -1069,6 +1069,13 @@ impl std::hash::Hash for Device {
     }
 }
 
+impl fmt::Display for Device {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let desc = self.description().map_err(|_| fmt::Error)?;
+        f.write_str(desc.name())
+    }
+}
+
 impl fmt::Debug for Device {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("Device")

--- a/src/host/webaudio/mod.rs
+++ b/src/host/webaudio/mod.rs
@@ -7,6 +7,7 @@ extern crate wasm_bindgen;
 extern crate web_sys;
 
 use std::{
+    fmt,
     ops::DerefMut,
     sync::{
         atomic::{AtomicBool, Ordering},
@@ -38,6 +39,13 @@ pub struct Devices(bool);
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Device;
+
+impl fmt::Display for Device {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let desc = self.description().map_err(|_| fmt::Error)?;
+        f.write_str(desc.name())
+    }
+}
 
 pub struct Host;
 

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -618,6 +618,77 @@ macro_rules! impl_platform_host {
             }
         }
 
+        use std::fmt;
+        use std::hash::{Hash, Hasher};
+
+        impl PartialEq for DeviceInner {
+            #[allow(unreachable_patterns)]
+            fn eq(&self, other: &DeviceInner) -> bool {
+                match (self, other) {
+                    $(
+                        $(#[cfg($feat)])?
+                        (DeviceInner::$HostVariant(a), DeviceInner::$HostVariant(b)) => a == b,
+                    )*
+                    _ => false,
+                }
+            }
+        }
+
+        impl Eq for DeviceInner {}
+
+        impl Hash for DeviceInner {
+            fn hash<H: Hasher>(&self, state: &mut H) {
+                match self {
+                    $(
+                        $(#[cfg($feat)])?
+                        DeviceInner::$HostVariant(d) => d.hash(state),
+                    )*
+                }
+            }
+        }
+
+        impl fmt::Debug for DeviceInner {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                match self {
+                    $(
+                        $(#[cfg($feat)])?
+                        DeviceInner::$HostVariant(d) => d.fmt(f),
+                    )*
+                }
+            }
+        }
+
+        impl PartialEq for Device {
+            fn eq(&self, other: &Device) -> bool {
+                self.0 == other.0
+            }
+        }
+
+        impl Eq for Device {}
+
+        impl Hash for Device {
+            fn hash<H: Hasher>(&self, state: &mut H) {
+                self.0.hash(state);
+            }
+        }
+
+        impl fmt::Debug for Device {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                self.0.fmt(f)
+            }
+        }
+
+        impl fmt::Display for Device {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                match self.0 {
+                    $(
+                        $(#[cfg($feat)])?
+                        DeviceInner::$HostVariant(ref d) => fmt::Display::fmt(d, f),
+                    )*
+                }
+            }
+        }
+
         impl From<DeviceInner> for Device {
             fn from(d: DeviceInner) -> Self {
                 Device(d)

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -5,7 +5,11 @@
 //! When implementing custom hosts with the `custom` feature, use the [`assert_stream_send!`](crate::assert_stream_send)
 //! and [`assert_stream_sync!`](crate::assert_stream_sync) macros to verify your `Stream` type meets CPAL's requirements.
 
-use std::time::Duration;
+use std::{
+    fmt::{Debug, Display},
+    hash::Hash,
+    time::Duration,
+};
 
 use crate::{
     Data, DeviceDescription, DeviceId, Error, InputCallbackInfo, InputDevices, OutputCallbackInfo,
@@ -105,7 +109,7 @@ pub trait HostTrait {
 ///
 /// Please note that `Device`s may become invalid if they get disconnected. Therefore, all the
 /// methods that involve a device return a `Result` allowing the user to handle this case.
-pub trait DeviceTrait {
+pub trait DeviceTrait: PartialEq + Eq + Hash + Debug + Display {
     /// The iterator type yielding supported input stream formats.
     type SupportedInputConfigs: Iterator<Item = SupportedStreamConfigRange>;
     /// The iterator type yielding supported output stream formats.
@@ -122,8 +126,8 @@ pub trait DeviceTrait {
     /// including name, manufacturer (if available), device type, bus type, and other
     /// platform-specific metadata.
     ///
-    /// For simple string representation, use `device.description().to_string()` or
-    /// `device.description().name()`.
+    /// For the device name as a string, use `device.to_string()` or format it with `{}`. For the
+    /// full structured description, call `device.description()?` and format or inspect that.
     ///
     /// # Errors
     ///


### PR DESCRIPTION
Since we've got stable device IDs, we can ubiquitously implement `PartialEq`, `Eq` and `Hash` on all hosts.
While there, add `Display` and `Debug` as well.