### PR TITLE
fix: clean up supported sample rates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed deprecated `DeviceTrait::name()`.
 - **ALSA**: `AlsaHost` is no longer re-exported from `cpal::platform`.
 - **Emscripten**: Removed broken host; use the WebAudio host instead.
+- **WASAPI**: Removed `U24` incorrectly listed as a supported sample format.
 
 ### Fixed
 
@@ -179,6 +180,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **CoreAudio**: Poisoned stream locks now return `ErrorKind::StreamInvalidated` instead of 
   panicking.
 - **CoreAudio**: Fix crashes on certain drivers due to early initialization.
+- **CoreAudio**: Fix `supported_output_configs()` and `supported_input_configs()` collapsing
+  non-continuous hardware rates into a continuous range of sample rates (regression since v0.17.0).
 - **JACK**: Fix input capture timestamp using callback execution time instead of cycle start.
 - **JACK**: Poisoned error callback mutex no longer silently drops subsequent error notifications.
 - **JACK**: Port registration failure now fails stream creation instead of silently failing.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -172,7 +172,7 @@ let config = device
 
 **What changed:** `default_input_config()` and `default_output_config()` now use a fully-ranked format ordering across all `SampleFormat` variants.
 
-Previously only `F32`, `I16`, and `U16` were explicitly ranked; all other formats compared as equal. On hosts that expose higher-precision formats, the default config may now return a different format than before. Likely candidates are `I32`, `I24`, or even `F64` if the device or plugin supports it.
+Previously only `F32`, `I16`, and `U16` were explicitly ranked; all other formats compared as equal. On hosts that expose higher-precision formats, the default config may now return a different format than before. Likely candidates are `I32` or `I24`.
 
 If your code assumes the default format is `F32`, request the format explicitly:
 
@@ -183,7 +183,7 @@ let configs = device
     .filter(|r| r.sample_format() == SampleFormat::F32);
 ```
 
-**Why:** The previous heuristic only explicitly ranked three formats, making selection unpredictable for any other format the device reported. The new ordering is complete and consistent: floats before integers (F64 > F32 for maximum fidelity), integers by bit-depth descending with signed above unsigned at each width, and DSD last.
+**Why:** The previous heuristic only explicitly ranked three formats, making selection unpredictable for any other format the device reported. The new ordering is complete and consistent: F32 first, then F64, integers by bit-depth descending with signed above unsigned at each width (I64 is deprioritised below I16 as an accumulator type), and DSD last.
 
 ## 6. `audio_thread_priority` feature renamed to `realtime-dbus`
 

--- a/src/host/coreaudio/macos/device.rs
+++ b/src/host/coreaudio/macos/device.rs
@@ -571,39 +571,19 @@ impl Device {
             }
             let buffer_size = get_io_buffer_frame_size_range(self.audio_device_id)?;
 
-            // Collect the supported formats for the device.
-
-            let contains_different_sample_rates = ranges.iter().any(|r| r.mMinimum != r.mMaximum);
-            if ranges.is_empty() {
-                Ok(vec![].into_iter())
-            } else if contains_different_sample_rates {
-                let res = ranges.iter().map(|range| SupportedStreamConfigRange {
+            // Most hardware reports discrete rates (mMinimum == mMaximum); some aggregate or
+            // virtual devices report continuous ranges.
+            let fmts: Vec<_> = ranges
+                .iter()
+                .map(|range| SupportedStreamConfigRange {
                     channels: n_channels as ChannelCount,
                     min_sample_rate: range.mMinimum as u32,
                     max_sample_rate: range.mMaximum as u32,
                     buffer_size,
                     sample_format,
-                });
-                Ok(res.collect::<Vec<_>>().into_iter())
-            } else {
-                let fmt = SupportedStreamConfigRange {
-                    channels: n_channels as ChannelCount,
-                    min_sample_rate: ranges
-                        .iter()
-                        .map(|v| v.mMinimum as u32)
-                        .min()
-                        .expect("the list must not be empty"),
-                    max_sample_rate: ranges
-                        .iter()
-                        .map(|v| v.mMaximum as u32)
-                        .max()
-                        .expect("the list must not be empty"),
-                    buffer_size,
-                    sample_format,
-                };
-
-                Ok(vec![fmt].into_iter())
-            }
+                })
+                .collect();
+            Ok(fmts.into_iter())
         }
     }
 

--- a/src/host/pulseaudio/mod.rs
+++ b/src/host/pulseaudio/mod.rs
@@ -24,7 +24,7 @@ use crate::{
 
 const INIT_TIMEOUT: Duration = Duration::from_secs(2);
 
-const MIN_SAMPLE_RATE: SampleRate = 8000;
+const MIN_SAMPLE_RATE: SampleRate = 1; // per `pa_sample_spec_valid()`
 
 const PULSE_FORMATS: &[SampleFormat] = &[
     SampleFormat::U8,

--- a/src/host/wasapi/device.rs
+++ b/src/host/wasapi/device.rs
@@ -654,29 +654,26 @@ impl Device {
                 }
             };
 
-            let mut sample_rates: Vec<SampleRate> = COMMON_SAMPLE_RATES.to_vec();
-
-            if !sample_rates.contains(&format.sample_rate) {
-                sample_rates.push(format.sample_rate)
-            }
-
-            let mut supported_formats = Vec::new();
-
             // Output streams use AUDCLNT_STREAMFLAGS_AUTOCONVERTPCM so Initialize accepts any
-            // PCM format regardless of what IsFormatSupported returns. Capture streams do not;
+            // format regardless of what IsFormatSupported returns. Capture streams do not;
             // only native formats will work.
             let is_output = self.data_flow() == Audio::eRender;
 
+            // For output, restrict to rates the MF Resampler can handle; for capture, probe all.
+            let mut sample_rates: Vec<SampleRate> = COMMON_SAMPLE_RATES
+                .iter()
+                .copied()
+                .filter(|&r| {
+                    !is_output || (OUTPUT_MIN_SAMPLE_RATE..=OUTPUT_MAX_SAMPLE_RATE).contains(&r)
+                })
+                .collect();
+            if !sample_rates.contains(&format.sample_rate) {
+                sample_rates.push(format.sample_rate);
+            }
+
+            let mut supported_formats = Vec::new();
             for sample_rate in sample_rates {
-                for sample_format in [
-                    SampleFormat::U8,
-                    SampleFormat::I16,
-                    SampleFormat::I24,
-                    SampleFormat::U24,
-                    SampleFormat::I32,
-                    SampleFormat::I64,
-                    SampleFormat::F32,
-                ] {
+                for sample_format in WAVEFORMATEXTENSIBLE_SAMPLE_FORMATS {
                     if let Some(waveformat) = config_to_waveformatextensible(
                         StreamConfig {
                             channels: format.channels,
@@ -697,7 +694,7 @@ impl Device {
                                 max_sample_rate: sample_rate,
                                 buffer_size: format.buffer_size,
                                 sample_format,
-                            })
+                            });
                         }
                     }
                 }
@@ -1294,6 +1291,22 @@ unsafe fn get_audio_clock(audio_client: &Audio::IAudioClient) -> Result<Audio::I
         .context("failed to get audio clock")
 }
 
+// Sample rate range supported by the Media Foundation Resampler MFT used by AUTOCONVERTPCM.
+const OUTPUT_MIN_SAMPLE_RATE: SampleRate = 8_000;
+const OUTPUT_MAX_SAMPLE_RATE: SampleRate = 384_000;
+
+// Formats encodable as WAVEFORMATEXTENSIBLE. U8/I16 map to WAVE_FORMAT_PCM; the rest use
+// WAVE_FORMAT_EXTENSIBLE. Unsigned formats wider than 8 bits are omitted: KSDATAFORMAT_SUBTYPE_PCM
+// is always signed for 16-bit and wider, so submitting unsigned data would produce a DC offset.
+const WAVEFORMATEXTENSIBLE_SAMPLE_FORMATS: [SampleFormat; 6] = [
+    SampleFormat::U8,
+    SampleFormat::I16,
+    SampleFormat::I24,
+    SampleFormat::I32,
+    SampleFormat::I64,
+    SampleFormat::F32,
+];
+
 // Turns a `Format` into a `WAVEFORMATEXTENSIBLE`.
 //
 // Returns `None` if the WAVEFORMATEXTENSIBLE does not support the given format.
@@ -1304,11 +1317,9 @@ fn config_to_waveformatextensible(
     let format_tag = match sample_format {
         SampleFormat::U8 | SampleFormat::I16 => Audio::WAVE_FORMAT_PCM,
 
-        SampleFormat::I24
-        | SampleFormat::U24
-        | SampleFormat::I32
-        | SampleFormat::I64
-        | SampleFormat::F32 => KernelStreaming::WAVE_FORMAT_EXTENSIBLE,
+        SampleFormat::I24 | SampleFormat::I32 | SampleFormat::I64 | SampleFormat::F32 => {
+            KernelStreaming::WAVE_FORMAT_EXTENSIBLE
+        }
 
         _ => return None,
     };
@@ -1318,8 +1329,7 @@ fn config_to_waveformatextensible(
     let avg_bytes_per_sec = u32::from(channels) * sample_rate * u32::from(sample_bytes);
     let block_align = channels * sample_bytes;
     let bits_per_sample = match sample_format {
-        // 24-bit formats use 32-bit storage but only 24 valid bits
-        SampleFormat::I24 | SampleFormat::U24 => 24,
+        SampleFormat::I24 => 24,
         _ => 8 * sample_bytes,
     };
 
@@ -1348,7 +1358,6 @@ fn config_to_waveformatextensible(
         SampleFormat::U8
         | SampleFormat::I16
         | SampleFormat::I24
-        | SampleFormat::U24
         | SampleFormat::I32
         | SampleFormat::I64 => KernelStreaming::KSDATAFORMAT_SUBTYPE_PCM,
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -727,9 +727,10 @@ impl SupportedStreamConfigRange {
     ///
     /// **Sample format** (most preferred first):
     ///
-    /// Float formats are preferred over integers. Within each category, formats are ranked by
-    /// bit-depth descending (higher is better), with signed integers ranked above unsigned at
-    /// the same width. DSD formats are ranked last as non-PCM.
+    /// F32 is ranked highest as the universal realtime audio format, followed by F64. Standard
+    /// integer widths descend by bit depth (I32 > I24 > I16); 64-bit integers are deprioritised
+    /// below I16 as accumulator types rather than native stream formats. Signed beats unsigned
+    /// at the same width. DSD ranks last as non-PCM.
     ///
     /// **Sample rate**:
     ///
@@ -754,22 +755,25 @@ impl SupportedStreamConfigRange {
             return cmp_channels;
         }
 
-        // Returns a (category, depth, signed) rank for a sample format.
-        fn format_rank(fmt: SampleFormat) -> (u8, u32, u8) {
-            let category = if fmt.is_float() {
-                2
-            } else if fmt.is_int() || fmt.is_uint() {
-                1
-            } else {
-                0
-            };
-            let depth = if fmt.is_dsd() {
-                fmt.sample_size() as u32
-            } else {
-                fmt.bits_per_sample()
-            };
-            let signed = u8::from(fmt.is_float() || fmt.is_int());
-            (category, depth, signed)
+        fn format_rank(fmt: SampleFormat) -> u8 {
+            match fmt {
+                SampleFormat::DsdU8 => 0,
+                SampleFormat::DsdU16 => 1,
+                SampleFormat::DsdU32 => 2,
+                SampleFormat::U8 => 3,
+                SampleFormat::I8 => 4,
+                // 64-bit integers: deprioritised below standard audio widths.
+                SampleFormat::U64 => 5,
+                SampleFormat::I64 => 6,
+                SampleFormat::U16 => 7,
+                SampleFormat::I16 => 8,
+                SampleFormat::U24 => 9,
+                SampleFormat::I24 => 10,
+                SampleFormat::U32 => 11,
+                SampleFormat::I32 => 12,
+                SampleFormat::F64 => 13,
+                SampleFormat::F32 => 14,
+            }
         }
 
         let cmp_format = format_rank(self.sample_format).cmp(&format_rank(other.sample_format));
@@ -875,7 +879,7 @@ fn test_cmp_default_heuristics_format_order() {
     // Expected order from lowest to highest priority:
     assert_eq!(
         sorted_formats,
-        vec![DsdU8, DsdU16, DsdU32, U8, I8, U16, I16, U24, I24, U32, I32, U64, I64, F32, F64,]
+        vec![DsdU8, DsdU16, DsdU32, U8, I8, U64, I64, U16, I16, U24, I24, U32, I32, F64, F32,]
     );
 }
 
@@ -892,7 +896,7 @@ fn test_cmp_default_heuristics() {
         make_range(2, SampleFormat::F32, 1, 44_100), // 44.1 kHz only
         make_range(2, SampleFormat::F32, 48_000, 96_000), // 48 kHz only
         make_range(2, SampleFormat::F32, 1, 96_000), // both standard rates
-        make_range(2, SampleFormat::F64, 1, 96_000), // F64; highest format priority
+        make_range(2, SampleFormat::F64, 1, 96_000),
     ];
 
     configs.sort_by(|a, b| a.cmp_default_heuristics(b));
@@ -910,24 +914,24 @@ fn test_cmp_default_heuristics() {
     assert_eq!(configs[4].sample_format(), SampleFormat::U16);
     assert_eq!(configs[5].sample_format(), SampleFormat::I16);
 
-    // [6]–[9] Stereo F32 entries ranked by rate coverage (F32 < F64).
-    assert_eq!(configs[6].sample_format(), SampleFormat::F32);
-    assert_eq!(configs[6].max_sample_rate(), 22_050); // neither standard rate
+    // [6] F64 is outranked by F32.
+    assert_eq!(configs[6].sample_format(), SampleFormat::F64);
+    assert_eq!(configs[6].channels(), 2);
 
+    // [7]–[10] Stereo F32 entries ranked by rate coverage.
     assert_eq!(configs[7].sample_format(), SampleFormat::F32);
-    assert_eq!(configs[7].max_sample_rate(), 44_100); // 44.1 kHz only
+    assert_eq!(configs[7].max_sample_rate(), 22_050); // neither standard rate
 
     assert_eq!(configs[8].sample_format(), SampleFormat::F32);
-    assert_eq!(configs[8].min_sample_rate(), 48_000); // 48 kHz only (no 44.1 kHz)
-    assert_eq!(configs[8].max_sample_rate(), 96_000);
+    assert_eq!(configs[8].max_sample_rate(), 44_100); // 44.1 kHz only
 
     assert_eq!(configs[9].sample_format(), SampleFormat::F32);
-    assert_eq!(configs[9].min_sample_rate(), 1);
-    assert_eq!(configs[9].max_sample_rate(), 96_000); // both standard rates
+    assert_eq!(configs[9].min_sample_rate(), 48_000); // 48 kHz only (no 44.1 kHz)
+    assert_eq!(configs[9].max_sample_rate(), 96_000);
 
-    // [10] F64 outranks all F32 entries regardless of rate coverage.
-    assert_eq!(configs[10].sample_format(), SampleFormat::F64);
-    assert_eq!(configs[10].channels(), 2);
+    assert_eq!(configs[10].sample_format(), SampleFormat::F32);
+    assert_eq!(configs[10].min_sample_rate(), 1);
+    assert_eq!(configs[10].max_sample_rate(), 96_000); // both standard rates
 }
 
 impl From<SupportedStreamConfig> for StreamConfig {


### PR DESCRIPTION
- Change default heuristics to prefer F32 over F64 and I64 (almost) last
- CoreAudio: do not collapse discrete sample ranges into a continuous range (reverts #926)
- PulseAudio: change minimum sample rate to 1 Hz per PA code
- WASAPI: remove `U24` support that was incorrectly advertised