### PR TITLE
ci: check with all features

### DIFF
--- a/.github/workflows/platforms.yml
+++ b/.github/workflows/platforms.yml
@@ -94,12 +94,6 @@ jobs:
       - name: Check examples (default features)
         run: cargo +${{ env.MSRV_ALSA }} check --examples --workspace --verbose
 
-      - name: Run tests (no default features)
-        run: cargo +${{ env.MSRV_ALSA }} test --no-default-features --workspace --verbose
-
-      - name: Check examples (no default features)
-        run: cargo +${{ env.MSRV_ALSA }} check --examples --no-default-features --workspace --verbose
-
       - name: Run tests (all features)
         run: cargo +${{ steps.msrv.outputs.all-features }} test --all-features --workspace --verbose
 
@@ -150,12 +144,6 @@ jobs:
 
       - name: Check examples (default features)
         run: cross +${{ env.MSRV_ALSA }} check --examples --workspace --verbose --target ${{ env.TARGET }}
-
-      - name: Run tests (no default features)
-        run: cross +${{ env.MSRV_ALSA }} test --no-default-features --workspace --verbose --target ${{ env.TARGET }}
-
-      - name: Check examples (no default features)
-        run: cross +${{ env.MSRV_ALSA }} test --no-default-features --workspace --verbose --target ${{ env.TARGET }}
 
       - name: Run tests (all features)
         run: cross +${{ steps.msrv.outputs.all-features }} test --features=jack,pulseaudio --workspace --verbose --target ${{ env.TARGET }}
@@ -241,12 +229,6 @@ jobs:
       - name: Check examples (default features)
         run: cargo +${{ env.MSRV_WINDOWS }} check --examples --workspace --verbose
 
-      - name: Run tests (no default features)
-        run: cargo +${{ env.MSRV_WINDOWS }} test --no-default-features --workspace --verbose
-
-      - name: Check examples (no default features)
-        run: cargo +${{ env.MSRV_WINDOWS }} check --examples --no-default-features --workspace --verbose
-
       - name: Run tests (all features)
         run: cargo +${{ steps.msrv.outputs.all-features }} test --workspace --all-features --verbose
 
@@ -293,12 +275,6 @@ jobs:
       - name: Check examples (default features)
         run: cargo +${{ env.MSRV_COREAUDIO }} check --examples --workspace --verbose
 
-      - name: Run tests (no default features)
-        run: cargo +${{ env.MSRV_COREAUDIO }} test --no-default-features --workspace --verbose
-
-      - name: Check examples (no default features)
-        run: cargo +${{ env.MSRV_COREAUDIO }} check --no-default-features --examples --workspace --verbose
-
       - name: Run tests (all features)
         run: cargo +${{ steps.msrv.outputs.all-features }} test --all-features --workspace --verbose
 
@@ -341,9 +317,6 @@ jobs:
 
       - name: Check examples (default features)
         run: cargo +${{ env.MSRV_AAUDIO }} check --examples --workspace --verbose --target ${{ env.TARGET }}
-
-      - name: Check examples (no default features)
-        run: cargo +${{ env.MSRV_AAUDIO }} check --examples --no-default-features --workspace --verbose --target ${{ env.TARGET }}
 
       - name: Check examples (all features)
         run: cargo +${{ steps.msrv.outputs.all-features }} check --examples --all-features --workspace --verbose --target ${{ env.TARGET }}
@@ -391,9 +364,6 @@ jobs:
       - name: Check examples (default features)
         run: cargo +${{ env.MSRV_COREAUDIO }} check --examples --workspace --verbose --target ${{ env.TARGET }}
 
-      - name: Check examples (no default features)
-        run: cargo +${{ env.MSRV_COREAUDIO }} check --examples --no-default-features --workspace --verbose --target ${{ env.TARGET }}
-
       - name: Check examples (all features)
         run: cargo +${{ env.MSRV_COREAUDIO }} check --examples --all-features --workspace --verbose --target ${{ env.TARGET }}
 
@@ -429,9 +399,6 @@ jobs:
       - name: Check examples (default features)
         run: cargo +nightly check --examples --workspace --verbose --target ${{ env.TARGET }} -Z build-std
 
-      - name: Check examples (no default features)
-        run: cargo +nightly check --examples --no-default-features --workspace --verbose --target ${{ env.TARGET }} -Z build-std
-
       - name: Check examples (all features)
         run: cargo +nightly check --examples --all-features --workspace --verbose --target ${{ env.TARGET }} -Z build-std
 
@@ -458,6 +425,9 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           key: wasm-bindgen
+
+      - name: Check examples (default features)
+        run: cargo +${{ env.MSRV_WASM }} check --examples --workspace --verbose --target ${{ env.TARGET }}
 
       - name: Check examples (wasm-bindgen feature)
         run: cargo +${{ env.MSRV_WASM }} check --examples --features wasm-bindgen --workspace --verbose --target ${{ env.TARGET }}
@@ -496,8 +466,14 @@ jobs:
         with:
           key: wasm-audioworklet
 
+      - name: Check examples (default features)
+        run: cargo +nightly check --examples --workspace --verbose -Z build-std=std,panic_abort --target ${{ env.TARGET }}
+
       - name: Check examples (audioworklet feature)
         run: cargo +nightly check --examples --features audioworklet --workspace --verbose -Z build-std=std,panic_abort --target ${{ env.TARGET }}
+
+      - name: Check all features
+        run: cargo +nightly check --workspace --all-features --verbose -Z build-std=std,panic_abort --target ${{ env.TARGET }}
 
       - name: Build audioworklet-beep example
         working-directory: ./examples/audioworklet-beep
@@ -527,8 +503,8 @@ jobs:
       - name: Check examples (default features)
         run: cargo +${{ env.MSRV_WASIP1 }} check --examples --workspace --target ${{ env.TARGET }} --verbose
 
-      - name: Check examples (no default features)
-        run: cargo +${{ env.MSRV_WASIP1 }} check --examples --no-default-features --workspace --verbose --target ${{ env.TARGET }}
+      - name: Check all features
+        run: cargo +${{ env.MSRV_WASIP1 }} check --workspace --all-features --verbose --target ${{ env.TARGET }}
 
   # Windows crate version compatibility
   windows-versions:

--- a/.github/workflows/platforms.yml
+++ b/.github/workflows/platforms.yml
@@ -149,7 +149,7 @@ jobs:
         run: cross +${{ steps.msrv.outputs.all-features }} test --features=jack,pulseaudio --workspace --verbose --target ${{ env.TARGET }}
 
       - name: Check examples (all features)
-        run: cross +${{ steps.msrv.outputs.all-features }} test --features=jack,pulseaudio --workspace --verbose --target ${{ env.TARGET }}
+        run: cross +${{ steps.msrv.outputs.all-features }} check --examples --features=jack,pulseaudio --workspace --verbose --target ${{ env.TARGET }}
 
   pipewire-bookworm:
     name: pipewire-bookworm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Exclude `pipewire` from the `docs.rs` build; system dependency not available in its environment.
+- Fix `wasm-bindgen` causing compile errors on non-browser `wasm32` targets such as `wasm32-wasip1`.
 
 ## [0.18.0] - 2026-06-06
 

--- a/src/host/mod.rs
+++ b/src/host/mod.rs
@@ -74,7 +74,11 @@ pub(crate) mod pulseaudio;
 #[cfg(windows)]
 pub(crate) mod wasapi;
 
-#[cfg(all(target_arch = "wasm32", target_os = "unknown", feature = "wasm-bindgen"))]
+#[cfg(all(
+    target_arch = "wasm32",
+    target_os = "unknown",
+    feature = "wasm-bindgen"
+))]
 pub(crate) mod webaudio;
 
 #[cfg(feature = "custom")]
@@ -88,7 +92,11 @@ pub(crate) mod custom;
     target_os = "netbsd",
     target_vendor = "apple",
     target_os = "android",
-    all(target_arch = "wasm32", target_os = "unknown", feature = "wasm-bindgen"),
+    all(
+        target_arch = "wasm32",
+        target_os = "unknown",
+        feature = "wasm-bindgen"
+    ),
 )))]
 pub(crate) mod null;
 

--- a/src/host/mod.rs
+++ b/src/host/mod.rs
@@ -25,6 +25,8 @@ pub(crate) mod alsa;
 pub(crate) mod asio;
 
 #[cfg(all(
+    target_arch = "wasm32",
+    target_os = "unknown",
     feature = "wasm-bindgen",
     feature = "audioworklet",
     target_feature = "atomics"
@@ -72,7 +74,7 @@ pub(crate) mod pulseaudio;
 #[cfg(windows)]
 pub(crate) mod wasapi;
 
-#[cfg(all(target_arch = "wasm32", feature = "wasm-bindgen"))]
+#[cfg(all(target_arch = "wasm32", target_os = "unknown", feature = "wasm-bindgen"))]
 pub(crate) mod webaudio;
 
 #[cfg(feature = "custom")]
@@ -86,7 +88,7 @@ pub(crate) mod custom;
     target_os = "netbsd",
     target_vendor = "apple",
     target_os = "android",
-    all(target_arch = "wasm32", feature = "wasm-bindgen"),
+    all(target_arch = "wasm32", target_os = "unknown", feature = "wasm-bindgen"),
 )))]
 pub(crate) mod null;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,11 +164,11 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 // Extern crate declarations with `#[macro_use]` must unfortunately be at crate root.
-#[cfg(all(target_arch = "wasm32", feature = "wasm-bindgen"))]
+#[cfg(all(target_arch = "wasm32", target_os = "unknown", feature = "wasm-bindgen"))]
 extern crate js_sys;
-#[cfg(all(target_arch = "wasm32", feature = "wasm-bindgen"))]
+#[cfg(all(target_arch = "wasm32", target_os = "unknown", feature = "wasm-bindgen"))]
 extern crate wasm_bindgen;
-#[cfg(all(target_arch = "wasm32", feature = "wasm-bindgen"))]
+#[cfg(all(target_arch = "wasm32", target_os = "unknown", feature = "wasm-bindgen"))]
 extern crate web_sys;
 
 pub use device_description::{
@@ -180,7 +180,7 @@ pub use platform::{
     SupportedInputConfigs, SupportedOutputConfigs, ALL_HOSTS,
 };
 pub use sample_format::{FromSample, Sample, SampleFormat, SizedSample, I24, U24};
-#[cfg(all(target_arch = "wasm32", feature = "wasm-bindgen"))]
+#[cfg(all(target_arch = "wasm32", target_os = "unknown", feature = "wasm-bindgen"))]
 use wasm_bindgen::prelude::*;
 
 pub mod device_description;
@@ -375,14 +375,14 @@ pub enum BufferSize {
     Fixed(FrameCount),
 }
 
-#[cfg(all(target_arch = "wasm32", feature = "wasm-bindgen"))]
+#[cfg(all(target_arch = "wasm32", target_os = "unknown", feature = "wasm-bindgen"))]
 impl wasm_bindgen::describe::WasmDescribe for BufferSize {
     fn describe() {
         <Option<FrameCount> as wasm_bindgen::describe::WasmDescribe>::describe();
     }
 }
 
-#[cfg(all(target_arch = "wasm32", feature = "wasm-bindgen"))]
+#[cfg(all(target_arch = "wasm32", target_os = "unknown", feature = "wasm-bindgen"))]
 impl wasm_bindgen::convert::IntoWasmAbi for BufferSize {
     type Abi = <Option<FrameCount> as wasm_bindgen::convert::IntoWasmAbi>::Abi;
 
@@ -395,7 +395,7 @@ impl wasm_bindgen::convert::IntoWasmAbi for BufferSize {
     }
 }
 
-#[cfg(all(target_arch = "wasm32", feature = "wasm-bindgen"))]
+#[cfg(all(target_arch = "wasm32", target_os = "unknown", feature = "wasm-bindgen"))]
 impl wasm_bindgen::convert::FromWasmAbi for BufferSize {
     type Abi = <Option<FrameCount> as wasm_bindgen::convert::FromWasmAbi>::Abi;
 
@@ -412,7 +412,7 @@ impl wasm_bindgen::convert::FromWasmAbi for BufferSize {
 /// The sample format is omitted in favour of using a sample type.
 ///
 /// See also [`BufferSize`] for details on buffer size behavior and latency considerations.
-#[cfg_attr(all(target_arch = "wasm32", feature = "wasm-bindgen"), wasm_bindgen)]
+#[cfg_attr(all(target_arch = "wasm32", target_os = "unknown", feature = "wasm-bindgen"), wasm_bindgen)]
 #[derive(Clone, Debug, Eq, PartialEq, Copy)]
 pub struct StreamConfig {
     pub channels: ChannelCount,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,11 +164,23 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 // Extern crate declarations with `#[macro_use]` must unfortunately be at crate root.
-#[cfg(all(target_arch = "wasm32", target_os = "unknown", feature = "wasm-bindgen"))]
+#[cfg(all(
+    target_arch = "wasm32",
+    target_os = "unknown",
+    feature = "wasm-bindgen"
+))]
 extern crate js_sys;
-#[cfg(all(target_arch = "wasm32", target_os = "unknown", feature = "wasm-bindgen"))]
+#[cfg(all(
+    target_arch = "wasm32",
+    target_os = "unknown",
+    feature = "wasm-bindgen"
+))]
 extern crate wasm_bindgen;
-#[cfg(all(target_arch = "wasm32", target_os = "unknown", feature = "wasm-bindgen"))]
+#[cfg(all(
+    target_arch = "wasm32",
+    target_os = "unknown",
+    feature = "wasm-bindgen"
+))]
 extern crate web_sys;
 
 pub use device_description::{
@@ -180,7 +192,11 @@ pub use platform::{
     SupportedInputConfigs, SupportedOutputConfigs, ALL_HOSTS,
 };
 pub use sample_format::{FromSample, Sample, SampleFormat, SizedSample, I24, U24};
-#[cfg(all(target_arch = "wasm32", target_os = "unknown", feature = "wasm-bindgen"))]
+#[cfg(all(
+    target_arch = "wasm32",
+    target_os = "unknown",
+    feature = "wasm-bindgen"
+))]
 use wasm_bindgen::prelude::*;
 
 pub mod device_description;
@@ -375,14 +391,22 @@ pub enum BufferSize {
     Fixed(FrameCount),
 }
 
-#[cfg(all(target_arch = "wasm32", target_os = "unknown", feature = "wasm-bindgen"))]
+#[cfg(all(
+    target_arch = "wasm32",
+    target_os = "unknown",
+    feature = "wasm-bindgen"
+))]
 impl wasm_bindgen::describe::WasmDescribe for BufferSize {
     fn describe() {
         <Option<FrameCount> as wasm_bindgen::describe::WasmDescribe>::describe();
     }
 }
 
-#[cfg(all(target_arch = "wasm32", target_os = "unknown", feature = "wasm-bindgen"))]
+#[cfg(all(
+    target_arch = "wasm32",
+    target_os = "unknown",
+    feature = "wasm-bindgen"
+))]
 impl wasm_bindgen::convert::IntoWasmAbi for BufferSize {
     type Abi = <Option<FrameCount> as wasm_bindgen::convert::IntoWasmAbi>::Abi;
 
@@ -395,7 +419,11 @@ impl wasm_bindgen::convert::IntoWasmAbi for BufferSize {
     }
 }
 
-#[cfg(all(target_arch = "wasm32", target_os = "unknown", feature = "wasm-bindgen"))]
+#[cfg(all(
+    target_arch = "wasm32",
+    target_os = "unknown",
+    feature = "wasm-bindgen"
+))]
 impl wasm_bindgen::convert::FromWasmAbi for BufferSize {
     type Abi = <Option<FrameCount> as wasm_bindgen::convert::FromWasmAbi>::Abi;
 
@@ -412,7 +440,14 @@ impl wasm_bindgen::convert::FromWasmAbi for BufferSize {
 /// The sample format is omitted in favour of using a sample type.
 ///
 /// See also [`BufferSize`] for details on buffer size behavior and latency considerations.
-#[cfg_attr(all(target_arch = "wasm32", target_os = "unknown", feature = "wasm-bindgen"), wasm_bindgen)]
+#[cfg_attr(
+    all(
+        target_arch = "wasm32",
+        target_os = "unknown",
+        feature = "wasm-bindgen"
+    ),
+    wasm_bindgen
+)]
 #[derive(Clone, Debug, Eq, PartialEq, Copy)]
 pub struct StreamConfig {
     pub channels: ChannelCount,

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -869,7 +869,7 @@ mod platform_impl {
     }
 }
 
-#[cfg(all(target_arch = "wasm32", feature = "wasm-bindgen"))]
+#[cfg(all(target_arch = "wasm32", target_os = "unknown", feature = "wasm-bindgen"))]
 mod platform_impl {
     #[cfg(all(feature = "audioworklet", target_feature = "atomics"))]
     use crate::host::audioworklet::Host as AudioWorkletHost;
@@ -936,7 +936,7 @@ mod platform_impl {
     target_os = "netbsd",
     target_vendor = "apple",
     target_os = "android",
-    all(target_arch = "wasm32", feature = "wasm-bindgen"),
+    all(target_arch = "wasm32", target_os = "unknown", feature = "wasm-bindgen"),
 )))]
 mod platform_impl {
     use crate::host::null::Host as NullHost;

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -869,7 +869,11 @@ mod platform_impl {
     }
 }
 
-#[cfg(all(target_arch = "wasm32", target_os = "unknown", feature = "wasm-bindgen"))]
+#[cfg(all(
+    target_arch = "wasm32",
+    target_os = "unknown",
+    feature = "wasm-bindgen"
+))]
 mod platform_impl {
     #[cfg(all(feature = "audioworklet", target_feature = "atomics"))]
     use crate::host::audioworklet::Host as AudioWorkletHost;
@@ -936,7 +940,11 @@ mod platform_impl {
     target_os = "netbsd",
     target_vendor = "apple",
     target_os = "android",
-    all(target_arch = "wasm32", target_os = "unknown", feature = "wasm-bindgen"),
+    all(
+        target_arch = "wasm32",
+        target_os = "unknown",
+        feature = "wasm-bindgen"
+    ),
 )))]
 mod platform_impl {
     use crate::host::null::Host as NullHost;

--- a/src/sample_format.rs
+++ b/src/sample_format.rs
@@ -28,7 +28,11 @@ pub use dasp_sample::I24;
 /// the actual bit depth (24) vs [`SampleFormat::sample_size`] for storage size (4 bytes).
 pub use dasp_sample::U24;
 pub use dasp_sample::{FromSample, Sample};
-#[cfg(all(target_arch = "wasm32", target_os = "unknown", feature = "wasm-bindgen"))]
+#[cfg(all(
+    target_arch = "wasm32",
+    target_os = "unknown",
+    feature = "wasm-bindgen"
+))]
 use wasm_bindgen::prelude::*;
 
 // I48 and U48 are not currently supported by cpal but available in dasp_sample:
@@ -49,7 +53,14 @@ use wasm_bindgen::prelude::*;
 ///
 /// [`is_float`]: SampleFormat::is_float
 /// [`supported_input_configs`]: crate::traits::DeviceTrait::supported_input_configs
-#[cfg_attr(all(target_arch = "wasm32", target_os = "unknown", feature = "wasm-bindgen"), wasm_bindgen)]
+#[cfg_attr(
+    all(
+        target_arch = "wasm32",
+        target_os = "unknown",
+        feature = "wasm-bindgen"
+    ),
+    wasm_bindgen
+)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[non_exhaustive]
 pub enum SampleFormat {

--- a/src/sample_format.rs
+++ b/src/sample_format.rs
@@ -28,7 +28,7 @@ pub use dasp_sample::I24;
 /// the actual bit depth (24) vs [`SampleFormat::sample_size`] for storage size (4 bytes).
 pub use dasp_sample::U24;
 pub use dasp_sample::{FromSample, Sample};
-#[cfg(all(target_arch = "wasm32", feature = "wasm-bindgen"))]
+#[cfg(all(target_arch = "wasm32", target_os = "unknown", feature = "wasm-bindgen"))]
 use wasm_bindgen::prelude::*;
 
 // I48 and U48 are not currently supported by cpal but available in dasp_sample:
@@ -49,7 +49,7 @@ use wasm_bindgen::prelude::*;
 ///
 /// [`is_float`]: SampleFormat::is_float
 /// [`supported_input_configs`]: crate::traits::DeviceTrait::supported_input_configs
-#[cfg_attr(all(target_arch = "wasm32", feature = "wasm-bindgen"), wasm_bindgen)]
+#[cfg_attr(all(target_arch = "wasm32", target_os = "unknown", feature = "wasm-bindgen"), wasm_bindgen)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[non_exhaustive]
 pub enum SampleFormat {


### PR DESCRIPTION
Ensure the following all work out of the box - assuming availability of system libraries:
1. Compiling with default features
2. Compiling with no default features (equal to item 1; so removed to save the CI effort)
3. Compiling with all features