### PR TITLE
feat: process-unique client names in PulseAudio and PipeWire

### DIFF
--- a/src/host/pipewire/stream.rs
+++ b/src/host/pipewire/stream.rs
@@ -560,7 +560,11 @@ where
     };
     let channels = config.channels as _;
     let rate = config.sample_rate as _;
-    let stream = pw::stream::StreamRc::new(core.clone(), "cpal-playback", properties)?;
+    let stream = pw::stream::StreamRc::new(
+        core.clone(),
+        &format!("cpal-playback-{}", std::process::id()),
+        properties,
+    )?;
 
     let listener = stream
         .add_local_listener_with_user_data(data)
@@ -802,7 +806,11 @@ where
 
     let channels = config.channels as _;
     let rate = config.sample_rate as _;
-    let stream = pw::stream::StreamRc::new(core.clone(), "cpal-capture", properties)?;
+    let stream = pw::stream::StreamRc::new(
+        core.clone(),
+        &format!("cpal-capture-{}", std::process::id()),
+        properties,
+    )?;
     let listener = stream
         .add_local_listener_with_user_data(data)
         .param_changed(move |stream, user_data, id, param| {

--- a/src/host/pulseaudio/mod.rs
+++ b/src/host/pulseaudio/mod.rs
@@ -1,4 +1,5 @@
 use std::{
+    ffi::CString,
     fmt,
     hash::{Hash, Hasher},
     mem::discriminant,
@@ -135,7 +136,8 @@ impl Host {
         // returns, fall through to the next host with no other option than to leak the thread.
         let (tx, rx) = mpsc::channel();
         std::thread::spawn(move || {
-            let _ = tx.send(pulseaudio::Client::from_env(c"cpal-pulseaudio"));
+            let name = CString::new(format!("cpal-pulseaudio-{}", std::process::id())).unwrap();
+            let _ = tx.send(pulseaudio::Client::from_env(&name));
         });
         let client = rx
             .recv_timeout(INIT_TIMEOUT)


### PR DESCRIPTION
When multiple cpal processes are running, this is the only way to discern between them in tools like `pw-top` or `pavucontrol`.