### PR TITLE
doc: add minimum supported OS versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **AudioWorklet**: `BufferSize::Fixed` now sets `renderSizeHint` on the `AudioContext`.
 - **AudioWorklet**: Sample rates now enumerated as discrete standard rates in the spec-required
   range of 3-768 kHz.
+- **CoreAudio**: Minimum supported macOS version is now 14.2 (Sonoma).
 - **CoreAudio**: Timestamps now include device latency and safety offset.
 - **CoreAudio**: Physical stream format is now set directly on the hardware device.
 - **CoreAudio**: Stream error callback now receives `ErrorKind::StreamInvalidated` on any sample

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,7 +92,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **AudioWorklet**: `BufferSize::Fixed` now sets `renderSizeHint` on the `AudioContext`.
 - **AudioWorklet**: Sample rates now enumerated as discrete standard rates in the spec-required
   range of 3-768 kHz.
-- **CoreAudio**: Minimum supported macOS version is now 14.2 (Sonoma).
 - **CoreAudio**: Timestamps now include device latency and safety offset.
 - **CoreAudio**: Physical stream format is now set directly on the hardware device.
 - **CoreAudio**: Stream error callback now receives `ErrorKind::StreamInvalidated` on any sample

--- a/README.md
+++ b/README.md
@@ -35,23 +35,24 @@ ALSA is needed even when using JACK, PipeWire, or PulseAudio.
 
 The optional `realtime-dbus` feature additionally requires `libdbus-1-dev` (Debian/Ubuntu) or `dbus-devel` (Fedora). See [ALSA Real-Time Priority Promotion](#alsa-real-time-priority-promotion).
 
-## Minimum Supported Rust Version (MSRV)
+## Minimum Supported Versions
 
-The minimum Rust version required depends on which audio backend and features you're using, as each platform has different dependencies:
+The minimum Rust version (MSRV) and minimum operating system / runtime version both depend on which audio backend and features you're using, as each platform has different dependencies:
 
-| Backend | Platforms | MSRV |
-| ------- | --------- | ---- |
-| AAudio | Android | 1.85 |
-| ALSA | Linux, BSD | 1.85 |
-| CoreAudio | macOS, iOS | 1.85 |
-| CoreAudio | tvOS | nightly |
-| JACK | Linux, BSD, macOS, Windows | 1.85 |
-| PipeWire | Linux, BSD | 1.85 |
-| PulseAudio | Linux, BSD | 1.88 |
-| WASAPI / ASIO | Windows | 1.85 |
-| WASM (`wasm32-unknown`) | WebAssembly | 1.85 |
-| WASM (`wasm32-wasip1`) | WebAssembly | 1.85 |
-| WASM (`audioworklet`) | WebAssembly | nightly |
+| Backend | Platforms | MSRV | Minimum OS / runtime |
+| ------- | --------- | ---- | -------------------- |
+| AAudio | Android | 1.85 | Android 8.0 (API 26) |
+| ALSA | Linux, BSD | 1.85 | — |
+| CoreAudio | macOS | 1.85 | macOS 14.2 (Sonoma) |
+| CoreAudio | iOS | 1.85 | — |
+| CoreAudio | tvOS | nightly | — |
+| JACK | Linux, BSD, macOS, Windows | 1.85 | — |
+| PipeWire | Linux, BSD | 1.85 | PipeWire 0.3.53 |
+| PulseAudio | Linux, BSD | 1.88 | — |
+| WASAPI / ASIO | Windows | 1.85 | Windows 8 |
+| WASM (`wasm32-unknown`) | WebAssembly | 1.85 | — |
+| WASM (`wasm32-wasip1`) | WebAssembly | 1.85 | — |
+| WASM (`audioworklet`) | WebAssembly | nightly | — |
 
 The `audioworklet` backend additionally requires `-Zbuild-std` with atomics support enabled.
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The minimum Rust version (MSRV) and minimum operating system / runtime version b
 | ------- | --------- | ---- | -------------------- |
 | AAudio | Android | 1.85 | Android 8.0 (API 26) |
 | ALSA | Linux, BSD | 1.85 | — |
-| CoreAudio | macOS | 1.85 | macOS 14.2 (Sonoma) |
+| CoreAudio | macOS | 1.85 | macOS 14.2 (loopback recording requires 14.6+) |
 | CoreAudio | iOS | 1.85 | — |
 | CoreAudio | tvOS | nightly | — |
 | JACK | Linux, BSD, macOS, Windows | 1.85 | — |


### PR DESCRIPTION
Retro-actively added the new macOS 14.2 requirement to the v0.18.0 changelog.

Closes #1241 