### PR TITLE
feat: add Default impls and new() constructors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,17 +30,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   to select 48 kHz or 44.1 kHz from a range.
 - `realtime` feature for high-priority audio scheduling without a D-Bus build dependency.
 - Add `CODE_OF_CONDUCT.md`, `CONTRIBUTING.md` and `SECURITY.md`.
+- `BufferSize` now implements `Default` (returns `BufferSize::Default`).
 - **AAudio**: Streams now request `PERFORMANCE_MODE_LOW_LATENCY` when the `realtime` feature is
   enabled; stream error callback receives `ErrorKind::RealtimeDenied` if not granted.
 - **AAudio**: `Device` now implements `PartialEq`, `Eq`, `Hash`, and `Debug`.
+- **AAudio**: `Host` and `Device` now implement `Default`; added `Device::new()`.
 - **ALSA**: `device_by_id()` now accepts PCM shorthand names such as `hw:0,0` and `plughw:foo`.
 - **ASIO**: `Device` now implements `Debug`.
+- **AudioWorklet**: `Device` and `Host` now implement `Default`; added `Device::new()`.
+- **CoreAudio**: `Host` now implements `Default`.
 - **CoreAudio**: tvOS target support (Tier 3, requires nightly).
 - **CoreAudio**: `Device` now implements `PartialEq`, `Eq`, and `Hash`.
+- **CoreAudio (iOS)**: `Device` now implements `Default`; added `Device::new()`.
+- **Custom**: `SupportedBufferSize` now implements `Default` (returns
+  `SupportedBufferSize::Unknown`).
 - **JACK**: `Device` now implements `PartialEq`, `Eq`, and `Hash`.
+- **Null**: `Device`, `Host`, `Stream`, `SupportedInputConfigs`, and `SupportedOutputConfigs` now
+  implement `Default`, added `new()` on each.
 - **PipeWire**: New host for Linux and some BSDs using the PipeWire API.
 - **PulseAudio**: New host for Linux and some BSDs using the PulseAudio API.
 - **WASAPI**: `Device` now implements `PartialEq`, `Eq`, `Hash`, and `Debug`.
+- **WASAPI**: `Host` now implements `Default`.
+- **WebAudio**: `Device` and `Host` now implement `Default`; added `Device::new()`.
 
 ### Changed
 
@@ -178,6 +189,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **ASIO**: Fix `driver.sample_rate()` failures at stream creation being silently ignored.
 - **ASIO**: Fix callbacks firing before `build_*_stream` returns the `Stream` handle.
 - **ASIO**: Fix overrun not being reported when the driver reports `kAsioOverload`.
+- **AudioWorklet**: Fix `Devices::default()` to enumerate only if `Host::is_available()`.
 - **CoreAudio**: Fix default output streams silently stopping when the system default output
   device is unplugged; they now reroute automatically or report `ErrorKind::DeviceNotAvailable`.
 - **CoreAudio**: Fix undefined behaviour and silent failure in loopback device creation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `realtime` feature for high-priority audio scheduling without a D-Bus build dependency.
 - Add `CODE_OF_CONDUCT.md`, `CONTRIBUTING.md` and `SECURITY.md`.
 - `BufferSize` now implements `Default` (returns `BufferSize::Default`).
+- `SupportedStreamConfig` now implements `Copy`.
 - **AAudio**: Streams now request `PERFORMANCE_MODE_LOW_LATENCY` when the `realtime` feature is
   enabled; stream error callback receives `ErrorKind::RealtimeDenied` if not granted.
 - **AAudio**: `Device` now implements `PartialEq`, `Eq`, `Hash`, and `Debug`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `realtime` feature for high-priority audio scheduling without a D-Bus build dependency.
 - Add `CODE_OF_CONDUCT.md`, `CONTRIBUTING.md` and `SECURITY.md`.
 - `BufferSize` now implements `Default` (returns `BufferSize::Default`).
+- `SupportedBufferSize` now implements `Default` (returns `SupportedBufferSize::Unknown`).
 - `SupportedStreamConfig` now implements `Copy`.
 - **AAudio**: Streams now request `PERFORMANCE_MODE_LOW_LATENCY` when the `realtime` feature is
   enabled; stream error callback receives `ErrorKind::RealtimeDenied` if not granted.
@@ -43,8 +44,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **CoreAudio**: tvOS target support (Tier 3, requires nightly).
 - **CoreAudio**: `Device` now implements `PartialEq`, `Eq`, and `Hash`.
 - **CoreAudio (iOS)**: `Device` now implements `Default`; added `Device::new()`.
-- **Custom**: `SupportedBufferSize` now implements `Default` (returns
-  `SupportedBufferSize::Unknown`).
 - **JACK**: `Device` now implements `PartialEq`, `Eq`, and `Hash`.
 - **Null**: `Device`, `Host`, `Stream`, `SupportedInputConfigs`, and `SupportedOutputConfigs` now
   implement `Default`, added `new()` on each.

--- a/src/host/aaudio/java_interface/audio_features.rs
+++ b/src/host/aaudio/java_interface/audio_features.rs
@@ -9,7 +9,7 @@ use super::{
 /**
  * The Android audio features
  */
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy)]
 pub enum AudioFeature {
     LowLatency,
     Output,

--- a/src/host/aaudio/java_interface/definitions.rs
+++ b/src/host/aaudio/java_interface/definitions.rs
@@ -75,10 +75,11 @@ pub struct AudioDeviceInfo {
 /**
  * The type of audio device
  */
-#[derive(Debug, Clone, Copy, FromPrimitive)]
+#[derive(Debug, Clone, Copy, Default, FromPrimitive)]
 #[non_exhaustive]
 #[repr(i32)]
 pub enum AudioDeviceType {
+    #[default]
     Unknown = 0,
     AuxLine = 19,
     BleBroadcast = 30,

--- a/src/host/aaudio/mod.rs
+++ b/src/host/aaudio/mod.rs
@@ -121,9 +121,17 @@ const SAMPLE_RATES: [i32; 15] = [
 /// The same default for blocking operations as Oboe uses
 const DEFAULT_TIMEOUT_NANOS: i64 = 2_000_000_000;
 
+#[derive(Default)]
 pub struct Host;
-#[derive(Clone, Debug)]
+
+#[derive(Clone, Debug, Default)]
 pub struct Device(Option<AudioDeviceInfo>);
+
+impl Device {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
 
 /// Stream wraps AudioStream in Arc<Mutex<>> to provide Send + Sync semantics.
 ///
@@ -191,16 +199,16 @@ impl HostTrait for Host {
                 .collect::<Vec<_>>()
                 .into_iter())
         } else {
-            Ok(vec![Device(None)].into_iter())
+            Ok(vec![Device::new()].into_iter())
         }
     }
 
     fn default_input_device(&self) -> Option<Self::Device> {
-        Some(Device(None))
+        Some(Device::default())
     }
 
     fn default_output_device(&self) -> Option<Self::Device> {
-        Some(Device(None))
+        Some(Device::default())
     }
 }
 

--- a/src/host/alsa/mod.rs
+++ b/src/host/alsa/mod.rs
@@ -667,7 +667,7 @@ impl Default for Device {
 }
 
 /// Strategy for pre-filling an output buffer with the equilibrium value.
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Debug)]
 enum EquilibriumFill {
     /// Equilibrium is represented as a single repeating byte value.
     Byte(u8),
@@ -704,7 +704,7 @@ impl EquilibriumFill {
 }
 
 // How callback timestamps are produced.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum TimestampMode {
     // Hardware timestamps are unavailable (e.g. PulseAudio ALSA plugin returns zero htstamp).
     // Timestamps are monotonic elapsed time since stream creation, sourced from Instant::now().

--- a/src/host/asio/stream.rs
+++ b/src/host/asio/stream.rs
@@ -34,10 +34,6 @@ struct TimeBase {
 const TIMEGETIME_WRAP_NS: u64 = (u32::MAX as u64 + 1) * 1_000_000;
 
 impl TimeBase {
-    fn new() -> Self {
-        Self::default()
-    }
-
     /// Convert a nanosecond timestamp to a monotonic `StreamInstant`.
     fn to_stream_instant(&self, ns: u64) -> StreamInstant {
         // `Relaxed` is sufficient: callbacks run on a single ASIO thread. The only
@@ -58,9 +54,8 @@ impl TimeBase {
 const ASIO_EVENT_DEBOUNCE: Duration = Duration::from_millis(500);
 
 #[repr(u8)]
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 enum StreamState {
-    #[default]
     Starting = 0,
     Paused = 1,
     Playing = 2,
@@ -209,7 +204,7 @@ impl Device {
         let mut current_buffer_size = buffer_size as i32;
         let mut last_buffer_index: i32 = -1;
 
-        let time_base = Arc::new(TimeBase::new());
+        let time_base = Arc::new(TimeBase::default());
         let time_base_cb = Arc::clone(&time_base);
 
         // Set the input callback.
@@ -542,7 +537,7 @@ impl Device {
         let mut current_buffer_size = buffer_size as i32;
         let mut last_buffer_index: i32 = -1;
 
-        let time_base = Arc::new(TimeBase::new());
+        let time_base = Arc::new(TimeBase::default());
         let time_base_cb = Arc::clone(&time_base);
 
         let callback_id = driver.add_callback(move |callback_info| unsafe {

--- a/src/host/asio/stream.rs
+++ b/src/host/asio/stream.rs
@@ -24,6 +24,7 @@ use crate::{
 
 /// Shared state for extending the 32-bit `timeGetTime()` millisecond counter into a
 /// monotonic 64-bit nanosecond value, shared between `now()` and audio callbacks.
+#[derive(Default)]
 struct TimeBase {
     last_ns: AtomicU64,
     epoch_ns: AtomicU64,
@@ -34,10 +35,7 @@ const TIMEGETIME_WRAP_NS: u64 = (u32::MAX as u64 + 1) * 1_000_000;
 
 impl TimeBase {
     fn new() -> Self {
-        Self {
-            last_ns: AtomicU64::new(0),
-            epoch_ns: AtomicU64::new(0),
-        }
+        Self::default()
     }
 
     /// Convert a nanosecond timestamp to a monotonic `StreamInstant`.

--- a/src/host/asio/stream.rs
+++ b/src/host/asio/stream.rs
@@ -54,7 +54,7 @@ impl TimeBase {
 const ASIO_EVENT_DEBOUNCE: Duration = Duration::from_millis(500);
 
 #[repr(u8)]
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 enum StreamState {
     Starting = 0,
     Paused = 1,

--- a/src/host/audioworklet/mod.rs
+++ b/src/host/audioworklet/mod.rs
@@ -110,7 +110,7 @@ impl HostTrait for Host {
     }
 
     fn default_output_device(&self) -> Option<Self::Device> {
-        Some(Device::default())
+        Some(Device)
     }
 }
 
@@ -425,7 +425,7 @@ impl Iterator for Devices {
     fn next(&mut self) -> Option<Self::Item> {
         if self.0 {
             self.0 = false;
-            Some(Device::new())
+            Some(Device)
         } else {
             None
         }

--- a/src/host/audioworklet/mod.rs
+++ b/src/host/audioworklet/mod.rs
@@ -30,8 +30,14 @@ use crate::dependent_module;
 /// Content is false if the iterator is empty.
 pub struct Devices(bool);
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
 pub struct Device;
+
+impl Device {
+    pub fn new() -> Self {
+        Self
+    }
+}
 
 impl fmt::Display for Device {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -40,6 +46,7 @@ impl fmt::Display for Device {
     }
 }
 
+#[derive(Default)]
 pub struct Host;
 
 pub struct Stream {
@@ -103,7 +110,7 @@ impl HostTrait for Host {
     }
 
     fn default_output_device(&self) -> Option<Self::Device> {
-        Some(Device)
+        Some(Device::default())
     }
 }
 
@@ -408,7 +415,7 @@ impl Drop for Stream {
 
 impl Default for Devices {
     fn default() -> Self {
-        Self(true)
+        Self(Host::is_available())
     }
 }
 
@@ -418,7 +425,7 @@ impl Iterator for Devices {
     fn next(&mut self) -> Option<Self::Item> {
         if self.0 {
             self.0 = false;
-            Some(Device)
+            Some(Device::new())
         } else {
             None
         }

--- a/src/host/audioworklet/mod.rs
+++ b/src/host/audioworklet/mod.rs
@@ -110,7 +110,11 @@ impl HostTrait for Host {
     }
 
     fn default_output_device(&self) -> Option<Self::Device> {
-        Some(Device)
+        if Self::is_available() {
+            Some(Device)
+        } else {
+            None
+        }
     }
 }
 

--- a/src/host/coreaudio/ios/enumerate.rs
+++ b/src/host/coreaudio/ios/enumerate.rs
@@ -14,7 +14,7 @@ impl Devices {
 
 impl Default for Devices {
     fn default() -> Self {
-        Self(vec![Device::new()].into_iter())
+        Self(vec![Device].into_iter())
     }
 }
 
@@ -27,9 +27,9 @@ impl Iterator for Devices {
 }
 
 pub fn default_input_device() -> Option<Device> {
-    Some(Device::default())
+    Some(Device)
 }
 
 pub fn default_output_device() -> Option<Device> {
-    Some(Device::default())
+    Some(Device)
 }

--- a/src/host/coreaudio/ios/enumerate.rs
+++ b/src/host/coreaudio/ios/enumerate.rs
@@ -14,7 +14,7 @@ impl Devices {
 
 impl Default for Devices {
     fn default() -> Self {
-        Self(vec![Device].into_iter())
+        Self(vec![Device::new()].into_iter())
     }
 }
 
@@ -27,9 +27,9 @@ impl Iterator for Devices {
 }
 
 pub fn default_input_device() -> Option<Device> {
-    Some(Device)
+    Some(Device::default())
 }
 
 pub fn default_output_device() -> Option<Device> {
-    Some(Device)
+    Some(Device::default())
 }

--- a/src/host/coreaudio/ios/mod.rs
+++ b/src/host/coreaudio/ios/mod.rs
@@ -36,7 +36,7 @@ use session_event_manager::SessionEventManager;
 // These days the default of iOS is now F32 and no longer I16
 const SUPPORTED_SAMPLE_FORMAT: SampleFormat = SampleFormat::F32;
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
 pub struct Device;
 
 impl fmt::Display for Device {
@@ -46,6 +46,7 @@ impl fmt::Display for Device {
     }
 }
 
+#[derive(Default)]
 pub struct Host;
 
 impl Host {
@@ -76,6 +77,10 @@ impl HostTrait for Host {
 }
 
 impl Device {
+    pub fn new() -> Self {
+        Self
+    }
+
     fn description(&self) -> Result<DeviceDescription, Error> {
         // Query AVAudioSession to determine actual input/output availability
         // SAFETY: AVAudioSession::sharedInstance() returns the global audio session singleton

--- a/src/host/coreaudio/macos/device.rs
+++ b/src/host/coreaudio/macos/device.rs
@@ -214,7 +214,7 @@ fn set_sample_rate(
     Ok(())
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy)]
 enum AudioUnitMode {
     /// HAL Output AudioUnit with input enabled, pinned to a specific device.
     Input,

--- a/src/host/coreaudio/macos/mod.rs
+++ b/src/host/coreaudio/macos/mod.rs
@@ -25,7 +25,7 @@ mod property_listener;
 pub use device::Device;
 
 /// Coreaudio host, the default host on macOS.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct Host;
 
 impl Host {

--- a/src/host/jack/stream.rs
+++ b/src/host/jack/stream.rs
@@ -12,7 +12,7 @@ use crate::{
 };
 
 #[repr(u8)]
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 enum StreamState {
     Starting = 0,
     Paused = 1,

--- a/src/host/jack/stream.rs
+++ b/src/host/jack/stream.rs
@@ -12,9 +12,8 @@ use crate::{
 };
 
 #[repr(u8)]
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 enum StreamState {
-    #[default]
     Starting = 0,
     Paused = 1,
     Playing = 2,

--- a/src/host/null/mod.rs
+++ b/src/host/null/mod.rs
@@ -15,7 +15,7 @@ use crate::{
 #[derive(Default)]
 pub struct Devices;
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
 pub struct Device;
 
 impl fmt::Display for Device {
@@ -25,24 +25,49 @@ impl fmt::Display for Device {
     }
 }
 
+#[derive(Default)]
 pub struct Host;
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Hash)]
 pub struct Stream;
 
 // Compile-time assertion that Stream is Send and Sync
 crate::assert_stream_send!(Stream);
 crate::assert_stream_sync!(Stream);
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct SupportedInputConfigs;
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct SupportedOutputConfigs;
+
+impl Device {
+    pub fn new() -> Self {
+        Self
+    }
+}
 
 impl Host {
     #[allow(dead_code)]
     pub fn new() -> Result<Self, Error> {
         Ok(Self)
+    }
+}
+
+impl Stream {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl SupportedInputConfigs {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl SupportedOutputConfigs {
+    pub fn new() -> Self {
+        Self
     }
 }
 

--- a/src/host/pipewire/device.rs
+++ b/src/host/pipewire/device.rs
@@ -697,16 +697,9 @@ impl From<MetadataListener> for Request {
 }
 
 /// Per-node rate and quantum discovered during device enumeration.
-#[derive(Default)]
 struct NodeOverrides {
     rate: Option<SampleRate>,
     quantum: Option<FrameCount>,
-}
-
-impl NodeOverrides {
-    fn new() -> Self {
-        Self::default()
-    }
 }
 
 /// Parses a PipeWire fraction string like "1/48000" or "256/48000" into its parts.

--- a/src/host/pipewire/device.rs
+++ b/src/host/pipewire/device.rs
@@ -54,7 +54,7 @@ pub(crate) enum Class {
 }
 
 #[derive(Clone, Debug, Default, Copy)]
-pub enum Role {
+enum Role {
     #[default]
     Sink,
     Source,
@@ -668,7 +668,7 @@ impl DeviceTrait for Device {
     }
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Clone, Default)]
 struct Settings {
     rate: SampleRate,
     allow_rates: Box<[SampleRate]>,

--- a/src/host/pipewire/device.rs
+++ b/src/host/pipewire/device.rs
@@ -55,8 +55,8 @@ pub(crate) enum Class {
 
 #[derive(Clone, Debug, Default, Copy)]
 pub enum Role {
-    Sink,
     #[default]
+    Sink,
     Source,
     Duplex,
     StreamOutput,
@@ -697,9 +697,16 @@ impl From<MetadataListener> for Request {
 }
 
 /// Per-node rate and quantum discovered during device enumeration.
+#[derive(Default)]
 struct NodeOverrides {
     rate: Option<SampleRate>,
     quantum: Option<FrameCount>,
+}
+
+impl NodeOverrides {
+    fn new() -> Self {
+        Self::default()
+    }
 }
 
 /// Parses a PipeWire fraction string like "1/48000" or "256/48000" into its parts.

--- a/src/host/pipewire/stream.rs
+++ b/src/host/pipewire/stream.rs
@@ -82,7 +82,7 @@ pub struct Stream {
 }
 
 impl Stream {
-    pub(crate) fn new(
+    pub(super) fn new(
         handle: JoinHandle<()>,
         controller: pw::channel::Sender<StreamCommand>,
         last_quantum: Arc<AtomicU64>,

--- a/src/host/pipewire/stream.rs
+++ b/src/host/pipewire/stream.rs
@@ -68,8 +68,7 @@ impl Drop for PwInitGuard {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
-pub enum StreamCommand {
+pub(super) enum StreamCommand {
     Toggle(bool),
     Stop,
 }

--- a/src/host/wasapi/mod.rs
+++ b/src/host/wasapi/mod.rs
@@ -23,7 +23,7 @@ mod stream;
 /// Note: If you use a WASAPI output device as an input device it will
 /// transparently enable loopback mode (see
 /// https://docs.microsoft.com/en-us/windows/win32/coreaudio/loopback-recording).
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct Host;
 
 impl Host {

--- a/src/host/webaudio/mod.rs
+++ b/src/host/webaudio/mod.rs
@@ -37,7 +37,7 @@ type ClosureHandle = Arc<RwLock<Option<Closure<dyn FnMut()>>>>;
 /// Content is false if the iterator is empty.
 pub struct Devices(bool);
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
 pub struct Device;
 
 impl fmt::Display for Device {
@@ -47,6 +47,7 @@ impl fmt::Display for Device {
     }
 }
 
+#[derive(Default)]
 pub struct Host;
 
 pub struct Stream {
@@ -112,6 +113,10 @@ impl Devices {
 }
 
 impl Device {
+    pub fn new() -> Self {
+        Self
+    }
+
     fn description(&self) -> Result<DeviceDescription, Error> {
         Ok(DeviceDescriptionBuilder::new("Default Device")
             .direction(DeviceDirection::Output)
@@ -634,7 +639,7 @@ impl Iterator for Devices {
     fn next(&mut self) -> Option<Self::Item> {
         if self.0 {
             self.0 = false;
-            Some(Device)
+            Some(Device::new())
         } else {
             None
         }
@@ -648,7 +653,7 @@ fn default_input_device() -> Option<Device> {
 
 fn default_output_device() -> Option<Device> {
     if is_webaudio_available() {
-        Some(Device)
+        Some(Device::default())
     } else {
         None
     }

--- a/src/host/webaudio/mod.rs
+++ b/src/host/webaudio/mod.rs
@@ -639,7 +639,7 @@ impl Iterator for Devices {
     fn next(&mut self) -> Option<Self::Item> {
         if self.0 {
             self.0 = false;
-            Some(Device::new())
+            Some(Device)
         } else {
             None
         }
@@ -653,7 +653,7 @@ fn default_input_device() -> Option<Device> {
 
 fn default_output_device() -> Option<Device> {
     if is_webaudio_available() {
-        Some(Device::default())
+        Some(Device)
     } else {
         None
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -368,8 +368,9 @@ impl std::str::FromStr for DeviceId {
 /// [`BufferSize::Fixed(x)`]: BufferSize::Fixed
 /// [`SupportedBufferSize`]: SupportedStreamConfig::buffer_size
 /// [`SupportedStreamConfig`]: SupportedStreamConfig
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub enum BufferSize {
+    #[default]
     Default,
     Fixed(FrameCount),
 }
@@ -420,7 +421,7 @@ pub struct StreamConfig {
 }
 
 /// Describes the minimum and maximum supported buffer size for the device
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub enum SupportedBufferSize {
     Range {
         min: FrameCount,
@@ -428,6 +429,7 @@ pub enum SupportedBufferSize {
     },
     /// In the case that the platform provides no way of getting the default
     /// buffer size before starting a stream.
+    #[default]
     Unknown,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -471,7 +471,7 @@ pub(crate) mod iter {
 /// Describes a single supported stream configuration, retrieved via either a
 /// [`SupportedStreamConfigRange`] instance or one of the
 /// [`Device::default_input/output_config`](traits::DeviceTrait#required-methods) methods.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SupportedStreamConfig {
     channels: ChannelCount,
     sample_rate: SampleRate,


### PR DESCRIPTION
As I noticed PipeWire had a curious choice of `#[default]` `Roles`, I did a sweep across all hosts to implement `Default` where it makes sense, add a `new()` constructor where idiomatic, and check the sanity of existing `Default` implementations.

These are not defined on the trait, so use it for platform-specific convenience rather than expecting it works cross-platform (it doesn't).

Additionally, tidy up the derives particularly on non-public types in order to reduce compile times.