### PR TITLE
fix(pipewire): use node.latency and re-promote RT when re-negotiated

### DIFF
--- a/src/host/pipewire/device.rs
+++ b/src/host/pipewire/device.rs
@@ -180,7 +180,10 @@ impl Device {
         properties.insert("node.group", format!("cpal-{}", std::process::id()));
 
         if let BufferSize::Fixed(buffer_size) = config.buffer_size {
-            properties.insert(*pw::keys::NODE_FORCE_QUANTUM, buffer_size.to_string());
+            properties.insert(
+                *pw::keys::NODE_LATENCY,
+                format!("{buffer_size}/{rate}", rate = config.sample_rate),
+            );
         }
         properties
     }
@@ -479,14 +482,6 @@ impl DeviceTrait for Device {
                     return;
                 }
 
-                #[cfg(feature = "realtime")]
-                if let Err(e) = audio_thread_priority::promote_current_thread_to_real_time(
-                    device.quantum,
-                    device.rate,
-                ) {
-                    emit_error(&error_callback, Error::from(e));
-                }
-
                 mainloop.run();
 
                 drop(listener);
@@ -658,14 +653,6 @@ impl DeviceTrait for Device {
                 // If the Latch is dropped without being released (error path), exit cleanly.
                 if !waiter.wait() {
                     return;
-                }
-
-                #[cfg(feature = "realtime")]
-                if let Err(e) = audio_thread_priority::promote_current_thread_to_real_time(
-                    device.quantum,
-                    device.rate,
-                ) {
-                    emit_error(&error_callback, Error::from(e));
                 }
 
                 mainloop.run();

--- a/src/host/pipewire/stream.rs
+++ b/src/host/pipewire/stream.rs
@@ -243,7 +243,7 @@ impl<D> UserData<D> {
         if let Err(e) =
             audio_thread_priority::promote_current_thread_to_real_time(frames, self.format.rate())
         {
-            emit_error(&self.error_callback, Error::from(e));
+            let _ = try_emit_error(&self.error_callback, Error::from(e));
         }
     }
 

--- a/src/host/pipewire/stream.rs
+++ b/src/host/pipewire/stream.rs
@@ -229,9 +229,24 @@ pub struct UserData<D> {
     has_connected: bool,
     invalidated: Arc<AtomicBool>,
     pending_device_changed: Arc<AtomicBool>,
+    #[cfg(feature = "realtime")]
+    rt_promoted: bool,
 }
 
 impl<D> UserData<D> {
+    // `#[cold]` because it only runs on the first cycle and whenever PipeWire renegotiates the graph quantum.
+    #[cfg(feature = "realtime")]
+    #[cold]
+    fn promote_realtime(&mut self, frames: FrameCount) {
+        // Set regardless of success, so a failed promotion isn't retried until the quantum changes.
+        self.rt_promoted = true;
+        if let Err(e) =
+            audio_thread_priority::promote_current_thread_to_real_time(frames, self.format.rate())
+        {
+            emit_error(&self.error_callback, Error::from(e));
+        }
+    }
+
     fn state_changed(&mut self, new: StreamState) {
         match new {
             StreamState::Streaming => self.has_connected = true,
@@ -276,7 +291,17 @@ where
     D: FnMut(&Data, &InputCallbackInfo) + Send + 'static,
 {
     fn publish_data_in(&mut self, stream: &pw::stream::Stream, frames: usize, data: &Data) {
+        #[cfg(feature = "realtime")]
+        {
+            let prev = self.last_quantum.swap(frames as u64, Ordering::Relaxed);
+            if !self.rt_promoted || frames as u64 != prev {
+                self.promote_realtime(frames as FrameCount);
+            }
+        }
+
+        #[cfg(not(feature = "realtime"))]
         self.last_quantum.store(frames as u64, Ordering::Relaxed);
+
         let (callback, capture) = match pw_stream_time(stream) {
             Some(t) => {
                 let delay_ns = t.delay() * 1_000_000_000i64 / t.rate().denom as i64;
@@ -305,7 +330,17 @@ where
     D: FnMut(&mut Data, &OutputCallbackInfo) + Send + 'static,
 {
     fn publish_data_out(&mut self, stream: &pw::stream::Stream, frames: usize, data: &mut Data) {
+        #[cfg(feature = "realtime")]
+        {
+            let prev = self.last_quantum.swap(frames as u64, Ordering::Relaxed);
+            if !self.rt_promoted || frames as u64 != prev {
+                self.promote_realtime(frames as FrameCount);
+            }
+        }
+
+        #[cfg(not(feature = "realtime"))]
         self.last_quantum.store(frames as u64, Ordering::Relaxed);
+
         let (callback, playback) = match pw_stream_time(stream) {
             Some(t) => {
                 let delay_ns = t.delay() * 1_000_000_000i64 / t.rate().denom as i64;
@@ -546,6 +581,8 @@ where
         is_default_device: is_default_device.clone(),
         has_connected: false,
         pending_device_changed: pending_device_changed.clone(),
+        #[cfg(feature = "realtime")]
+        rt_promoted: false,
     };
     let channels = config.channels as _;
     let rate = config.sample_rate as _;
@@ -709,7 +746,8 @@ where
 
     // RT_PROCESS is intentionally absent: with add_local_listener the process callback always
     // runs on this mainloop thread, not the separate data-loop thread RT_PROCESS creates.
-    // The worker thread is promoted to RT after signalling the main thread (see device.rs).
+    // That thread promotes itself to RT from the process callback, once when the negotiated
+    // quantum is known and again whenever PipeWire renegotiates it.
     let mut flags = StreamFlags::MAP_BUFFERS;
     if connect_automatically {
         flags |= StreamFlags::AUTOCONNECT;
@@ -789,6 +827,8 @@ where
         is_default_device: is_default_device.clone(),
         has_connected: false,
         pending_device_changed: pending_device_changed.clone(),
+        #[cfg(feature = "realtime")]
+        rt_promoted: false,
     };
 
     let channels = config.channels as _;
@@ -935,7 +975,8 @@ where
 
     // RT_PROCESS is intentionally absent: with add_local_listener the process callback always
     // runs on this mainloop thread, not the separate data-loop thread RT_PROCESS creates.
-    // The worker thread is promoted to RT after signalling the main thread (see device.rs).
+    // That thread promotes itself to RT from the process callback, once when the negotiated
+    // quantum is known and again whenever PipeWire renegotiates it.
     let mut flags = StreamFlags::MAP_BUFFERS;
     if connect_automatically {
         flags |= StreamFlags::AUTOCONNECT;


### PR DESCRIPTION
Reported on Discord:

Forcing small quantum sizes on the entire PipeWire graph leads to freezing the entire audio server when filter chains are in effect. Try negotiating node latency instead.

Because PipeWire can dynamically renegotiate the node latency, refactor `realtime` to re-promote when node latency changes.