### PR TITLE
refactor: do not auto-start streams nor RT-promote

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   on supported devices.
 - **ALSA**: `default_input_config()` and `default_output_config()` now prefer 48 kHz, then
   44.1 kHz, then the maximum supported sample rate, instead of preferring 44.1 kHz.
+- **ALSA**: Streams no longer start automatically on creation; call `play()` manually.
 - **ASIO**: `Device::driver`, `asio_streams`, and `current_callback_flag` are no longer `pub`.
 - **ASIO**: Timestamps now include driver-reported hardware latency.
 - **ASIO**: Hardware latency is now re-queried when the driver reports `kAsioLatenciesChanged`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   [UPGRADING.md](UPGRADING.md) for migration details.
 - `SupportedStreamConfigRange::cmp_default_heuristics` now ranks all `SampleFormat` variants.
   See [UPGRADING.md](UPGRADING.md) for migration details.
-- `audio_thread_priority` feature renamed to `realtime-dbus` and enabled by default.
+- `audio_thread_priority` feature renamed to `realtime-dbus`.
 - `audio_thread_priority` dependency bumped to 0.35.
 - `DeviceTrait` now requires `PartialEq + Eq + Hash + Debug + Display` with a stable device ID.
 - **AAudio**: Device names now include the device type suffix (e.g. "Speaker (Builtin Speaker)")
@@ -76,6 +76,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **ALSA**: `default_input_config()` and `default_output_config()` now prefer 48 kHz, then
   44.1 kHz, then the maximum supported sample rate, instead of preferring 44.1 kHz.
 - **ALSA**: Streams no longer start automatically on creation; call `play()` manually.
+- **ALSA**: The `realtime` feature now skips RT promotion for ineligible PCM types (null,
+  I/O plugins, wrapper types); `audio_thread_priority` promoted unconditionally.
 - **ASIO**: `Device::driver`, `asio_streams`, and `current_callback_flag` are no longer `pub`.
 - **ASIO**: Timestamps now include driver-reported hardware latency.
 - **ASIO**: Hardware latency is now re-queried when the driver reports `kAsioLatenciesChanged`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 rust-version = "1.78"
 
 [features]
-default = ["realtime-dbus"]
+default = []
 
 # Real-time audio thread scheduling
 # Promotes audio callback threads to real-time or high-priority scheduling for lower latency

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # CPAL - Cross-Platform Audio Library
 
-[![Actions Status](https://github.com/RustAudio/cpal/workflows/cpal/badge.svg)](https://github.com/RustAudio/cpal/actions)
-[![Crates.io](https://img.shields.io/crates/v/cpal.svg)](https://crates.io/crates/cpal) [![docs.rs](https://docs.rs/cpal/badge.svg)](https://docs.rs/cpal/)
+[![Actions Status](https://github.com/RustAudio/cpal/workflows/cpal/badge.svg)](https://github.com/RustAudio/cpal/actions) [![Crates.io](https://img.shields.io/crates/v/cpal.svg)](https://crates.io/crates/cpal) [![docs.rs](https://docs.rs/cpal/badge.svg)](https://docs.rs/cpal/)
 
 Low-level library for audio input and output in pure Rust.
 
@@ -9,7 +8,7 @@ Low-level library for audio input and output in pure Rust.
 
 - Enumerate audio hosts, devices, and their supported stream configurations.
 - Look up devices by stable ID or by default input/output role.
-- Inspect device metadata: name, manufacturer, type, and bus type.       
+- Inspect device metadata: name, manufacturer, type, and bus type.
 - Build input and output streams with compile-time or runtime sample formats.
 - Play, pause, and query the buffer size and clock of a stream.
 
@@ -26,19 +25,15 @@ Low-level library for audio input and output in pure Rust.
 
 ## Linux Build Dependencies
 
-On Linux, building cpal requires the ALSA and D-Bus development files: `libasound2-dev` and 
-`libdbus-1-dev` on Debian and Ubuntu, `alsa-lib-devel` and `dbus-devel` on Fedora.
+On Linux, building cpal requires the ALSA development files: `libasound2-dev` on Debian and Ubuntu, `alsa-lib-devel` on Fedora.
 
 ALSA is needed even when using JACK, PipeWire, or PulseAudio.
 
-D-Bus is pulled in by the default `realtime-dbus` feature for `rtkit`-based RT scheduling, typical
-for desktop systems. For systems without D-Bus, disable default features and enable the plain
-`realtime` feature instead. See [Real-Time Priority Promotion](#real-time-priority-promotion).
-Disable both features to disable RT scheduling entirely.
+The optional `realtime-dbus` feature additionally requires `libdbus-1-dev` (Debian/Ubuntu) or `dbus-devel` (Fedora). See [ALSA Real-Time Priority Promotion](#alsa-real-time-priority-promotion).
 
 ## Minimum Supported Rust Version (MSRV)
 
-The minimum Rust version required depends on which audio backend and features you're using, as each platform has different dependencies:
+The minimum Rust version required depends on which audio backend and features you're using, as eachplatform has different dependencies:
 
 - **AAudio (Android):** Rust **1.85**
 - **ALSA (Linux/BSD):** Rust **1.82**
@@ -58,7 +53,7 @@ If you are interested in using CPAL with WebAssembly, please see [this guide](ht
 ## Optional Features
 
 | Feature | Platform | Description |
-|---------|----------|-------------|
+| ------- | -------- | ----------- |
 | `asio` | Windows | ASIO backend for low-latency audio, bypassing the Windows audio stack. Requires ASIO drivers and LLVM/Clang. See the [ASIO setup guide](#asio). |
 | `audioworklet` | WebAssembly (`wasm32-unknown-unknown`) | Audio Worklet backend for lower-latency web audio than the default Web Audio API, running audio on a dedicated thread. Requires atomics support (`RUSTFLAGS="-C target-feature=+atomics,+bulk-memory,+mutable-globals"`) and `Cross-Origin` headers for `SharedArrayBuffer`. See the `audioworklet-beep` example. |
 | `custom` | All | User-defined backend implementations for audio systems not natively supported by CPAL. See `examples/custom.rs`. |
@@ -66,7 +61,7 @@ If you are interested in using CPAL with WebAssembly, please see [this guide](ht
 | `pipewire` | Linux, BSD | PipeWire media server backend. Requires `libpipewire-0.3-dev` (Debian/Ubuntu) or `pipewire-devel` (Fedora). |
 | `pulseaudio` | Linux, BSD | PulseAudio sound server backend. Requires `libpulse-dev` (Debian/Ubuntu) or `pulseaudio-libs-devel` (Fedora). |
 | `realtime` | Linux, BSD, Windows, Android | Raises the audio callback thread to real-time or high-priority scheduling for lower latency. On Linux/BSD, requires `rtprio` granted in `limits.conf` (e.g. `@audio - rtprio 95`) unless `realtime-dbus` is also enabled. |
-| `realtime-dbus` | Linux, BSD, Windows, Android | Uses `rtkit` via D-Bus for RT scheduling on Linux/BSD desktop systems, removing the need for manual `limits.conf` setup. Implies `realtime` on all platforms. Enabled by default. |
+| `realtime-dbus` | Linux, BSD | Uses `rtkit` via D-Bus for RT scheduling on Linux/BSD desktop systems, removing the need for manual `limits.conf` setup. Implies `realtime` on all platforms. Requires `libdbus-1-dev` on Linux/BSD. |
 | `wasm-bindgen` | WebAssembly (`wasm32-unknown-unknown`) | Web Audio API backend for browser-based audio; required for any WebAssembly audio support. See the `wasm-beep` example. |
 
 See the [beep example](examples/beep.rs) for selecting the backend at runtime.
@@ -90,37 +85,35 @@ In an ideal situation you don't need to worry about this step.
 1. **Install LLVM/Clang**: `bindgen`, the library used to generate bindings to the C++ SDK, requires clang. Download and install LLVM from <http://releases.llvm.org/download.html> under the "Pre-Built Binaries" section.
 
 2. **Set LIBCLANG_PATH**: Add the LLVM `bin` directory to a `LIBCLANG_PATH` environment variable. If you installed LLVM to the default directory, this should work in the command prompt:
-   ```
+
+   ```bat
    setx LIBCLANG_PATH "C:\Program Files\LLVM\bin"
    ```
 
 3. **Install ASIO Drivers** (optional for testing): If you don't have any ASIO devices or drivers available, you can download and install ASIO4ALL from <http://www.asio4all.org/>. Be sure to enable the "offline" feature during installation.
 
 4. **Visual Studio**: The build script assumes Microsoft Visual Studio is installed. It will try to find `vcvarsall.bat` and execute it with the right host and target architecture. If needed, you can manually execute it:
-   ```
+
+   ```bat
    "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat" amd64
    ```
+
    For more information see the [vcvarsall.bat documentation](https://docs.microsoft.com/en-us/cpp/build/building-on-the-command-line).
 
 ### Using ASIO in Your Application
 
 1. **Enable the feature** in your `Cargo.toml`:
+
    ```toml
    cpal = { version = "*", features = ["asio"] }
    ```
 
 2. **Select the ASIO backend** in your code:
+
    ```rust
    let host = cpal::host_from_id(cpal::HostId::Asio)
        .expect("failed to initialise ASIO host");
    ```
-
-### Troubleshooting
-
-If you encounter compilation errors from `asio-sys` or `bindgen`:
-- Verify `CPAL_ASIO_DIR` is set correctly
-- Try running `cargo clean`
-- Ensure LLVM/Clang is properly installed and `LIBCLANG_PATH` is set
 
 ### Cross-Compilation
 
@@ -129,10 +122,12 @@ When Windows is the host and target OS, the build script supports all cross-comp
 It is also possible to compile Windows applications with ASIO support on Linux and macOS using the MinGW-w64 toolchain.
 
 **Requirements:**
+
 - Include the MinGW-w64 include directory in your `CPLUS_INCLUDE_PATH` environment variable
 - Include the LLVM include directory in your `CPLUS_INCLUDE_PATH` environment variable
 
 **Example for macOS** (targeting `x86_64-pc-windows-gnu` with `mingw-w64` installed via brew):
+
 ```sh
 export CPLUS_INCLUDE_PATH="$CPLUS_INCLUDE_PATH:/opt/homebrew/Cellar/mingw-w64/11.0.1/toolchain-x86_64/x86_64-w64-mingw32/include"
 ```
@@ -151,10 +146,7 @@ If you receive errors about no default input or output device:
 
 ## ALSA, PipeWire, and PulseAudio
 
-When PipeWire or PulseAudio is running, it holds the ALSA `default` device exclusively. A second
-stream attempting to open it via the ALSA host will fail with a `DeviceBusy` error. To route
-audio through the sound server via ALSA, use the bridge devices `pipewire` or `pulse` instead of
-`default`. Better yet, use the `pipewire` or `pulseaudio` cpal features for native integration.
+When PipeWire or PulseAudio is running, it holds the ALSA `default` device exclusively. A second stream attempting to open it via the ALSA host will fail with a `DeviceBusy` error. To route audio through the sound server via ALSA, use the bridge devices `pipewire` or `pulse` instead of `default`. Better yet, use the `pipewire` or `pulseaudio` cpal features for native integration.
 
 On targets without a sound server, address devices directly as `hw:` or `plughw:`.
 
@@ -165,7 +157,7 @@ On targets without a sound server, address devices directly as `hw:` or `plughw:
 Configure the system and/or request a fixed size in your application:
 
 | System | File | Setting |
-|--------|------|---------|
+| ------ | ---- | ------- |
 | ALSA | `~/.asoundrc` or `/etc/asound.conf` | `buffer_size`, `periods` * `period_size` |
 | PipeWire | `~/.config/pipewire/pipewire.conf.d/` | `default.clock.quantum` |
 | PulseAudio | `~/.config/pulse/daemon.conf` | `default-fragments` * `default-fragment-size-msec` |
@@ -178,45 +170,37 @@ Query `device.default_output_config()?.buffer_size()` for valid ranges. Smaller 
 
 ### ALSA Real-Time Priority Promotion
 
-The ALSA backend refuses to promote the audio thread to RT priority for plugins such as `pcm.pulse`
-and `pcm.pipewire`, notifying `RealtimeDenied` after stream creation on the error callback.
-Consider using the `pulseaudio` or `pipewire` cpal features to open the device through the native
-backend instead. While RT priority is desirable for low latency, the stream will continue to play 
-at the default scheduling priority.
+The ALSA backend refuses to promote the audio thread to RT priority for plugins such as `pcm.pulse` and `pcm.pipewire`, notifying `RealtimeDenied` after stream creation on the error callback. Consider using the `pulseaudio` or `pipewire` cpal features to open the device through the native backend instead. While RT priority is desirable for low latency, the stream will continue to play at the default scheduling priority.
 
 Kernel-backed PCMs (`hw`, `plughw`) and pure-computation plugins are unaffected.
 
-`RealtimeDenied` is also received when the process lacks the resource limits to acquire
-`SCHED_FIFO`. With the default `realtime-dbus` feature, `rtkit` arranges this over D-Bus on 
-typical desktop systems. With the plain `realtime` feature, you must ensure that `rtprio` is 
-granted yourself. Add to `/etc/security/limits.d/audio.conf` and ensure the user is member of the 
-`audio` group:
+`RealtimeDenied` is also received when the process lacks the resource limits to acquire `SCHED_FIFO`. With the `realtime-dbus` feature, `rtkit` arranges this over D-Bus on typical desktop systems. With the plain `realtime` feature, you must ensure that `rtprio` is granted yourself. Add to `/etc/security/limits.d/audio.conf` and ensure the user is member of the `audio` group:
 
-```
+```text
 @audio - rtprio 95
 ```
 
-then add the user to the `audio` group (`usermod -aG audio "$USER"`) and re-login. The same group
-may anyway be needed to grant access to ALSA device files via `udev` on systems that do not
-arrange this automatically via `logind`.
+then add the user to the `audio` group (`usermod -aG audio "$USER"`) and re-login. The same group may anyway be needed to grant access to ALSA device files via `udev` on systems that do not arrange this automatically via `logind`.
 
 ### Build Errors
 
 If you are unable to build the library:
 
 - Verify you have installed the required development libraries, as documented above
-- **ASIO on Windows:** Verify `LIBCLANG_PATH` is set and LLVM is installed
+- **ASIO on Windows:** Verify `CPAL_ASIO_DIR` and `LIBCLANG_PATH` are set and LLVM is installed
 
 ## Examples
 
 CPAL comes with several examples in `examples/`.
 
 Run an example with:
+
 ```sh
 cargo run --example beep
 ```
 
 For platform-specific features, enable the relevant features:
+
 ```sh
 cargo run --example beep --features asio        # Windows ASIO backend
 cargo run --example beep --features jack        # JACK backend

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -20,8 +20,8 @@ This guide covers breaking changes requiring code updates. See [CHANGELOG.md](CH
 - [ ] If you relied on the default config returning `F32`, pin the sample format explicitly.
 - [ ] **JACK**: Handle or discard the new `Result` from `Stream::connect_to_system_outputs()` and
   `Stream::connect_to_system_inputs()`.
-- [ ] **CoreAudio, JACK**: Add an explicit `stream.play()` call after `build_*_stream()` if you
-  were relying these backends to auto-start streams.
+- [ ] **ALSA, CoreAudio, JACK**: Add an explicit `stream.play()` call after `build_*_stream()` if
+  you were relying on these backends to auto-start streams.
 
 ## 1. Unified `Error` and `ErrorKind` type
 
@@ -242,10 +242,10 @@ made it easy to accidentally ship without it.
 ## 7. Streams are returned paused on every backend
 
 **What changed:** `build_input_stream` and `build_output_stream` now return a paused `Stream` on
-every backend. Previously, CoreAudio and JACK started the stream automatically.
+every backend. Previously, ALSA, CoreAudio, and JACK started the stream automatically.
 
 ```rust
-// Before (v0.17): on CoreAudio/JACK the stream was already running
+// Before (v0.17): on ALSA/CoreAudio/JACK the stream was already running
 let stream = device.build_output_stream(config, data_fn, err_fn, None)?;
 
 // After (v0.18): every backend requires play()
@@ -253,12 +253,12 @@ let stream = device.build_output_stream(config, data_fn, err_fn, None)?;
 stream.play()?;
 ```
 
-**Impact:** If you were targeting CoreAudio or JACK and never called `play()`, your callback will
-never fire after upgrading. Add the `play()` call.
+**Impact:** If you were targeting ALSA, CoreAudio, or JACK and never called `play()`, your
+callback will never fire after upgrading. Add the `play()` call.
 
 **Why:** Auto-starting before the caller has the `Stream` handle creates a window where data and
-error callbacks can fire before the application can pause, stop, or drop the stream. Other hosts 
-already required `play()`. The behavior is now uniform.
+error callbacks can fire before the application can pause, stop, or drop the stream. The behavior
+is now uniform across all backends.
 
 ## 8. `wasm32-unknown-emscripten` target removed
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -25,10 +25,7 @@ This guide covers breaking changes requiring code updates. See [CHANGELOG.md](CH
 
 ## 1. Unified `Error` and `ErrorKind` type
 
-**What changed:** All per-operation error types (`DevicesError`, `SupportedStreamConfigsError`,
-`DefaultStreamConfigError`, `BuildStreamError`, `StreamError`, `PlayStreamError`,
-`PauseStreamError`) and the `HostUnavailable` struct are replaced by a single `cpal::Error` struct
-with getters for its `kind()` and optional `message()`.
+**What changed:** All per-operation error types (`DevicesError`, `SupportedStreamConfigsError`, `DefaultStreamConfigError`, `BuildStreamError`, `StreamError`, `PlayStreamError`, `PauseStreamError`) and the `HostUnavailable` struct are replaced by a single `cpal::Error` struct with getters for its `kind()` and optional `message()`.
 
 ```rust
 // Before (v0.17): each operation returned its own error type
@@ -73,11 +70,9 @@ The `ErrorKind` variants and their equivalents from v0.17:
 | `BackendError`         | - (new; previously folded into `BackendSpecific`)    |
 | `Other`                | `BackendSpecific`                                    |
 
-The `message()` getter on `Error` returns human-readable context (formerly in
-`BackendSpecific::err`).
+The `message()` getter on `Error` returns human-readable context (formerly in `BackendSpecific::err`).
 
-**Why:** A single type simplifies error handling across all cpal operations and allows new
-`ErrorKind` variants to be added without changing any return types.
+**Why:** A single type simplifies error handling across all cpal operations and allows new `ErrorKind` variants to be added without changing any return types.
 
 ## 2. `StreamConfig` is now passed by value
 
@@ -101,8 +96,7 @@ The `StreamInstant` API has been aligned with `std::time::Instant` and `std::tim
 
 ### `duration_since` now returns `Duration` (saturating)
 
-**What changed:** `duration_since` now returns `Duration` directly, saturating to `Duration::ZERO`
-when the argument is later than `self`, instead of returning `Option<Duration>`.
+**What changed:** `duration_since` now returns `Duration` directly, saturating to `Duration::ZERO` when the argument is later than `self`, instead of returning `Option<Duration>`.
 
 ```rust
 // Before (v0.17): returned Option<Duration>, argument by reference
@@ -124,9 +118,7 @@ if let Some(d) = callback.checked_duration_since(start) {
 
 ### `add` / `sub` renamed to `checked_add` / `checked_sub`; operator impls added
 
-**What changed:** The `add` and `sub` methods (which returned `Option`) are replaced by
-`checked_add` / `checked_sub` with the same semantics. `+`, `-`, `+=`, and `-=` operator impls
-are also added.
+**What changed:** The `add` and `sub` methods (which returned `Option`) are replaced by `checked_add` / `checked_sub` with the same semantics. `+`, `-`, `+=`, and `-=` operator impls are also added.
 
 ```rust
 // Before (v0.17)
@@ -149,8 +141,7 @@ let elapsed: Duration = later - earlier;
 
 ### `new` and `from_nanos` take unsigned integers
 
-**What changed:** The `secs` parameter of `StreamInstant::new` and the `nanos` parameter of
-`StreamInstant::from_nanos` are now `u64` instead of `i64`.
+**What changed:** The `secs` parameter of `StreamInstant::new` and the `nanos` parameter of `StreamInstant::from_nanos` are now `u64` instead of `i64`.
 
 ```rust
 // Before (v0.17): negative seconds were accepted
@@ -164,8 +155,7 @@ StreamInstant::new(0_u64, 0);
 
 ## 4. Default sample rate changed to 48 kHz
 
-**What changed:** `default_input_config()` and `default_output_config()` now prefer 48 kHz over
-44.1 kHz on backends that apply a heuristic. The new selection order is 48 kHz, then 44.1 kHz, then the device maximum.
+**What changed:** `default_input_config()` and `default_output_config()` now prefer 48 kHz over 44.1 kHz on backends that apply a heuristic. The new selection order is 48 kHz, then 44.1 kHz, then the device maximum.
 
 If your pipeline requires 44.1 kHz, request it explicitly:
 
@@ -176,18 +166,13 @@ let config = device
     .expect("device does not support 44.1 kHz");
 ```
 
-**Why:** 48 kHz is the native rate of virtually all modern hardware; the old default caused
-unnecessary resampling on such devices.
+**Why:** 48 kHz is the native rate of virtually all modern hardware; the old default caused unnecessary resampling on such devices.
 
 ## 5. Default sample format selection changed
 
-**What changed:** `default_input_config()` and `default_output_config()` now use a fully-ranked
-format ordering across all `SampleFormat` variants.
+**What changed:** `default_input_config()` and `default_output_config()` now use a fully-ranked format ordering across all `SampleFormat` variants.
 
-Previously only `F32`, `I16`, and `U16` were explicitly ranked; all other formats compared as
-equal. On hosts that expose higher-precision formats, the default config may now return a
-different format than before. Likely candidates are `I32`, `I24`, or even `F64` if the device 
-or plugin supports it.
+Previously only `F32`, `I16`, and `U16` were explicitly ranked; all other formats compared as equal. On hosts that expose higher-precision formats, the default config may now return a different format than before. Likely candidates are `I32`, `I24`, or even `F64` if the device or plugin supports it.
 
 If your code assumes the default format is `F32`, request the format explicitly:
 
@@ -198,51 +183,32 @@ let configs = device
     .filter(|r| r.sample_format() == SampleFormat::F32);
 ```
 
-**Why:** The previous heuristic only explicitly ranked three formats, making selection
-unpredictable for any other format the device reported. The new ordering is complete and
-consistent: floats before integers (F64 > F32 for maximum fidelity), integers by bit-depth
-descending with signed above unsigned at each width, and DSD last.
+**Why:** The previous heuristic only explicitly ranked three formats, making selection unpredictable for any other format the device reported. The new ordering is complete and consistent: floats before integers (F64 > F32 for maximum fidelity), integers by bit-depth descending with signed above unsigned at each width, and DSD last.
 
-## 6. `audio_thread_priority` feature renamed to `realtime-dbus` and enabled by default
+## 6. `audio_thread_priority` feature renamed to `realtime-dbus`
 
-**What changed:** The `audio_thread_priority` feature has been renamed to `realtime-dbus` and is
-now a default feature. If you did not previously enable it, real-time scheduling will now be
-requested automatically for audio callback threads. A new `realtime` feature was also added,
-providing the same scheduling promotion without a D-Bus build dependency.
+**What changed:** The `audio_thread_priority` feature has been renamed to `realtime-dbus`. A new `realtime` feature was also added, providing the same scheduling promotion without a D-Bus build dependency (suitable for headless or embedded targets).
 
 ```toml
-# Before (v0.17): opt-in required
+# Before (v0.17)
 cpal = { version = "0.17", features = ["audio_thread_priority"] }
 
-# After (v0.18): on by default; rename the feature if you were opting in
-cpal = { version = "0.18" }
+# After (v0.18): rename the feature
+cpal = { version = "0.18", features = ["realtime-dbus"] }
 
-# To opt out explicitly:
-cpal = { version = "0.18", default-features = false }
+# For systems without D-Bus (embedded, headless, containers):
+cpal = { version = "0.18", features = ["realtime"] }
 ```
 
-On Linux and BSD, `realtime-dbus` requires `libdbus-1-dev` (Debian/Ubuntu), `dbus-devel`
-(Fedora/RHEL), or equivalent at build time. On headless or embedded targets without D-Bus, use
-`realtime` instead:
+On Linux and BSD, `realtime-dbus` requires `libdbus-1-dev` (Debian/Ubuntu), `dbus-devel` (Fedora/RHEL), or equivalent at build time.
 
-```toml
-cpal = { version = "0.18", default-features = false, features = ["realtime"] }
-```
+For both features, promotion failures are non-fatal: the stream still starts and an `ErrorKind::RealtimeDenied` error is delivered through `error_callback`.
 
-For both features, promotion failures are non-fatal: the stream still starts and an
-`ErrorKind::RealtimeDenied` error is delivered through `error_callback`.
-
-**Impact:** In most cases no action is needed. If your `Cargo.toml` names `audio_thread_priority`
-explicitly, rename it to `realtime-dbus`. If you relied on the opt-out behavior, pass
-`default-features = false`.
-
-**Why:** Real-time scheduling is the correct default for audio applications. The previous opt-in
-made it easy to accidentally ship without it.
+**Impact:** Rename `audio_thread_priority` to `realtime-dbus` in your `Cargo.toml`. No other action is needed.
 
 ## 7. Streams are returned paused on every backend
 
-**What changed:** `build_input_stream` and `build_output_stream` now return a paused `Stream` on
-every backend. Previously, ALSA, CoreAudio, and JACK started the stream automatically.
+**What changed:** `build_input_stream` and `build_output_stream` now return a paused `Stream` on every backend. Previously, ALSA, CoreAudio, and JACK started the stream automatically.
 
 ```rust
 // Before (v0.17): on ALSA/CoreAudio/JACK the stream was already running
@@ -253,12 +219,9 @@ let stream = device.build_output_stream(config, data_fn, err_fn, None)?;
 stream.play()?;
 ```
 
-**Impact:** If you were targeting ALSA, CoreAudio, or JACK and never called `play()`, your
-callback will never fire after upgrading. Add the `play()` call.
+**Impact:** If you were targeting ALSA, CoreAudio, or JACK and never called `play()`, your callback will never fire after upgrading. Add the `play()` call.
 
-**Why:** Auto-starting before the caller has the `Stream` handle creates a window where data and
-error callbacks can fire before the application can pause, stop, or drop the stream. The behavior
-is now uniform across all backends.
+**Why:** Auto-starting before the caller has the `Stream` handle creates a window where data and error callbacks can fire before the application can pause, stop, or drop the stream. The behavior is now uniform across all backends.
 
 ## 8. `wasm32-unknown-emscripten` target removed
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -45,8 +45,12 @@ pub enum ErrorKind {
     /// [`DeviceNotAvailable`]: ErrorKind::DeviceNotAvailable
     PermissionDenied,
 
-    /// Real-time scheduling was requested for the audio callback thread but was not granted.
+    /// A real-time scheduling promotion attempt was explicitly refused.
     /// Audio will still play, but may be subject to increased latency or glitches under load.
+    ///
+    /// Absence of this error does **not** mean real-time scheduling is active: promotion may
+    /// not have been attempted (feature flag disabled, device ineligible, or the host manages
+    /// scheduling internally).
     RealtimeDenied,
 
     /// An OS resource limit was reached, such as a system or process thread or memory limit.
@@ -101,7 +105,7 @@ impl Display for ErrorKind {
                 "Permission denied. Grant the required access and retry.",
             ),
             Self::RealtimeDenied => f.write_str(
-                "Real-time scheduling was requested but not granted for the audio thread. \
+                "Real-time scheduling was refused for the audio thread. \
                  Audio may be subject to increased latency or glitches under load.",
             ),
             Self::ResourceExhausted => f.write_str(

--- a/src/host/alsa/mod.rs
+++ b/src/host/alsa/mod.rs
@@ -239,7 +239,6 @@ impl DeviceTrait for Device {
             error_callback,
             timeout,
         );
-        stream.signal_ready();
         Ok(stream)
     }
 
@@ -263,7 +262,6 @@ impl DeviceTrait for Device {
             error_callback,
             timeout,
         );
-        stream.signal_ready();
         Ok(stream)
     }
 }
@@ -412,15 +410,12 @@ impl Device {
         };
         drop(hw_params);
 
-        if let alsa::Direction::Capture = stream_type {
-            handle.start()?;
-        }
-
         let period_size = period_size as usize;
         let frame_size = sample_format.sample_size() * conf.channels as usize;
 
         let stream_inner = StreamInner {
             dropping: AtomicBool::new(false),
+            direction: stream_type.into(),
             handle,
             pcm_id: self.pcm_id.clone(),
             sample_format,
@@ -744,6 +739,9 @@ struct StreamInner {
     // (e.g. broken due to a disconnected device).
     dropping: AtomicBool,
 
+    // Stream direction.
+    direction: DeviceDirection,
+
     // The ALSA handle.
     handle: alsa::pcm::PCM,
 
@@ -796,8 +794,7 @@ pub struct Stream {
     /// `trigger.wakeup()` never writes to a closed pipe, even if the worker exited early.
     _rx: Arc<TriggerReceiver>,
 
-    /// Latch that prevents the worker thread from firing callbacks until the caller has received
-    /// the `Stream` handle.
+    /// Latch that blocks the worker thread until `play()` is called for the first time.
     latch: Latch,
 }
 
@@ -1295,7 +1292,6 @@ fn process_output(
             Err(err) => return Err(err.into()),
         }
     }
-
     Ok(())
 }
 
@@ -1324,7 +1320,7 @@ fn htstamp_elapsed(status: &alsa::pcm::Status, origin: libc::timespec) -> Stream
 
 impl Stream {
     /// Releases the latch so the worker thread can begin processing audio callbacks.
-    pub(crate) fn signal_ready(&self) {
+    fn signal_ready(&self) {
         self.latch.release();
     }
 
@@ -1342,8 +1338,8 @@ impl Stream {
         let rx_thread = rx.clone();
         let stream = inner.clone();
 
-        // The latch is released just before the `Stream` is returned so the worker cannot fire any
-        // callbacks before the caller has the handle.
+        // The latch is released by play(); the worker blocks here until then, keeping the PCM
+        // in PREPARED state with no DMA activity.
         let mut latch = Latch::new();
         let waiter = latch.waiter();
 
@@ -1385,8 +1381,8 @@ impl Stream {
         let rx_thread = rx.clone();
         let stream = inner.clone();
 
-        // The latch is released just before the `Stream` is returned so the worker cannot fire any
-        // callbacks before the caller has the handle.
+        // The latch is released by play(); the worker blocks here until then, keeping the PCM
+        // in PREPARED state with no DMA activity.
         let mut latch = Latch::new();
         let waiter = latch.waiter();
 
@@ -1417,8 +1413,8 @@ impl Stream {
 
 impl Drop for Stream {
     fn drop(&mut self) {
-        // Unblock the worker in case the stream is dropped before signal_ready() was
-        // called. Idempotent: no effect if the worker is already running.
+        // Unblock the worker in case the stream is dropped before play() was called.
+        // Idempotent: no effect if the worker is already running.
         self.signal_ready();
         self.inner.dropping.store(true, Ordering::Release);
         self.trigger.wakeup();
@@ -1430,8 +1426,16 @@ impl Drop for Stream {
 
 impl StreamTrait for Stream {
     fn play(&self) -> Result<(), Error> {
-        if self.inner.handle.state() == alsa::pcm::State::Paused {
-            self.inner.handle.pause(false)?;
+        self.signal_ready(); // idempotent: no-op after first call
+        match self.inner.handle.state() {
+            // Calling start() on an empty output buffer would trigger an immediate XRUN.
+            alsa::pcm::State::Prepared if self.inner.direction == DeviceDirection::Input => {
+                self.inner.handle.start()?;
+            }
+            alsa::pcm::State::Paused => {
+                self.inner.handle.pause(false)?;
+            }
+            _ => {}
         }
         Ok(())
     }
@@ -1447,6 +1451,7 @@ impl StreamTrait for Stream {
         if self.inner.handle.state() != alsa::pcm::State::Paused {
             self.inner.handle.pause(true)?;
         }
+        // TODO: when can_pause() is false, considering implementing a software fallback
         Ok(())
     }
 

--- a/src/host/alsa/mod.rs
+++ b/src/host/alsa/mod.rs
@@ -847,6 +847,36 @@ impl StreamInner {
             }
         }
     }
+
+    #[cfg(feature = "realtime")]
+    fn is_rt_eligible(&self) -> bool {
+        use alsa_sys::*;
+        // SAFETY: `alsa::pcm::PCM` is `pub struct PCM(*mut snd_pcm_t, Cell<bool>)`. The crate
+        // does not expose a public `as_ptr()`, but we can cast and read from it.
+        // TODO: replace with `self.handle.as_ptr()` once alsa-rs exposes it publicly.
+        let raw = unsafe {
+            (&self.handle as *const alsa::pcm::PCM)
+                .cast::<*mut snd_pcm_t>()
+                .read()
+        };
+        let pcm_type = unsafe { snd_pcm_type(raw) };
+
+        // Only attempt RT promotion for types known not to spin and not to chain to a
+        // server-backed backend. Therefore, we exclude:
+        // - NULL: always-ready poll() spins and exhausts RLIMIT_RTTIME, causing SIGXCPU.
+        // - IOPLUG/EXTPLUG: may route to PulseAudio, causing priority inversion and SIGXCPU.
+        // - HOOKS, SOFTVOL, PLUG, RATE, ROUTE, COPY: that can chain to either of the above.
+        matches!(
+            pcm_type,
+            SND_PCM_TYPE_HW
+                | SND_PCM_TYPE_LINEAR
+                | SND_PCM_TYPE_ALAW
+                | SND_PCM_TYPE_MULAW
+                | SND_PCM_TYPE_ADPCM
+                | SND_PCM_TYPE_LINEAR_FLOAT
+                | SND_PCM_TYPE_IEC958
+        )
+    }
 }
 
 struct StreamWorkerContext {
@@ -911,8 +941,14 @@ fn input_stream_worker(
     timeout: Option<Duration>,
 ) {
     #[cfg(feature = "realtime")]
-    if let Err(err) = boost_current_thread_priority(stream) {
-        error_callback(err);
+    if stream.is_rt_eligible() {
+        let period_frames = u32::try_from(stream.period_size).unwrap_or(0);
+        if let Err(err) = audio_thread_priority::promote_current_thread_to_real_time(
+            period_frames,
+            stream.sample_rate,
+        ) {
+            error_callback(err.into());
+        }
     }
 
     let mut ctxt = StreamWorkerContext::new(&timeout, stream, &rx);
@@ -962,8 +998,14 @@ fn output_stream_worker(
     timeout: Option<Duration>,
 ) {
     #[cfg(feature = "realtime")]
-    if let Err(err) = boost_current_thread_priority(stream) {
-        error_callback(err);
+    if stream.is_rt_eligible() {
+        let period_frames = u32::try_from(stream.period_size).unwrap_or(0);
+        if let Err(err) = audio_thread_priority::promote_current_thread_to_real_time(
+            period_frames,
+            stream.sample_rate,
+        ) {
+            error_callback(err.into());
+        }
     }
 
     let mut ctxt = StreamWorkerContext::new(&timeout, stream, &rx);
@@ -1005,61 +1047,6 @@ fn output_stream_worker(
             }
         }
     }
-}
-
-#[cfg(feature = "realtime")]
-fn boost_current_thread_priority(
-    stream: &StreamInner,
-) -> Result<audio_thread_priority::RtPriorityHandle, Error> {
-    use alsa_sys::*;
-    // SAFETY: `alsa::pcm::PCM` is `pub struct PCM(*mut snd_pcm_t, Cell<bool>)`. The crate
-    // does not expose a public `as_ptr()`, but we can cast and read from it.
-    // TODO: replace with `stream.handle.as_ptr()` once alsa-rs exposes it publicly.
-    let raw = unsafe {
-        (&stream.handle as *const alsa::pcm::PCM)
-            .cast::<*mut snd_pcm_t>()
-            .read()
-    };
-    let pcm_type = unsafe { snd_pcm_type(raw) };
-
-    // Only promote to RT for kernel-backed and pure-computation plugins. Others can exhaust
-    // RLIMIT_RTTIME when they block or coordinate with non-RT servers and trigger SIGXCPU
-    // on an RT thread. IOPLUG and EXTPLUG are excluded: no reliable way to distinguish
-    // RT-safe drivers (e.g. pipewire-alsa) from server-backed ones (e.g. pcm_pulse).
-    if !matches!(
-        pcm_type,
-        SND_PCM_TYPE_HW
-            | SND_PCM_TYPE_HOOKS
-            | SND_PCM_TYPE_NULL
-            | SND_PCM_TYPE_COPY
-            | SND_PCM_TYPE_LINEAR
-            | SND_PCM_TYPE_ALAW
-            | SND_PCM_TYPE_MULAW
-            | SND_PCM_TYPE_ADPCM
-            | SND_PCM_TYPE_RATE
-            | SND_PCM_TYPE_ROUTE
-            | SND_PCM_TYPE_PLUG
-            | SND_PCM_TYPE_LINEAR_FLOAT
-            | SND_PCM_TYPE_IEC958
-            | SND_PCM_TYPE_SOFTVOL
-    ) {
-        let type_name = unsafe {
-            std::ffi::CStr::from_ptr(snd_pcm_type_name(pcm_type))
-                .to_str()
-                .unwrap_or("unknown")
-        };
-        return Err(Error::with_message(
-            ErrorKind::RealtimeDenied,
-            format!(
-                "device '{}' ({type_name}) cannot be promoted to real-time priority",
-                stream.pcm_id,
-            ),
-        ));
-    }
-
-    let period_frames = u32::try_from(stream.period_size).unwrap_or(0);
-    audio_thread_priority::promote_current_thread_to_real_time(period_frames, stream.sample_rate)
-        .map_err(Error::from)
 }
 
 /// Attempt hardware resume from a suspend event (`ESTRPIPE`).

--- a/src/host/mod.rs
+++ b/src/host/mod.rs
@@ -189,7 +189,7 @@ pub(crate) mod error_emit;
 pub(crate) use error_emit::emit_error;
 #[cfg(any(
     target_vendor = "apple",
-    target_os = "android",
+    all(target_os = "android", feature = "realtime"),
     all(
         feature = "jack",
         any(

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -409,12 +409,12 @@ pub trait DeviceTrait: PartialEq + Eq + Hash + Debug + Display {
         E: FnMut(Error) + Send + 'static;
 }
 
-/// A stream created from [`Device`](DeviceTrait), with methods to control playback.
+/// A stream created from [`Device`](DeviceTrait), with methods to control it.
 pub trait StreamTrait {
-    /// Run the stream.
+    /// Start the stream.
     ///
-    /// Streams returned by `build_*_stream` are always paused, so `play` must be called before the
-    /// data callback will fire.
+    /// Streams returned by `build_*_stream` are always stopped, so `play` must be called before the
+    /// data callback will fire. Despite the name, this applies equally to input (capture) streams.
     ///
     /// # Errors
     ///
@@ -426,8 +426,8 @@ pub trait StreamTrait {
     /// [`ErrorKind::StreamInvalidated`]: crate::ErrorKind::StreamInvalidated
     fn play(&self) -> Result<(), Error>;
 
-    /// Some devices support pausing the audio stream. This can be useful for saving energy in
-    /// moments of silence.
+    /// Pause the stream. Some devices support suspending at the hardware level (saving energy);
+    /// others stop only the data callback while the hardware keeps running.
     ///
     /// Note: Not all devices support suspending the stream at the hardware level. This method may
     /// fail in these cases.


### PR DESCRIPTION
- ALSA was the last host to auto-start streams. This makes it uniform across all hosts that streams initially start paused (or in this case, "prepared").
- Reverted `realtime-dbus` as a default feature: keep default dependencies lean, keep features additive, don't unexpectedly segfault on OS-configuration issues, and err on the side of caution (see next point).
- ALSA PCMs that are not hardware-backed have a tendency to segfault with SIGXCPU. This cannot be detected exhaustively, so change the whitelist to what we can be sure about.