### PR TITLE
feat: require Device to be Send+Sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `DeviceTrait` and `StreamTrait` now require `Send + Sync` as supertrait bounds.
 - `assert_stream_send!` and `assert_stream_sync!` are deprecated; `StreamTrait: Send + Sync` makes them redundant.
 
+### Fixed
+
+- **AudioWorklet**: Fix `Stream` operations to work when called from any thread.
+
 ## [0.18.0] - YYYY-MM-DD
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `DeviceTrait` and `StreamTrait` now require `Send + Sync` as supertrait bounds.
+- `assert_stream_send!` and `assert_stream_sync!` are deprecated; `StreamTrait: Send + Sync` makes them redundant.
+
 ## [0.18.0] - YYYY-MM-DD
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ asio = [
 # Requires: Build with atomics support and Cross-Origin headers for SharedArrayBuffer
 # Platform: WebAssembly (wasm32-unknown-unknown)
 audioworklet = [
+    "dep:futures",
     "wasm-bindgen",
     "web-sys/Blob",
     "web-sys/BlobPropertyBag",
@@ -177,6 +178,7 @@ objc2-avf-audio = { version = "0.3", default-features = false, features = [
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
 wasm-bindgen = { version = "0.2", optional = true }
 wasm-bindgen-futures = { version = "0.4", optional = true }
+futures = { version = "0.3", optional = true }
 js-sys = { version = "0.3" }
 web-sys = { version = "0.3", features = [
     "AudioContext",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,8 @@ asio = [
 # Requires: Build with atomics support and Cross-Origin headers for SharedArrayBuffer
 # Platform: WebAssembly (wasm32-unknown-unknown)
 audioworklet = [
-    "dep:futures",
+    "dep:futures-channel",
+    "dep:futures-util",
     "wasm-bindgen",
     "web-sys/Blob",
     "web-sys/BlobPropertyBag",
@@ -73,7 +74,7 @@ pipewire = ["dep:pipewire"]
 # Provides audio I/O support on Linux and some BSDs using the PulseAudio sound server
 # Requires: PulseAudio server and client libraries installed on the system
 # Platform: Linux, DragonFly BSD, FreeBSD, NetBSD
-pulseaudio = ["dep:pulseaudio", "dep:futures"]
+pulseaudio = ["dep:pulseaudio", "dep:futures-executor", "dep:futures-util"]
 
 # WebAssembly backend using wasm-bindgen
 # Enables the Web Audio API backend for browser-based audio
@@ -124,7 +125,8 @@ libc = "0.2"
 audio_thread_priority = { version = "0.35", optional = true, default-features = false }
 jack = { version = "0.13", optional = true }
 pulseaudio = { version = "0.3", optional = true }
-futures = { version = "0.3", optional = true }
+futures-executor = { version = "0.3", optional = true }
+futures-util = { version = "0.3", default-features = false, optional = true, features = ["alloc"] }
 pipewire = { version = "0.10", optional = true, features = ["v0_3_53"] }
 
 [target.'cfg(target_vendor = "apple")'.dependencies]
@@ -178,7 +180,8 @@ objc2-avf-audio = { version = "0.3", default-features = false, features = [
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
 wasm-bindgen = { version = "0.2", optional = true }
 wasm-bindgen-futures = { version = "0.4", optional = true }
-futures = { version = "0.3", optional = true }
+futures-channel = { version = "0.3", optional = true }
+futures-util = { version = "0.3", default-features = false, optional = true, features = ["alloc"] }
 js-sys = { version = "0.3" }
 web-sys = { version = "0.3", features = [
     "AudioContext",

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,3 +1,22 @@
+# Upgrading from v0.18 to v0.19
+
+This guide covers breaking changes requiring code updates. See [CHANGELOG.md](CHANGELOG.md) for the complete list of changes and improvements.
+
+## Breaking Changes Checklist
+
+- [ ] If you implement a custom host, ensure your `Device` and `Stream` types are `Send + Sync`.
+- [ ] Remove any calls to the deprecated `assert_stream_send!` and `assert_stream_sync!` macros.
+
+## 1. `DeviceTrait` and `StreamTrait` require `Send + Sync`
+
+**What changed:** `DeviceTrait` and `StreamTrait` now declare `Send + Sync` as supertrait bounds.
+
+This only affects authors of `custom` host implementations. Users of built-in hosts are unaffected.
+
+**Impact:** Remove any `assert_stream_send!` and `assert_stream_sync!` calls from your custom host; they are now deprecated. If your `Device` or `Stream` type contains raw pointers or other non-`Send`/non-`Sync` internals (e.g. COM handles, JS objects), audit that concurrent access is actually safe, then add `unsafe impl Send` and `unsafe impl Sync`.
+
+---
+
 # Upgrading from v0.17 to v0.18
 
 This guide covers breaking changes requiring code updates. See [CHANGELOG.md](CHANGELOG.md) for the complete list of changes and improvements.

--- a/src/host/aaudio/mod.rs
+++ b/src/host/aaudio/mod.rs
@@ -148,10 +148,6 @@ unsafe impl Send for Stream {}
 // All operations on the stream go through the mutex, ensuring exclusive access.
 unsafe impl Sync for Stream {}
 
-// Compile-time assertion that Stream is Send and Sync
-crate::assert_stream_send!(Stream);
-crate::assert_stream_sync!(Stream);
-
 /// State for dynamic buffer tuning on output streams.
 #[derive(Default)]
 struct BufferTuningState {

--- a/src/host/alsa/mod.rs
+++ b/src/host/alsa/mod.rs
@@ -745,10 +745,6 @@ pub struct Stream {
     latch: Latch,
 }
 
-// Compile-time assertion that Stream is Send and Sync
-crate::assert_stream_send!(Stream);
-crate::assert_stream_sync!(Stream);
-
 impl StreamInner {
     #[inline]
     fn callback_instant(&self, status: &alsa::pcm::Status) -> StreamInstant {

--- a/src/host/asio/stream.rs
+++ b/src/host/asio/stream.rs
@@ -84,10 +84,6 @@ pub struct Stream {
     time_base: Arc<TimeBase>,
 }
 
-// Compile-time assertion that Stream is Send and Sync
-crate::assert_stream_send!(Stream);
-crate::assert_stream_sync!(Stream);
-
 impl Stream {
     pub fn now(&self) -> StreamInstant {
         // `ASIOTimeInfo::systemTime` is specified by the ASIO SDK as nanoseconds

--- a/src/host/audioworklet/mod.rs
+++ b/src/host/audioworklet/mod.rs
@@ -12,7 +12,8 @@ use std::{
     time::Duration,
 };
 
-use futures::{channel::mpsc, StreamExt as _};
+use futures_channel::mpsc;
+use futures_util::StreamExt as _;
 use js_sys::wasm_bindgen;
 use wasm_bindgen::prelude::*;
 
@@ -256,7 +257,13 @@ impl DeviceTrait for Device {
     /// initialization succeeds, then the queued commands take effect; if it fails they are
     /// discarded and the error is delivered to `error_callback`.
     ///
+    /// [`now`](crate::traits::StreamTrait::now) returns the scheduled time of the last rendered
+    /// audio frame, seeded from [`AudioContext::current_time`] at construction. While the stream
+    /// is paused, this value does not advance. This is consistent with the [`AudioContext`] clock,
+    /// which also freezes when paused.
+    ///
     /// [`AudioContext`]: web_sys::AudioContext
+    /// [`AudioContext::current_time`]: https://developer.mozilla.org/en-US/docs/Web/API/BaseAudioContext/currentTime
     /// [`AudioWorkletNode`]: web_sys::AudioWorkletNode
     fn build_output_stream_raw<D, E>(
         &self,

--- a/src/host/audioworklet/mod.rs
+++ b/src/host/audioworklet/mod.rs
@@ -465,6 +465,10 @@ impl StreamTrait for Stream {
     }
 }
 
+// SAFETY: `AudioContext` is only accessed from the thread that created the `Stream`.
+unsafe impl Send for Stream {}
+unsafe impl Sync for Stream {}
+
 impl Drop for Stream {
     fn drop(&mut self) {
         let _ = self.audio_context.close();

--- a/src/host/audioworklet/mod.rs
+++ b/src/host/audioworklet/mod.rs
@@ -12,6 +12,7 @@ use std::{
     time::Duration,
 };
 
+use futures::{channel::mpsc, StreamExt as _};
 use js_sys::wasm_bindgen;
 use wasm_bindgen::prelude::*;
 
@@ -43,7 +44,8 @@ impl fmt::Display for Device {
 pub struct Host;
 
 pub struct Stream {
-    audio_context: web_sys::AudioContext,
+    command_tx: mpsc::UnboundedSender<Command>,
+    current_time_bits: Arc<AtomicU64>,
     buffer_size_frames: Arc<AtomicU64>,
 }
 
@@ -86,6 +88,11 @@ fn supported_render_quantum_range(sample_rate: SampleRate) -> SupportedBufferSiz
             max: DEFAULT_RENDER_SIZE as FrameCount,
         }
     }
+}
+
+enum Command {
+    Play,
+    Pause,
 }
 
 impl Host {
@@ -244,6 +251,11 @@ impl DeviceTrait for Device {
     /// delivered to `error_callback` after the caller already holds a [`Stream`]. There is no
     /// way to surface such errors synchronously given the Web Audio API's design.
     ///
+    /// [`play`](crate::traits::StreamTrait::play) and [`pause`](crate::traits::StreamTrait::pause)
+    /// calls made before initialization completes return `Ok` immediately and are queued. If
+    /// initialization succeeds, then the queued commands take effect; if it fails they are
+    /// discarded and the error is delivered to `error_callback`.
+    ///
     /// [`AudioContext`]: web_sys::AudioContext
     /// [`AudioWorkletNode`]: web_sys::AudioWorkletNode
     fn build_output_stream_raw<D, E>(
@@ -346,6 +358,13 @@ impl DeviceTrait for Device {
         });
         let buffer_size_frames = Arc::new(AtomicU64::new(initial_quantum));
         let buffer_size_frames_cb = buffer_size_frames.clone();
+
+        let current_time_bits = Arc::new(AtomicU64::new(audio_context.current_time().to_bits()));
+        let current_time_bits_cb = current_time_bits.clone();
+        let current_time_bits_init = current_time_bits.clone();
+
+        let (command_tx, mut command_rx) = mpsc::unbounded::<Command>();
+
         let ctx = audio_context.clone();
         wasm_bindgen_futures::spawn_local(async move {
             let result: Result<(), JsValue> = async move {
@@ -389,6 +408,7 @@ impl DeviceTrait for Device {
                     &WasmAudioProcessor::new(Box::new(
                         move |interleaved_data, frame_size, sample_rate, now| {
                             buffer_size_frames_cb.store(frame_size as u64, Ordering::Relaxed);
+                            current_time_bits_cb.store(now.to_bits(), Ordering::Relaxed);
                             let data = interleaved_data.as_mut_ptr() as *mut ();
                             let mut data = unsafe {
                                 Data::from_parts(data, interleaved_data.len(), sample_format)
@@ -421,15 +441,46 @@ impl DeviceTrait for Device {
                 let message = err
                     .as_string()
                     .unwrap_or_else(|| "Failed to initialize audio worklet".to_string());
-                error_callback(Error::with_message(
-                    ErrorKind::UnsupportedOperation,
-                    message,
-                ))
+                error_callback(Error::with_message(ErrorKind::HostUnavailable, message));
+
+                // Close AudioContext and exit; dropping command_rx closes the channel,
+                // so subsequent play()/pause() calls return HostUnavailable.
+                let _ = audio_context.close();
+                return;
             }
+
+            current_time_bits_init.store(audio_context.current_time().to_bits(), Ordering::Relaxed);
+
+            // Process play/pause commands from any thread until Stream is dropped.
+            // Dropping Stream closes command_tx, which terminates this loop.
+            while let Some(cmd) = command_rx.next().await {
+                match cmd {
+                    Command::Play => {
+                        if audio_context.resume().is_err() {
+                            error_callback(Error::with_message(
+                                ErrorKind::DeviceNotAvailable,
+                                "Failed to resume audio context",
+                            ));
+                        }
+                    }
+                    Command::Pause => {
+                        if audio_context.suspend().is_err() {
+                            error_callback(Error::with_message(
+                                ErrorKind::DeviceNotAvailable,
+                                "Failed to suspend audio context",
+                            ));
+                        }
+                    }
+                }
+            }
+
+            // Stream dropped: close the AudioContext on the main thread.
+            let _ = audio_context.close();
         });
 
         Ok(Self::Stream {
-            audio_context,
+            command_tx,
+            current_time_bits,
             buffer_size_frames,
         })
     }
@@ -441,37 +492,27 @@ impl StreamTrait for Stream {
     }
 
     fn play(&self) -> Result<(), Error> {
-        match self.audio_context.resume() {
-            Ok(_) => Ok(()),
-            Err(_) => Err(Error::with_message(
-                ErrorKind::DeviceNotAvailable,
-                "Failed to resume audio context",
-            )),
-        }
+        self.command_tx.unbounded_send(Command::Play).map_err(|_| {
+            Error::with_message(
+                ErrorKind::HostUnavailable,
+                "audio worklet initialization failed",
+            )
+        })
     }
 
     fn pause(&self) -> Result<(), Error> {
-        match self.audio_context.suspend() {
-            Ok(_) => Ok(()),
-            Err(_) => Err(Error::with_message(
-                ErrorKind::DeviceNotAvailable,
-                "Failed to suspend audio context",
-            )),
-        }
+        self.command_tx.unbounded_send(Command::Pause).map_err(|_| {
+            Error::with_message(
+                ErrorKind::HostUnavailable,
+                "audio worklet initialization failed",
+            )
+        })
     }
 
     fn now(&self) -> StreamInstant {
-        StreamInstant::from_secs_f64(self.audio_context.current_time())
-    }
-}
-
-// SAFETY: `AudioContext` is only accessed from the thread that created the `Stream`.
-unsafe impl Send for Stream {}
-unsafe impl Sync for Stream {}
-
-impl Drop for Stream {
-    fn drop(&mut self) {
-        let _ = self.audio_context.close();
+        StreamInstant::from_secs_f64(f64::from_bits(
+            self.current_time_bits.load(Ordering::Relaxed),
+        ))
     }
 }
 

--- a/src/host/coreaudio/mod.rs
+++ b/src/host/coreaudio/mod.rs
@@ -23,6 +23,7 @@ pub use self::ios::{
     Device, Host, Stream,
 };
 #[cfg(target_os = "macos")]
+#[allow(unused_imports)]
 pub use self::macos::{Host, Stream};
 
 // Common helper methods used by both macOS and iOS
@@ -137,7 +138,3 @@ impl From<coreaudio::Error> for Error {
 }
 
 pub(crate) type OSStatus = i32;
-
-// Compile-time assertion that Stream is Send and Sync
-crate::assert_stream_send!(Stream);
-crate::assert_stream_sync!(Stream);

--- a/src/host/custom/mod.rs
+++ b/src/host/custom/mod.rs
@@ -38,10 +38,9 @@ impl Host {
     pub fn from_host<T>(host: T) -> Self
     where
         T: HostTrait + Send + Sync + 'static,
-        T::Device: Send + Sync + Clone,
+        T::Device: Clone,
         <T::Device as DeviceTrait>::SupportedInputConfigs: Clone,
         <T::Device as DeviceTrait>::SupportedOutputConfigs: Clone,
-        <T::Device as DeviceTrait>::Stream: Send + Sync,
     {
         Self(Box::new(host))
     }
@@ -72,10 +71,9 @@ impl Device {
     /// Construct a custom device from an arbitrary [`DeviceTrait`] implementation.
     pub fn from_device<T>(device: T) -> Self
     where
-        T: DeviceTrait + Send + Sync + Clone + 'static,
+        T: DeviceTrait + Clone + 'static,
         T::SupportedInputConfigs: Clone,
         T::SupportedOutputConfigs: Clone,
-        T::Stream: Send + Sync,
     {
         Self(Box::new(device))
     }
@@ -123,7 +121,7 @@ impl Stream {
     /// Construct a custom stream from an arbitrary [`StreamTrait`] implementation.
     pub fn from_stream<T>(stream: T) -> Self
     where
-        T: StreamTrait + Send + Sync + 'static,
+        T: StreamTrait + 'static,
     {
         Self(Box::new(stream))
     }
@@ -241,7 +239,7 @@ fn supported_configs_to_erased(
     SupportedConfigs(Box::new(i))
 }
 
-fn stream_to_erased(s: impl StreamTrait + Send + Sync + 'static) -> Stream {
+fn stream_to_erased(s: impl StreamTrait + 'static) -> Stream {
     Stream(Box::new(s))
 }
 
@@ -329,7 +327,7 @@ where
 
 impl<T> StreamErased for T
 where
-    T: StreamTrait + Send + Sync,
+    T: StreamTrait,
 {
     fn play(&self) -> Result<(), Error> {
         <T as StreamTrait>::play(self)

--- a/src/host/jack/stream.rs
+++ b/src/host/jack/stream.rs
@@ -41,10 +41,6 @@ pub struct Stream {
     output_port_names: Box<[String]>,
 }
 
-// Compile-time assertion that Stream is Send and Sync
-crate::assert_stream_send!(Stream);
-crate::assert_stream_sync!(Stream);
-
 impl Stream {
     pub fn new_input<D, E>(
         client: jack::Client,

--- a/src/host/null/mod.rs
+++ b/src/host/null/mod.rs
@@ -29,10 +29,6 @@ pub struct Host;
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Stream;
 
-// Compile-time assertion that Stream is Send and Sync
-crate::assert_stream_send!(Stream);
-crate::assert_stream_sync!(Stream);
-
 #[derive(Clone)]
 pub struct SupportedInputConfigs;
 #[derive(Clone)]

--- a/src/host/pulseaudio/mod.rs
+++ b/src/host/pulseaudio/mod.rs
@@ -7,7 +7,7 @@ use std::{
     time::Duration,
 };
 
-use futures::executor::block_on;
+use futures_executor::block_on;
 use pulseaudio::protocol;
 
 mod stream;

--- a/src/host/pulseaudio/stream.rs
+++ b/src/host/pulseaudio/stream.rs
@@ -6,8 +6,8 @@ use std::{
     time::{Duration, Instant},
 };
 
-use futures::executor::block_on;
-use futures::FutureExt as _;
+use futures_executor::block_on;
+use futures_util::FutureExt as _;
 use pulseaudio::{protocol, AsPlaybackSource};
 
 use crate::{

--- a/src/host/wasapi/stream.rs
+++ b/src/host/wasapi/stream.rs
@@ -239,10 +239,6 @@ unsafe impl Send for Stream {}
 // The audio thread owns all COM objects, so no cross-thread COM access occurs.
 unsafe impl Sync for Stream {}
 
-// Compile-time assertion that Stream is Send and Sync
-crate::assert_stream_send!(Stream);
-crate::assert_stream_sync!(Stream);
-
 struct RunContext {
     // Streams that have been created in this event loop.
     stream: StreamInner,

--- a/src/host/webaudio/mod.rs
+++ b/src/host/webaudio/mod.rs
@@ -61,10 +61,6 @@ pub struct Stream {
 unsafe impl Send for Stream {}
 unsafe impl Sync for Stream {}
 
-// Compile-time assertion that Stream is Send and Sync
-crate::assert_stream_send!(Stream);
-crate::assert_stream_sync!(Stream);
-
 pub use crate::iter::{SupportedInputConfigs, SupportedOutputConfigs};
 
 // https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-createbuffer

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -109,7 +109,7 @@ pub trait HostTrait {
 ///
 /// Please note that `Device`s may become invalid if they get disconnected. Therefore, all the
 /// methods that involve a device return a `Result` allowing the user to handle this case.
-pub trait DeviceTrait: PartialEq + Eq + Hash + Debug + Display {
+pub trait DeviceTrait: PartialEq + Eq + Hash + Debug + Display + Send + Sync {
     /// The iterator type yielding supported input stream formats.
     type SupportedInputConfigs: Iterator<Item = SupportedStreamConfigRange>;
     /// The iterator type yielding supported output stream formats.
@@ -410,7 +410,7 @@ pub trait DeviceTrait: PartialEq + Eq + Hash + Debug + Display {
 }
 
 /// A stream created from [`Device`](DeviceTrait), with methods to control it.
-pub trait StreamTrait {
+pub trait StreamTrait: Send + Sync {
     /// Start the stream.
     ///
     /// Streams returned by `build_*_stream` are always stopped, so `play` must be called before the
@@ -481,17 +481,7 @@ pub trait StreamTrait {
 }
 
 /// Compile-time assertion that a stream type implements [`Send`].
-///
-/// Custom host implementations should use this macro to verify their `Stream` type
-/// can be safely transferred between threads, as required by CPAL's API.
-///
-/// # Example
-///
-/// ```
-/// use cpal::assert_stream_send;
-/// struct MyStream { /* ... */ }
-/// assert_stream_send!(MyStream);
-/// ```
+#[deprecated(since = "0.19.0", note = "StreamTrait now requires Send + Sync")]
 #[macro_export]
 macro_rules! assert_stream_send {
     ($t:ty) => {
@@ -501,17 +491,7 @@ macro_rules! assert_stream_send {
 }
 
 /// Compile-time assertion that a stream type implements [`Sync`].
-///
-/// Custom host implementations should use this macro to verify their `Stream` type
-/// can be safely shared between threads, as required by CPAL's API.
-///
-/// # Example
-///
-/// ```
-/// use cpal::assert_stream_sync;
-/// struct MyStream { /* ... */ }
-/// assert_stream_sync!(MyStream);
-/// ```
+#[deprecated(since = "0.19.0", note = "StreamTrait now requires Send + Sync")]
 #[macro_export]
 macro_rules! assert_stream_sync {
     ($t:ty) => {

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -2,8 +2,8 @@
 //!
 //! # Custom Host Implementations
 //!
-//! When implementing custom hosts with the `custom` feature, use the [`assert_stream_send!`](crate::assert_stream_send)
-//! and [`assert_stream_sync!`](crate::assert_stream_sync) macros to verify your `Stream` type meets CPAL's requirements.
+//! When implementing custom hosts with the `custom` feature, your `Device` type must implement
+//! [`DeviceTrait`] and your `Stream` type must implement [`StreamTrait`].
 
 use std::{
     fmt::{Debug, Display},


### PR DESCRIPTION
Also refactors the `Stream` assertions for `Send + Sync` bounds.

Fixes #435 