### PR TITLE
fix(wasapi): racy timestamp callback padding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **WASAPI**: The `windows` and `windows-core` dependencies are now both pinned to 0.62.
 
+### Fixed
+
+- **WASAPI**: Fix output `playback` timestamps occasionally stepping backwards.
+
 ## [0.18.1] - 2026-06-07
 
 ### Fixed

--- a/src/host/wasapi/device.rs
+++ b/src/host/wasapi/device.rs
@@ -19,6 +19,7 @@ impl From<Audio::EDataFlow> for DeviceDirection {
     }
 }
 use std::{
+    cell::Cell,
     ffi::OsString,
     fmt,
     hash::Hash,
@@ -927,7 +928,7 @@ impl Device {
             // `run()` method and added to the `RunContext`.
             let client_flow = AudioClientFlow::Capture { capture_client };
 
-            let audio_clock = get_audio_clock(&audio_client)?;
+            let (audio_clock, clock_frequency) = get_audio_clock(&audio_client)?;
 
             let stream_latency = {
                 let hns = audio_client
@@ -939,6 +940,8 @@ impl Device {
             Ok(StreamInner {
                 audio_client,
                 audio_clock,
+                clock_frequency,
+                frames_written: Cell::new(0),
                 client_flow,
                 event,
                 playing: false,
@@ -1040,7 +1043,7 @@ impl Device {
             // `run()` method and added to the `RunContext`.
             let client_flow = AudioClientFlow::Render { render_client };
 
-            let audio_clock = get_audio_clock(&audio_client)?;
+            let (audio_clock, clock_frequency) = get_audio_clock(&audio_client)?;
 
             let stream_latency = {
                 let hns = audio_client
@@ -1052,6 +1055,8 @@ impl Device {
             Ok(StreamInner {
                 audio_client,
                 audio_clock,
+                clock_frequency,
+                frames_written: Cell::new(0),
                 client_flow,
                 event,
                 playing: false,
@@ -1340,11 +1345,21 @@ pub fn default_output_device() -> Option<Device> {
     current_default_endpoint(Audio::eRender).map(|_| Device::default_output())
 }
 
-/// Get the audio clock used to produce `StreamInstant`s.
-unsafe fn get_audio_clock(audio_client: &Audio::IAudioClient) -> Result<Audio::IAudioClock, Error> {
-    audio_client
+/// Get the audio clock used to produce `StreamInstant`s, together with its (constant) frequency.
+unsafe fn get_audio_clock(
+    audio_client: &Audio::IAudioClient,
+) -> Result<(Audio::IAudioClock, u64), Error> {
+    let audio_clock = audio_client
         .GetService::<Audio::IAudioClock>()
-        .context("Failed to get audio clock")
+        .context("Failed to get audio clock")?;
+    let clock_frequency = audio_clock
+        .GetFrequency()
+        .context("Failed to get audio clock frequency")?;
+    debug_assert_ne!(
+        clock_frequency, 0,
+        "IAudioClock::GetFrequency returned zero"
+    );
+    Ok((audio_clock, clock_frequency))
 }
 
 // Sample rate range supported by the Media Foundation Resampler MFT used by AUTOCONVERTPCM.

--- a/src/host/wasapi/device.rs
+++ b/src/host/wasapi/device.rs
@@ -1,5 +1,4 @@
 use std::{
-    cell::Cell,
     ffi::OsString,
     fmt,
     hash::Hash,
@@ -917,7 +916,9 @@ impl Device {
             // `run()` method and added to the `RunContext`.
             let client_flow = AudioClientFlow::Capture { capture_client };
 
-            let (audio_clock, clock_frequency) = get_audio_clock(&audio_client)?;
+            let audio_clock = audio_client
+                .GetService::<Audio::IAudioClock>()
+                .context("Failed to get audio clock")?;
 
             let stream_latency = {
                 let hns = audio_client
@@ -929,8 +930,6 @@ impl Device {
             Ok(StreamInner {
                 audio_client,
                 audio_clock,
-                clock_frequency,
-                frames_written: Cell::new(0),
                 client_flow,
                 event,
                 playing: false,
@@ -1032,7 +1031,9 @@ impl Device {
             // `run()` method and added to the `RunContext`.
             let client_flow = AudioClientFlow::Render { render_client };
 
-            let (audio_clock, clock_frequency) = get_audio_clock(&audio_client)?;
+            let audio_clock = audio_client
+                .GetService::<Audio::IAudioClock>()
+                .context("Failed to get audio clock")?;
 
             let stream_latency = {
                 let hns = audio_client
@@ -1044,8 +1045,6 @@ impl Device {
             Ok(StreamInner {
                 audio_client,
                 audio_clock,
-                clock_frequency,
-                frames_written: Cell::new(0),
                 client_flow,
                 event,
                 playing: false,
@@ -1344,23 +1343,6 @@ impl From<Audio::EDataFlow> for DeviceDirection {
             DeviceDirection::Unknown
         }
     }
-}
-
-/// Get the audio clock used to produce `StreamInstant`s, together with its (constant) frequency.
-unsafe fn get_audio_clock(
-    audio_client: &Audio::IAudioClient,
-) -> Result<(Audio::IAudioClock, u64), Error> {
-    let audio_clock = audio_client
-        .GetService::<Audio::IAudioClock>()
-        .context("Failed to get audio clock")?;
-    let clock_frequency = audio_clock
-        .GetFrequency()
-        .context("Failed to get audio clock frequency")?;
-    debug_assert_ne!(
-        clock_frequency, 0,
-        "IAudioClock::GetFrequency returned zero"
-    );
-    Ok((audio_clock, clock_frequency))
 }
 
 // Sample rate range supported by the Media Foundation Resampler MFT used by AUTOCONVERTPCM.

--- a/src/host/wasapi/device.rs
+++ b/src/host/wasapi/device.rs
@@ -1,23 +1,3 @@
-use crate::{
-    error::ResultExt,
-    host::{com::ComString, ErrorCallbackArc},
-    BufferSize, Data, DeviceDescription, DeviceDescriptionBuilder, DeviceDirection, DeviceId,
-    DeviceType, Error, ErrorKind, FrameCount, InputCallbackInfo, InterfaceType, OutputCallbackInfo,
-    SampleFormat, SampleRate, StreamConfig, SupportedBufferSize, SupportedStreamConfig,
-    SupportedStreamConfigRange, COMMON_SAMPLE_RATES,
-};
-
-impl From<Audio::EDataFlow> for DeviceDirection {
-    fn from(data_flow: Audio::EDataFlow) -> Self {
-        if data_flow == Audio::eCapture {
-            DeviceDirection::Input
-        } else if data_flow == Audio::eRender {
-            DeviceDirection::Output
-        } else {
-            DeviceDirection::Unknown
-        }
-    }
-}
 use std::{
     cell::Cell,
     ffi::OsString,
@@ -28,6 +8,15 @@ use std::{
     ptr, slice,
     sync::{Arc, Mutex, MutexGuard, OnceLock},
     time::Duration,
+};
+
+use crate::{
+    error::ResultExt,
+    host::{com::ComString, ErrorCallbackArc},
+    BufferSize, Data, DeviceDescription, DeviceDescriptionBuilder, DeviceDirection, DeviceId,
+    DeviceType, Error, ErrorKind, FrameCount, InputCallbackInfo, InterfaceType, OutputCallbackInfo,
+    SampleFormat, SampleRate, StreamConfig, SupportedBufferSize, SupportedStreamConfig,
+    SupportedStreamConfigRange, COMMON_SAMPLE_RATES,
 };
 
 use windows::{
@@ -1343,6 +1332,18 @@ pub fn default_input_device() -> Option<Device> {
 pub fn default_output_device() -> Option<Device> {
     // Detect if a default output device exists before creating a `Device` for it.
     current_default_endpoint(Audio::eRender).map(|_| Device::default_output())
+}
+
+impl From<Audio::EDataFlow> for DeviceDirection {
+    fn from(data_flow: Audio::EDataFlow) -> Self {
+        if data_flow == Audio::eCapture {
+            DeviceDirection::Input
+        } else if data_flow == Audio::eRender {
+            DeviceDirection::Output
+        } else {
+            DeviceDirection::Unknown
+        }
+    }
 }
 
 /// Get the audio clock used to produce `StreamInstant`s, together with its (constant) frequency.

--- a/src/host/wasapi/stream.rs
+++ b/src/host/wasapi/stream.rs
@@ -1,5 +1,4 @@
 use std::{
-    cell::Cell,
     mem,
     ops::ControlFlow,
     ptr,
@@ -288,10 +287,6 @@ pub enum AudioClientFlow {
 pub struct StreamInner {
     pub audio_client: Audio::IAudioClient,
     pub audio_clock: Audio::IAudioClock,
-    // Cached (constant) frequency of `audio_clock`.
-    pub clock_frequency: u64,
-    // Running total of frames submitted to the render buffer.
-    pub frames_written: Cell<u64>,
     pub client_flow: AudioClientFlow,
     // Event that is signalled by WASAPI whenever audio data must be written.
     pub event: Foundation::HANDLE,
@@ -653,6 +648,21 @@ fn run_output(
         emit_error(error_callback, err);
     }
 
+    // The clock frequency is constant for the stream's lifetime.
+    let clock_frequency = match unsafe { run_ctxt.stream.audio_clock.GetFrequency() }
+        .context("Failed to get audio clock frequency")
+    {
+        Ok(frequency) => {
+            debug_assert_ne!(frequency, 0, "IAudioClock::GetFrequency returned zero");
+            frequency
+        }
+        Err(err) => {
+            emit_error(error_callback, err);
+            return;
+        }
+    };
+    let mut frames_written: u64 = 0;
+
     loop {
         match process_commands_and_await_signal(&mut run_ctxt, error_callback) {
             ControlFlow::Break(()) => break,
@@ -663,7 +673,13 @@ fn run_output(
             AudioClientFlow::Render { ref render_client } => render_client.clone(),
             _ => unreachable!(),
         };
-        if let Err(err) = process_output(&run_ctxt.stream, render_client, data_callback) {
+        if let Err(err) = process_output(
+            &run_ctxt.stream,
+            render_client,
+            data_callback,
+            clock_frequency,
+            &mut frames_written,
+        ) {
             emit_error(error_callback, err);
             break;
         }
@@ -789,6 +805,8 @@ fn process_output(
     stream: &StreamInner,
     render_client: Audio::IAudioRenderClient,
     data_callback: &mut dyn FnMut(&mut Data, &OutputCallbackInfo),
+    clock_frequency: u64,
+    frames_written: &mut u64,
 ) -> Result<(), Error> {
     // The number of frames available for writing.
     let frames_available = match get_available_frames(stream)? {
@@ -811,7 +829,7 @@ fn process_output(
         let len = byte_count / stream.sample_format.sample_size();
         let mut data = Data::from_parts(data, len, stream.sample_format);
         let sample_rate = stream.config.sample_rate;
-        let timestamp = output_timestamp(stream, sample_rate)?;
+        let timestamp = output_timestamp(stream, sample_rate, clock_frequency, *frames_written)?;
         let info = OutputCallbackInfo { timestamp };
         data_callback(&mut data, &info);
 
@@ -819,9 +837,7 @@ fn process_output(
             .ReleaseBuffer(frames_available, 0)
             .map_err(Error::from)?;
 
-        stream
-            .frames_written
-            .set(stream.frames_written.get() + frames_available as u64);
+        *frames_written += frames_available as u64;
     }
 
     Ok(())
@@ -875,12 +891,14 @@ fn input_timestamp(
 fn output_timestamp(
     stream: &StreamInner,
     sample_rate: SampleRate,
+    clock_frequency: u64,
+    frames_written: u64,
 ) -> Result<OutputStreamTimestamp, Error> {
     let (callback, position) = clock_position(stream)?;
     // `padding` is the number of frames already queued in the endpoint buffer ahead of the
     // frames we are about to write. Those frames must drain before ours are heard.
-    let consumed_nanos = position as u128 * 1_000_000_000 / stream.clock_frequency as u128;
-    let written_nanos = stream.frames_written.get() as u128 * 1_000_000_000 / sample_rate as u128;
+    let consumed_nanos = position as u128 * 1_000_000_000 / clock_frequency as u128;
+    let written_nanos = frames_written as u128 * 1_000_000_000 / sample_rate as u128;
     let buffered_nanos =
         u64::try_from(written_nanos.saturating_sub(consumed_nanos)).unwrap_or(u64::MAX);
     let buffered = Duration::from_nanos(buffered_nanos);

--- a/src/host/wasapi/stream.rs
+++ b/src/host/wasapi/stream.rs
@@ -828,7 +828,7 @@ fn process_output(
 }
 
 /// Atomically reads the stream's `IAudioClock`, returning the callback [`StreamInstant`]
-/// together with the device position (how far playback has progressed.
+/// together with the device position.
 #[inline]
 fn clock_position(stream: &StreamInner) -> Result<(StreamInstant, u64), Error> {
     let mut position: u64 = 0;
@@ -881,8 +881,9 @@ fn output_timestamp(
     // frames we are about to write. Those frames must drain before ours are heard.
     let consumed_nanos = position as u128 * 1_000_000_000 / stream.clock_frequency as u128;
     let written_nanos = stream.frames_written.get() as u128 * 1_000_000_000 / sample_rate as u128;
-    // The difference is the (small) buffer fill, so it fits in `u64` nanoseconds.
-    let buffered = Duration::from_nanos(written_nanos.saturating_sub(consumed_nanos) as u64);
+    let buffered_nanos =
+        u64::try_from(written_nanos.saturating_sub(consumed_nanos)).unwrap_or(u64::MAX);
+    let buffered = Duration::from_nanos(buffered_nanos);
 
     let playback = callback + (buffered + stream.stream_latency);
     Ok(OutputStreamTimestamp { callback, playback })

--- a/src/host/wasapi/stream.rs
+++ b/src/host/wasapi/stream.rs
@@ -1,4 +1,5 @@
 use std::{
+    cell::Cell,
     mem,
     ops::ControlFlow,
     ptr,
@@ -18,10 +19,7 @@ use windows::Win32::{
 };
 
 use crate::{
-    host::{
-        emit_error, equilibrium::fill_equilibrium, frames_to_duration, latch::Latch,
-        ErrorCallbackArc,
-    },
+    host::{emit_error, equilibrium::fill_equilibrium, latch::Latch, ErrorCallbackArc},
     traits::StreamTrait,
     Data, Error, ErrorKind, FrameCount, InputCallbackInfo, InputStreamTimestamp,
     OutputCallbackInfo, OutputStreamTimestamp, ResultExt, SampleFormat, SampleRate, StreamConfig,
@@ -290,6 +288,10 @@ pub enum AudioClientFlow {
 pub struct StreamInner {
     pub audio_client: Audio::IAudioClient,
     pub audio_clock: Audio::IAudioClock,
+    // Cached (constant) frequency of `audio_clock`.
+    pub clock_frequency: u64,
+    // Running total of frames submitted to the render buffer.
+    pub frames_written: Cell<u64>,
     pub client_flow: AudioClientFlow,
     // Event that is signalled by WASAPI whenever audio data must be written.
     pub event: Foundation::HANDLE,
@@ -809,23 +811,26 @@ fn process_output(
         let len = byte_count / stream.sample_format.sample_size();
         let mut data = Data::from_parts(data, len, stream.sample_format);
         let sample_rate = stream.config.sample_rate;
-        let timestamp = output_timestamp(stream, frames_available, sample_rate)?;
+        let timestamp = output_timestamp(stream, sample_rate)?;
         let info = OutputCallbackInfo { timestamp };
         data_callback(&mut data, &info);
 
         render_client
             .ReleaseBuffer(frames_available, 0)
             .map_err(Error::from)?;
+
+        stream
+            .frames_written
+            .set(stream.frames_written.get() + frames_available as u64);
     }
 
     Ok(())
 }
 
-/// Use the stream's `IAudioClock` to produce the current stream instant.
-///
-/// Uses the QPC position produced via the `GetPosition` method.
+/// Atomically reads the stream's `IAudioClock`, returning the callback [`StreamInstant`]
+/// together with the device position (how far playback has progressed.
 #[inline]
-fn stream_instant(stream: &StreamInner) -> Result<StreamInstant, Error> {
+fn clock_position(stream: &StreamInner) -> Result<(StreamInstant, u64), Error> {
     let mut position: u64 = 0;
     let mut qpc_position: u64 = 0;
     unsafe {
@@ -840,7 +845,7 @@ fn stream_instant(stream: &StreamInner) -> Result<StreamInstant, Error> {
         (nanos / 1_000_000_000) as u64,
         (nanos % 1_000_000_000) as u32,
     );
-    Ok(instant)
+    Ok((instant, position))
 }
 
 /// Produce the input stream timestamp.
@@ -859,26 +864,26 @@ fn input_timestamp(
         (nanos / 1_000_000_000) as u64,
         (nanos % 1_000_000_000) as u32,
     );
-    let callback = stream_instant(stream)?;
+    let (callback, _position) = clock_position(stream)?;
     Ok(InputStreamTimestamp { capture, callback })
 }
 
 /// Produce the output stream timestamp.
 ///
-/// `frames_available` is the number of frames available for writing as reported by subtracting the
-/// result of `GetCurrentPadding` from the maximum buffer size.
-///
 /// `sample_rate` is the rate at which audio frames are processed by the device.
 #[inline]
 fn output_timestamp(
     stream: &StreamInner,
-    frames_available: FrameCount,
     sample_rate: SampleRate,
 ) -> Result<OutputStreamTimestamp, Error> {
-    let callback = stream_instant(stream)?;
+    let (callback, position) = clock_position(stream)?;
     // `padding` is the number of frames already queued in the endpoint buffer ahead of the
     // frames we are about to write. Those frames must drain before ours are heard.
-    let padding = stream.max_frames_in_buffer - frames_available;
-    let playback = callback + (frames_to_duration(padding, sample_rate) + stream.stream_latency);
+    let consumed_nanos = position as u128 * 1_000_000_000 / stream.clock_frequency as u128;
+    let written_nanos = stream.frames_written.get() as u128 * 1_000_000_000 / sample_rate as u128;
+    // The difference is the (small) buffer fill, so it fits in `u64` nanoseconds.
+    let buffered = Duration::from_nanos(written_nanos.saturating_sub(consumed_nanos) as u64);
+
+    let playback = callback + (buffered + stream.stream_latency);
     Ok(OutputStreamTimestamp { callback, playback })
 }

--- a/src/host/wasapi/stream.rs
+++ b/src/host/wasapi/stream.rs
@@ -652,10 +652,17 @@ fn run_output(
     let clock_frequency = match unsafe { run_ctxt.stream.audio_clock.GetFrequency() }
         .context("Failed to get audio clock frequency")
     {
-        Ok(frequency) => {
-            debug_assert_ne!(frequency, 0, "IAudioClock::GetFrequency returned zero");
-            frequency
+        Ok(0) => {
+            emit_error(
+                error_callback,
+                Error::with_message(
+                    ErrorKind::BackendError,
+                    "IAudioClock::GetFrequency returned zero",
+                ),
+            );
+            return;
         }
+        Ok(frequency) => frequency,
         Err(err) => {
             emit_error(error_callback, err);
             return;

--- a/src/host/wasapi/stream.rs
+++ b/src/host/wasapi/stream.rs
@@ -904,8 +904,8 @@ fn output_timestamp(
     frames_written: u64,
 ) -> Result<OutputStreamTimestamp, Error> {
     let (callback, position) = clock_position(stream)?;
-    // `padding` is the number of frames already queued in the endpoint buffer ahead of the
-    // frames we are about to write. Those frames must drain before ours are heard.
+    // `buffered` is the amount of audio we've already submitted that has not yet been consumed by
+    // the device at this instant; it determines when the next written frame will be heard.
     let consumed_nanos = position as u128 * 1_000_000_000 / clock_frequency as u128;
     let written_nanos = frames_written as u128 * 1_000_000_000 / sample_rate as u128;
     let buffered_nanos =

--- a/src/host/wasapi/stream.rs
+++ b/src/host/wasapi/stream.rs
@@ -822,9 +822,7 @@ fn process_output(
     };
 
     unsafe {
-        let buffer = render_client
-            .GetBuffer(frames_available)
-            .map_err(Error::from)?;
+        let buffer = render_client.GetBuffer(frames_available)?;
 
         debug_assert!(!buffer.is_null());
 
@@ -840,9 +838,7 @@ fn process_output(
         let info = OutputCallbackInfo { timestamp };
         data_callback(&mut data, &info);
 
-        render_client
-            .ReleaseBuffer(frames_available, 0)
-            .map_err(Error::from)?;
+        render_client.ReleaseBuffer(frames_available, 0)?;
 
         *frames_written += frames_available as u64;
     }
@@ -850,8 +846,8 @@ fn process_output(
     Ok(())
 }
 
-/// Atomically reads the stream's `IAudioClock`, returning the callback [`StreamInstant`]
-/// together with the device position.
+/// Reads the stream's `IAudioClock` in a single `GetPosition` call, returning the callback
+/// [`StreamInstant`] together with the device position from that same snapshot.
 #[inline]
 fn clock_position(stream: &StreamInner) -> Result<(StreamInstant, u64), Error> {
     let mut position: u64 = 0;
@@ -894,6 +890,12 @@ fn input_timestamp(
 /// Produce the output stream timestamp.
 ///
 /// `sample_rate` is the rate at which audio frames are processed by the device.
+///
+/// `clock_frequency` is the device clock's constant tick rate, used to convert the reported clock
+/// position into a played-out duration.
+///
+/// `frames_written` is the running total of frames submitted to the render buffer so far, used to
+/// derive how much audio is buffered ahead of the device position.
 #[inline]
 fn output_timestamp(
     stream: &StreamInner,


### PR DESCRIPTION
Pre-v0.18 the WASAPI playback timestamps were not monotonic because the padding calculation was backward. v0.18 made that go away for the most part [here](https://github.com/RustAudio/cpal/commit/2622b29#diff-ff4206a5c7e0e9d9eca133bcc06baa9c53113348b30f9e468653b924a1a13aa5R611), but still keeps a tiny window between two syscalls that could make it go awry.

This PR does an atomic read on the callback timestamp and playback position instead of those two syscalls.

Fixes https://github.com/BillyDM/Firewheel/issues/43