### PR TITLE
fix(webaudio): resolve issues with atomics support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **AudioWorklet**: Fix `Stream` operations to work when called from any thread.
 - **WebAudio**: Fix unsound `Send + Sync` on `Stream` when compiled with `+atomics`.
 - **WebAudio**: Fix `Host::is_available()` always returning `true`, even in non-window contexts.
-- **WebAudio**: Fix `Host::new()` succeeding even when WebAudio is unavailable.
 
 ## [0.18.0] - YYYY-MM-DD
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **AudioWorklet**: Fix `Stream` operations to work when called from any thread.
+- **WebAudio**: Fix unsound `Send + Sync` on `Stream` when compiled with `+atomics`.
+- **WebAudio**: Fix `Host::is_available()` always returning `true`, even in non-window contexts.
+- **WebAudio**: Fix `Host::new()` succeeding even when WebAudio is unavailable.
 
 ## [0.18.0] - YYYY-MM-DD
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,25 +31,22 @@ realtime-dbus = ["realtime", "audio_thread_priority/with_dbus"]
 # Provides low-latency audio I/O by bypassing the Windows audio stack
 # Requires: ASIO drivers and LLVM/Clang for build-time bindings
 # See README for detailed setup instructions
-asio = [
-    "dep:asio-sys",
-    "dep:num-traits",
-]
+asio = ["dep:asio-sys", "dep:num-traits"]
 
 # Audio Worklet backend for WebAssembly
 # Provides lower-latency web audio processing compared to default Web Audio API
 # Requires: Build with atomics support and Cross-Origin headers for SharedArrayBuffer
 # Platform: WebAssembly (wasm32-unknown-unknown)
 audioworklet = [
-    "dep:futures-channel",
-    "dep:futures-util",
-    "wasm-bindgen",
-    "web-sys/Blob",
-    "web-sys/BlobPropertyBag",
-    "web-sys/Url",
-    "web-sys/AudioWorklet",
-    "web-sys/AudioWorkletNode",
-    "web-sys/AudioWorkletNodeOptions",
+  "dep:futures-channel",
+  "dep:futures-util",
+  "wasm-bindgen",
+  "web-sys/Blob",
+  "web-sys/BlobPropertyBag",
+  "web-sys/Url",
+  "web-sys/AudioWorklet",
+  "web-sys/AudioWorkletNode",
+  "web-sys/AudioWorkletNodeOptions",
 ]
 
 # Support for user-defined custom hosts, devices, and streams
@@ -81,7 +78,12 @@ pulseaudio = ["dep:pulseaudio", "dep:futures-executor", "dep:futures-util"]
 # Required for any WebAssembly audio support
 # Platform: WebAssembly (wasm32-unknown-unknown)
 # Note: This is typically enabled automatically when targeting wasm32
-wasm-bindgen = ["dep:wasm-bindgen", "dep:wasm-bindgen-futures"]
+wasm-bindgen = [
+  "dep:wasm-bindgen",
+  "dep:wasm-bindgen-futures",
+  "dep:futures-channel",
+  "dep:futures-util",
+]
 
 [dependencies]
 dasp_sample = "0.11"
@@ -99,19 +101,19 @@ clap = { version = "4.6", features = ["derive"] }
 [target.'cfg(target_os = "windows")'.dependencies]
 windows-core = { version = ">=0.61, <=0.62" }
 windows = { version = ">=0.61, <=0.62", features = [
-    "Win32_Media",
-    "Win32_Media_Audio",
-    "Win32_Foundation",
-    "Win32_Devices_Properties",
-    "Win32_Media_KernelStreaming",
-    "Win32_System_Com_StructuredStorage",
-    "Win32_System_Threading",
-    "Win32_System_Performance",
-    "Win32_Security",
-    "Win32_System_SystemServices",
-    "Win32_System_Variant",
-    "Win32_Media_Multimedia",
-    "Win32_UI_Shell_PropertiesSystem",
+  "Win32_Media",
+  "Win32_Media_Audio",
+  "Win32_Foundation",
+  "Win32_Devices_Properties",
+  "Win32_Media_KernelStreaming",
+  "Win32_System_Com_StructuredStorage",
+  "Win32_System_Threading",
+  "Win32_System_Performance",
+  "Win32_Security",
+  "Win32_System_SystemServices",
+  "Win32_System_Variant",
+  "Win32_Media_Multimedia",
+  "Win32_UI_Shell_PropertiesSystem",
 ] }
 audio_thread_priority = { version = "0.35", optional = true, default-features = false }
 asio-sys = { version = "0.4.0", path = "asio-sys", optional = true }
@@ -126,37 +128,39 @@ audio_thread_priority = { version = "0.35", optional = true, default-features = 
 jack = { version = "0.13", optional = true }
 pulseaudio = { version = "0.3", optional = true }
 futures-executor = { version = "0.3", optional = true }
-futures-util = { version = "0.3", default-features = false, optional = true, features = ["alloc"] }
+futures-util = { version = "0.3", default-features = false, optional = true, features = [
+  "alloc",
+] }
 pipewire = { version = "0.10", optional = true, features = ["v0_3_53"] }
 
 [target.'cfg(target_vendor = "apple")'.dependencies]
 mach2 = "0.6"
 coreaudio-rs = { version = "0.14.2", default-features = false, features = [
-    "core_audio",
-    "audio_toolbox",
+  "core_audio",
+  "audio_toolbox",
 ] }
 objc2-core-audio = { version = "0.3", default-features = false, features = [
-    "std",
-    "AudioHardware",
-    "AudioHardwareDeprecated",
-    "objc2",
-    "objc2-foundation",
+  "std",
+  "AudioHardware",
+  "AudioHardwareDeprecated",
+  "objc2",
+  "objc2-foundation",
 ] }
 objc2-audio-toolbox = { version = "0.3", default-features = false, features = [
-    "std",
-    "AUComponent",
-    "AudioUnitProperties",
+  "std",
+  "AUComponent",
+  "AudioUnitProperties",
 ] }
 objc2-core-audio-types = { version = "0.3", default-features = false, features = [
-    "std",
-    "CoreAudioBaseTypes",
+  "std",
+  "CoreAudioBaseTypes",
 ] }
 objc2-core-foundation = { version = "0.3" }
 objc2-foundation = { version = "0.3", default-features = false, features = [
-    "std",
-    "NSArray",
-    "NSString",
-    "NSValue",
+  "std",
+  "NSArray",
+  "NSString",
+  "NSValue",
 ] }
 objc2 = { version = "0.6" }
 
@@ -166,39 +170,41 @@ jack = { version = "0.13", optional = true }
 [target.'cfg(any(target_os = "ios", target_os = "tvos"))'.dependencies]
 block2 = "0.6"
 objc2-foundation = { version = "0.3", features = [
-    "block2",
-    "NSDictionary",
-    "NSNotification",
-    "NSOperation",
+  "block2",
+  "NSDictionary",
+  "NSNotification",
+  "NSOperation",
 ] }
 objc2-avf-audio = { version = "0.3", default-features = false, features = [
-    "std",
-    "AVAudioSession",
-    "AVAudioSessionTypes",
+  "std",
+  "AVAudioSession",
+  "AVAudioSessionTypes",
 ] }
 
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
 wasm-bindgen = { version = "0.2", optional = true }
 wasm-bindgen-futures = { version = "0.4", optional = true }
 futures-channel = { version = "0.3", optional = true }
-futures-util = { version = "0.3", default-features = false, optional = true, features = ["alloc"] }
+futures-util = { version = "0.3", default-features = false, optional = true, features = [
+  "alloc",
+] }
 js-sys = { version = "0.3" }
 web-sys = { version = "0.3", features = [
-    "AudioContext",
-    "AudioContextOptions",
-    "AudioBuffer",
-    "AudioBufferSourceNode",
-    "AudioNode",
-    "AudioDestinationNode",
-    "Window",
-    "AudioContextState",
+  "AudioContext",
+  "AudioContextOptions",
+  "AudioBuffer",
+  "AudioBufferSourceNode",
+  "AudioNode",
+  "AudioDestinationNode",
+  "Window",
+  "AudioContextState",
 ] }
 
 [target.'cfg(target_os = "android")'.dependencies]
 audio_thread_priority = { version = "0.35", optional = true, default-features = false }
 ndk = { version = "0.9", default-features = false, features = [
-    "audio",
-    "api-level-26",
+  "audio",
+  "api-level-26",
 ] }
 ndk-context = "0.1"
 jni = "0.22"
@@ -225,14 +231,14 @@ name = "synth_tones"
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 targets = [
-    "x86_64-unknown-linux-gnu",
-    "x86_64-pc-windows-msvc",
-    "x86_64-apple-darwin",
-    "aarch64-apple-darwin",
-    "aarch64-apple-ios",
-    "wasm32-unknown-unknown",
-    "aarch64-linux-android",
-    "x86_64-unknown-freebsd",
-    "x86_64-unknown-netbsd",
-    "x86_64-unknown-dragonfly",
+  "x86_64-unknown-linux-gnu",
+  "x86_64-pc-windows-msvc",
+  "x86_64-apple-darwin",
+  "aarch64-apple-darwin",
+  "aarch64-apple-ios",
+  "wasm32-unknown-unknown",
+  "aarch64-linux-android",
+  "x86_64-unknown-freebsd",
+  "x86_64-unknown-netbsd",
+  "x86_64-unknown-dragonfly",
 ]

--- a/src/host/webaudio/mod.rs
+++ b/src/host/webaudio/mod.rs
@@ -6,6 +6,8 @@ extern crate js_sys;
 extern crate wasm_bindgen;
 extern crate web_sys;
 
+#[cfg(target_feature = "atomics")]
+use std::sync::atomic::AtomicU64;
 use std::{
     fmt,
     ops::DerefMut,
@@ -15,6 +17,11 @@ use std::{
     },
     time::Duration,
 };
+
+#[cfg(target_feature = "atomics")]
+use futures_channel::mpsc;
+#[cfg(target_feature = "atomics")]
+use futures_util::StreamExt as _;
 
 type OutputDataCallbackArc = Arc<Mutex<dyn FnMut(&mut Data, &OutputCallbackInfo) + Send>>;
 
@@ -34,6 +41,12 @@ use crate::{
 /// Type alias for shared closure handles used in audio callbacks
 type ClosureHandle = Arc<RwLock<Option<Closure<dyn FnMut()>>>>;
 
+#[cfg(target_feature = "atomics")]
+enum Command {
+    Play,
+    Pause,
+}
+
 /// Content is false if the iterator is empty.
 pub struct Devices(bool);
 
@@ -50,16 +63,31 @@ impl fmt::Display for Device {
 pub struct Host;
 
 pub struct Stream {
-    ctx: Arc<AudioContext>,
-    on_ended_closures: Vec<ClosureHandle>,
     config: StreamConfig,
     buffer_size_frames: usize,
+
+    // Single-threaded WASM: hold JS types directly. Safe because there is only one thread.
+    #[cfg(not(target_feature = "atomics"))]
+    ctx: Arc<AudioContext>,
+    #[cfg(not(target_feature = "atomics"))]
+    on_ended_closures: Vec<ClosureHandle>,
+    #[cfg(not(target_feature = "atomics"))]
     is_started: Arc<AtomicBool>,
+
+    // Multi-threaded WASM (+atomics): all fields are Send+Sync; JS types are held in a
+    // spawn_local task that runs on the main thread.
+    #[cfg(target_feature = "atomics")]
+    command_tx: mpsc::UnboundedSender<Command>,
+    #[cfg(target_feature = "atomics")]
+    current_time_bits: Arc<AtomicU64>,
 }
 
-// WASM runs in a single-threaded environment, so Send and Sync are safe by design.
+// Without atomics, WASM is single-threaded, so there are no thread boundaries to cross.
+#[cfg(not(target_feature = "atomics"))]
 unsafe impl Send for Stream {}
+#[cfg(not(target_feature = "atomics"))]
 unsafe impl Sync for Stream {}
+// With atomics, all Stream fields auto-derive Send+Sync.
 
 pub use crate::iter::{SupportedInputConfigs, SupportedOutputConfigs};
 
@@ -76,9 +104,20 @@ const SUPPORTED_SAMPLE_FORMAT: SampleFormat = SampleFormat::F32;
 
 const DEFAULT_BUFFER_SIZE: usize = 2048;
 
+// Minimum initial timer delay mandated by the HTML spec.
+// https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#timers
+const INITIAL_TIMEOUT_MS: i32 = 4;
+
 impl Host {
     pub fn new() -> Result<Self, Error> {
-        Ok(Self)
+        if Self::is_available() {
+            Ok(Self)
+        } else {
+            Err(Error::with_message(
+                ErrorKind::HostUnavailable,
+                "WebAudio is not available",
+            ))
+        }
     }
 }
 
@@ -87,8 +126,7 @@ impl HostTrait for Host {
     type Device = Device;
 
     fn is_available() -> bool {
-        // Assume this host is always available on webaudio.
-        true
+        is_webaudio_available()
     }
 
     fn devices(&self) -> Result<Self::Devices, Error> {
@@ -106,7 +144,7 @@ impl HostTrait for Host {
 
 impl Devices {
     fn new() -> Result<Self, Error> {
-        Ok(Devices(is_webaudio_available()))
+        Ok(Devices(Host::is_available()))
     }
 }
 
@@ -281,6 +319,8 @@ impl DeviceTrait for Device {
 
         let data_callback: OutputDataCallbackArc = Arc::new(Mutex::new(data_callback));
         let error_callback: ErrorCallbackArc = Arc::new(Mutex::new(error_callback));
+
+        #[cfg(not(target_feature = "atomics"))]
         let is_started = Arc::new(AtomicBool::new(false));
 
         // Create the WebAudio stream.
@@ -307,7 +347,9 @@ impl DeviceTrait for Device {
         }
         destination.set_channel_count(config.channels as u32);
 
-        // SAFETY: WASM is single-threaded, so Arc is safe even though AudioContext is not Send/Sync
+        // SAFETY: AudioContext and Closure are not Send/Sync, but these Arcs are created on the
+        // main thread and never leave it: in the non-atomics path WASM is single-threaded, and in
+        // the atomics path they are moved into a spawn_local task which also runs on the main thread.
         #[allow(clippy::arc_with_non_send_sync)]
         let ctx = Arc::new(ctx);
 
@@ -323,6 +365,10 @@ impl DeviceTrait for Device {
             .and_then(|v| v.as_f64())
             .unwrap_or(0.0);
 
+        // Shared current-time counter updated on every callback invocation.
+        #[cfg(target_feature = "atomics")]
+        let current_time_bits = Arc::new(AtomicU64::new(0u64));
+
         // Create a set of closures / callbacks which will continuously fetch and schedule sample
         // playback. Starting with two workers, e.g. a front and back buffer so that audio frames
         // can be fetched in the background.
@@ -331,6 +377,9 @@ impl DeviceTrait for Device {
             let error_callback_handle = error_callback.clone();
             let ctx_handle = ctx.clone();
             let time_handle = time.clone();
+
+            #[cfg(target_feature = "atomics")]
+            let current_time_bits_handle = current_time_bits.clone();
 
             // A set of temporary buffers to be used for intermediate sample transformation steps.
             let mut temporary_buffer = vec![0f32; buffer_size_samples];
@@ -361,7 +410,6 @@ impl DeviceTrait for Device {
                 })?;
 
             // A self reference to this closure for passing to future audio event calls.
-            // SAFETY: WASM is single-threaded, so Arc is safe even though Closure is not Send/Sync
             #[allow(clippy::arc_with_non_send_sync)]
             let on_ended_closure: ClosureHandle = Arc::new(RwLock::new(None));
             let on_ended_closure_handle = on_ended_closure.clone();
@@ -371,6 +419,11 @@ impl DeviceTrait for Device {
                 .unwrap()
                 .replace(Closure::wrap(Box::new(move || {
                     let now = ctx_handle.current_time();
+
+                    // Keep the shared clock up to date so Stream::now() has a fresh value.
+                    #[cfg(target_feature = "atomics")]
+                    current_time_bits_handle.store(now.to_bits(), Ordering::Relaxed);
+
                     let time_at_start_of_buffer = {
                         let time_at_start_of_buffer = time_handle
                             .read()
@@ -557,16 +610,70 @@ impl DeviceTrait for Device {
             on_ended_closures.push(on_ended_closure);
         }
 
-        Ok(Self::Stream {
+        #[cfg(not(target_feature = "atomics"))]
+        return Ok(Self::Stream {
             ctx,
             on_ended_closures,
             config,
             buffer_size_frames,
             is_started,
-        })
+        });
+
+        #[cfg(target_feature = "atomics")]
+        {
+            let current_time_bits_stream = current_time_bits.clone();
+            let (command_tx, mut command_rx) = mpsc::unbounded::<Command>();
+            wasm_bindgen_futures::spawn_local(async move {
+                let window = web_sys::window().unwrap();
+                let mut started = false;
+                while let Some(cmd) = command_rx.next().await {
+                    match cmd {
+                        Command::Play => {
+                            if !started {
+                                started = true;
+                                schedule_initial_timeouts(
+                                    &window,
+                                    &on_ended_closures,
+                                    buffer_size_frames,
+                                    config.sample_rate,
+                                );
+                            }
+                            if ctx.resume().is_err() {
+                                error_callback.lock().unwrap_or_else(|e| e.into_inner())(
+                                    Error::with_message(
+                                        ErrorKind::DeviceNotAvailable,
+                                        "Failed to resume audio context",
+                                    ),
+                                );
+                            }
+                        }
+                        Command::Pause => {
+                            if ctx.suspend().is_err() {
+                                error_callback.lock().unwrap_or_else(|e| e.into_inner())(
+                                    Error::with_message(
+                                        ErrorKind::DeviceNotAvailable,
+                                        "Failed to suspend audio context",
+                                    ),
+                                );
+                            }
+                        }
+                    }
+                }
+                // Stream dropped: close the AudioContext on the main thread.
+                let _ = ctx.close();
+            });
+            Ok(Self::Stream {
+                command_tx,
+                current_time_bits: current_time_bits_stream,
+                buffer_size_frames,
+                config,
+            })
+        }
     }
 }
 
+// Without atomics: AudioContext is accessible directly from Stream.
+#[cfg(not(target_feature = "atomics"))]
 impl Stream {
     /// Return the [`AudioContext`](https://developer.mozilla.org/docs/Web/API/AudioContext) used
     /// by this stream.
@@ -577,59 +684,62 @@ impl Stream {
 
 impl StreamTrait for Stream {
     fn play(&self) -> Result<(), Error> {
-        let window = web_sys::window().unwrap();
-        match self.ctx.resume() {
-            Ok(_) => {
-                // Only schedule the initial timeouts once.
-                if self
-                    .is_started
-                    .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
-                    .is_err()
-                {
-                    return Ok(());
+        #[cfg(not(target_feature = "atomics"))]
+        {
+            let window = web_sys::window().unwrap();
+            match self.ctx.resume() {
+                Ok(_) => {
+                    // Only schedule the initial timeouts once.
+                    if self
+                        .is_started
+                        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+                        .is_err()
+                    {
+                        return Ok(());
+                    }
+                    schedule_initial_timeouts(
+                        &window,
+                        &self.on_ended_closures,
+                        self.buffer_size_frames,
+                        self.config.sample_rate,
+                    );
+                    Ok(())
                 }
-                // Begin webaudio playback, initially scheduling the closures to fire on a timeout
-                // event. Minimum value as per spec: https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#timers
-                let mut offset_ms = 4;
-                let time_step_secs =
-                    buffer_time_step_secs(self.buffer_size_frames, self.config.sample_rate);
-                let time_step_ms = ((time_step_secs * 1_000.0).ceil() as i32).max(1);
-                for on_ended_closure in self.on_ended_closures.iter() {
-                    window
-                        .set_timeout_with_callback_and_timeout_and_arguments_0(
-                            on_ended_closure
-                                .read()
-                                .unwrap()
-                                .as_ref()
-                                .unwrap()
-                                .as_ref()
-                                .unchecked_ref(),
-                            offset_ms,
-                        )
-                        .unwrap();
-                    offset_ms += time_step_ms;
-                }
-                Ok(())
+                Err(_) => Err(Error::with_message(
+                    ErrorKind::DeviceNotAvailable,
+                    "Failed to resume audio context",
+                )),
             }
-            Err(_) => Err(Error::with_message(
-                ErrorKind::DeviceNotAvailable,
-                "Failed to resume audio context",
-            )),
         }
+        #[cfg(target_feature = "atomics")]
+        self.command_tx.unbounded_send(Command::Play).map_err(|_| {
+            Error::with_message(ErrorKind::DeviceNotAvailable, "Stream has been dropped")
+        })
     }
 
     fn pause(&self) -> Result<(), Error> {
-        match self.ctx.suspend() {
-            Ok(_) => Ok(()),
-            Err(_) => Err(Error::with_message(
-                ErrorKind::DeviceNotAvailable,
-                "Failed to suspend audio context",
-            )),
+        #[cfg(not(target_feature = "atomics"))]
+        {
+            match self.ctx.suspend() {
+                Ok(_) => Ok(()),
+                Err(_) => Err(Error::with_message(
+                    ErrorKind::DeviceNotAvailable,
+                    "Failed to suspend audio context",
+                )),
+            }
         }
+        #[cfg(target_feature = "atomics")]
+        self.command_tx.unbounded_send(Command::Pause).map_err(|_| {
+            Error::with_message(ErrorKind::DeviceNotAvailable, "Stream has been dropped")
+        })
     }
 
     fn now(&self) -> StreamInstant {
-        StreamInstant::from_secs_f64(self.ctx.current_time())
+        #[cfg(not(target_feature = "atomics"))]
+        let t = self.ctx.current_time();
+        #[cfg(target_feature = "atomics")]
+        let t = f64::from_bits(self.current_time_bits.load(Ordering::Relaxed));
+        StreamInstant::from_secs_f64(t)
     }
 
     fn buffer_size(&self) -> Result<FrameCount, Error> {
@@ -637,11 +747,15 @@ impl StreamTrait for Stream {
     }
 }
 
+// Without atomics: close the AudioContext synchronously on drop.
+#[cfg(not(target_feature = "atomics"))]
 impl Drop for Stream {
     fn drop(&mut self) {
         let _ = self.ctx.close();
     }
 }
+// With atomics: dropping `command_tx` closes the channel, which signals the
+// spawn_local task to call ctx.close() on the main thread.
 
 impl Iterator for Devices {
     type Item = Device;
@@ -662,22 +776,51 @@ fn default_input_device() -> Option<Device> {
 }
 
 fn default_output_device() -> Option<Device> {
-    if is_webaudio_available() {
+    if Host::is_available() {
         Some(Device)
     } else {
         None
     }
 }
 
-// Detects whether the `AudioContext` global variable is available.
+// Detects whether WebAudio is available: requires a window context (not a Worker) with an
+// AudioContext constructor present.
 fn is_webaudio_available() -> bool {
-    js_sys::Reflect::get(&js_sys::global(), &JsValue::from("AudioContext"))
-        .unwrap()
-        .is_truthy()
+    web_sys::window()
+        .and_then(|w| js_sys::Reflect::get(w.as_ref(), &JsValue::from("AudioContext")).ok())
+        .is_some_and(|v| v.is_truthy())
 }
 
 fn buffer_time_step_secs(buffer_size_frames: usize, sample_rate: SampleRate) -> f64 {
     buffer_size_frames as f64 / sample_rate as f64
+}
+
+/// Stagger the initial `setTimeout` kicks for the double-buffer pair so the two closures
+/// don't fire at the same instant on the first tick.
+fn schedule_initial_timeouts(
+    window: &web_sys::Window,
+    on_ended_closures: &[ClosureHandle],
+    buffer_size_frames: usize,
+    sample_rate: SampleRate,
+) {
+    let time_step_secs = buffer_time_step_secs(buffer_size_frames, sample_rate);
+    let time_step_ms = ((time_step_secs * 1_000.0).ceil() as i32).max(1);
+    let mut offset_ms = INITIAL_TIMEOUT_MS;
+    for on_ended_closure in on_ended_closures {
+        window
+            .set_timeout_with_callback_and_timeout_and_arguments_0(
+                on_ended_closure
+                    .read()
+                    .unwrap()
+                    .as_ref()
+                    .unwrap()
+                    .as_ref()
+                    .unchecked_ref(),
+                offset_ms,
+            )
+            .unwrap();
+        offset_ms += time_step_ms;
+    }
 }
 
 #[cfg(target_feature = "atomics")]

--- a/src/host/webaudio/mod.rs
+++ b/src/host/webaudio/mod.rs
@@ -11,12 +11,12 @@ use std::sync::atomic::AtomicU64;
 use std::{
     fmt,
     ops::DerefMut,
-    sync::{
-        Arc, Mutex, RwLock,
-        atomic::{AtomicBool, Ordering},
-    },
+    sync::{Arc, Mutex, RwLock, atomic::Ordering},
     time::Duration,
 };
+
+#[cfg(not(target_feature = "atomics"))]
+use std::sync::atomic::AtomicBool;
 
 #[cfg(target_feature = "atomics")]
 use futures_channel::mpsc;
@@ -63,10 +63,11 @@ impl fmt::Display for Device {
 pub struct Host;
 
 pub struct Stream {
-    config: StreamConfig,
     buffer_size_frames: usize,
 
     // Single-threaded WASM: hold JS types directly. Safe because there is only one thread.
+    #[cfg(not(target_feature = "atomics"))]
+    config: StreamConfig,
     #[cfg(not(target_feature = "atomics"))]
     ctx: Arc<AudioContext>,
     #[cfg(not(target_feature = "atomics"))]
@@ -666,7 +667,6 @@ impl DeviceTrait for Device {
                 command_tx,
                 current_time_bits: current_time_bits_stream,
                 buffer_size_frames,
-                config,
             })
         }
     }

--- a/src/host/webaudio/mod.rs
+++ b/src/host/webaudio/mod.rs
@@ -75,8 +75,8 @@ pub struct Stream {
     #[cfg(not(target_feature = "atomics"))]
     is_started: Arc<AtomicBool>,
 
-    // Multi-threaded WASM (+atomics): all fields are Send+Sync; JS types are held in a
-    // spawn_local task that runs on the main thread.
+    // Multi-threaded WASM (+atomics): all fields are Send+Sync; JS types are owned by a
+    // spawn_local future on the local thread and are never stored here.
     #[cfg(target_feature = "atomics")]
     command_tx: mpsc::UnboundedSender<Command>,
     #[cfg(target_feature = "atomics")]
@@ -116,7 +116,7 @@ impl Host {
         } else {
             Err(Error::with_message(
                 ErrorKind::HostUnavailable,
-                "WebAudio is not available",
+                "WebAudio is not available in this context",
             ))
         }
     }
@@ -348,9 +348,10 @@ impl DeviceTrait for Device {
         }
         destination.set_channel_count(config.channels as u32);
 
-        // SAFETY: AudioContext and Closure are not Send/Sync, but these Arcs are created on the
-        // main thread and never leave it: in the non-atomics path WASM is single-threaded, and in
-        // the atomics path they are moved into a spawn_local task which also runs on the main thread.
+        // SAFETY: AudioContext and Closure are not Send/Sync. In the non-atomics path WASM is
+        // single-threaded so there are no thread boundaries to cross. In the atomics path these
+        // values are moved into a spawn_local future on the same local thread; they are never
+        // stored in Stream (which is Send+Sync) and therefore never escape to another thread.
         #[allow(clippy::arc_with_non_send_sync)]
         let ctx = Arc::new(ctx);
 
@@ -367,8 +368,9 @@ impl DeviceTrait for Device {
             .unwrap_or(0.0);
 
         // Shared current-time counter updated on every callback invocation.
+        // Seeded from the live clock so now() is on the correct time base before the first callback.
         #[cfg(target_feature = "atomics")]
-        let current_time_bits = Arc::new(AtomicU64::new(0u64));
+        let current_time_bits = Arc::new(AtomicU64::new(ctx.current_time().to_bits()));
 
         // Create a set of closures / callbacks which will continuously fetch and schedule sample
         // playback. Starting with two workers, e.g. a front and back buffer so that audio frames
@@ -612,13 +614,15 @@ impl DeviceTrait for Device {
         }
 
         #[cfg(not(target_feature = "atomics"))]
-        return Ok(Self::Stream {
-            ctx,
-            on_ended_closures,
-            config,
-            buffer_size_frames,
-            is_started,
-        });
+        {
+            Ok(Self::Stream {
+                ctx,
+                on_ended_closures,
+                config,
+                buffer_size_frames,
+                is_started,
+            })
+        }
 
         #[cfg(target_feature = "atomics")]
         {
@@ -630,21 +634,20 @@ impl DeviceTrait for Device {
                 while let Some(cmd) = command_rx.next().await {
                     match cmd {
                         Command::Play => {
-                            if !started {
-                                started = true;
-                                schedule_initial_timeouts(
-                                    &window,
-                                    &on_ended_closures,
-                                    buffer_size_frames,
-                                    config.sample_rate,
-                                );
-                            }
                             if ctx.resume().is_err() {
                                 error_callback.lock().unwrap_or_else(|e| e.into_inner())(
                                     Error::with_message(
                                         ErrorKind::DeviceNotAvailable,
                                         "Failed to resume audio context",
                                     ),
+                                );
+                            } else if !started {
+                                started = true;
+                                schedule_initial_timeouts(
+                                    &window,
+                                    &on_ended_closures,
+                                    buffer_size_frames,
+                                    config.sample_rate,
                                 );
                             }
                         }
@@ -713,7 +716,10 @@ impl StreamTrait for Stream {
         }
         #[cfg(target_feature = "atomics")]
         self.command_tx.unbounded_send(Command::Play).map_err(|_| {
-            Error::with_message(ErrorKind::DeviceNotAvailable, "Stream has been dropped")
+            Error::with_message(
+                ErrorKind::StreamInvalidated,
+                "WebAudio context task stopped unexpectedly",
+            )
         })
     }
 
@@ -730,7 +736,10 @@ impl StreamTrait for Stream {
         }
         #[cfg(target_feature = "atomics")]
         self.command_tx.unbounded_send(Command::Pause).map_err(|_| {
-            Error::with_message(ErrorKind::DeviceNotAvailable, "Stream has been dropped")
+            Error::with_message(
+                ErrorKind::StreamInvalidated,
+                "WebAudio context task stopped unexpectedly",
+            )
         })
     }
 

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -874,6 +874,7 @@ mod platform_impl {
     #[cfg(feature = "audioworklet")]
     use crate::host::audioworklet::Host as AudioWorkletHost;
     use crate::host::webaudio::Host as WebAudioHost;
+    use crate::traits::HostTrait as _;
 
     impl_platform_host!(
         WebAudio => WebAudioHost,
@@ -882,10 +883,18 @@ mod platform_impl {
     );
 
     /// The default host for the current compilation target platform.
+    ///
+    /// # Panics
+    ///
+    /// Panics if called outside a Window context (e.g. from a Web Worker or Service Worker),
+    /// where `AudioContext` is unavailable.
     pub fn default_host() -> Host {
-        WebAudioHost::new()
-            .expect("the default host should always be available")
-            .into()
+        assert!(
+            WebAudioHost::is_available(),
+            "WebAudio is not available in this context; \
+             AudioContext requires a Window (not a Worker or Service Worker)"
+        );
+        WebAudioHost::new().unwrap().into()
     }
 }
 


### PR DESCRIPTION
Fixes:

- WebAudio's `Send + Sync` assertion was unsound when compiled with `+atomics`. 
- WebAudio should not indicate availability in non-window contexts.