### PR TITLE
refactor(pipewire): ensure monotonic timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
-### Fixed
-
-- **PipeWire**: Fix non-monotonic timestamps on unusual clock readings.
-
 ## [0.18.1] - 2026-06-07
 
 ### Fixed
@@ -1291,7 +1285,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial commit.
 
-[Unreleased]: https://github.com/RustAudio/cpal/compare/v0.18.1...HEAD
 [0.18.1]: https://github.com/RustAudio/cpal/compare/v0.18.0...v0.18.1
 [0.18.0]: https://github.com/RustAudio/cpal/compare/v0.17.3...v0.18.0
 [0.17.3]: https://github.com/RustAudio/cpal/compare/v0.17.2...v0.17.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **PipeWire**: Fix non-monotonic timestamps on unusual clock readings.
+
 ## [0.18.1] - 2026-06-07
 
 ### Fixed
@@ -1285,6 +1291,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial commit.
 
+[Unreleased]: https://github.com/RustAudio/cpal/compare/v0.18.1...HEAD
 [0.18.1]: https://github.com/RustAudio/cpal/compare/v0.18.0...v0.18.1
 [0.18.0]: https://github.com/RustAudio/cpal/compare/v0.17.3...v0.18.0
 [0.17.3]: https://github.com/RustAudio/cpal/compare/v0.17.2...v0.17.3

--- a/src/host/pipewire/stream.rs
+++ b/src/host/pipewire/stream.rs
@@ -306,8 +306,8 @@ where
             Some(t) => {
                 let delay_ns = t.delay() * 1_000_000_000i64 / t.rate().denom as i64;
                 (
-                    StreamInstant::from_nanos(t.now() as u64),
-                    StreamInstant::from_nanos((t.now() - delay_ns.max(0)) as u64),
+                    StreamInstant::from_nanos(t.now().max(0) as u64),
+                    StreamInstant::from_nanos((t.now() - delay_ns.max(0)).max(0) as u64),
                 )
             }
             None => {
@@ -345,8 +345,8 @@ where
             Some(t) => {
                 let delay_ns = t.delay() * 1_000_000_000i64 / t.rate().denom as i64;
                 (
-                    StreamInstant::from_nanos(t.now() as u64),
-                    StreamInstant::from_nanos((t.now() + delay_ns.max(0)) as u64),
+                    StreamInstant::from_nanos(t.now().max(0) as u64),
+                    StreamInstant::from_nanos((t.now() + delay_ns.max(0)).max(0) as u64),
                 )
             }
             None => {

--- a/src/host/pipewire/stream.rs
+++ b/src/host/pipewire/stream.rs
@@ -304,10 +304,12 @@ where
 
         let (callback, capture) = match pw_stream_time(stream) {
             Some(t) => {
-                let delay_ns = t.delay() * 1_000_000_000i64 / t.rate().denom as i64;
+                // `pw_stream_time` guarantees `now > 0` and `denom != 0`.
+                let now = t.now() as u64;
+                let delay_ns = (t.delay() * 1_000_000_000i64 / t.rate().denom as i64).max(0) as u64;
                 (
-                    StreamInstant::from_nanos(t.now().max(0) as u64),
-                    StreamInstant::from_nanos((t.now() - delay_ns.max(0)).max(0) as u64),
+                    StreamInstant::from_nanos(now),
+                    StreamInstant::from_nanos(now.saturating_sub(delay_ns)),
                 )
             }
             None => {
@@ -343,10 +345,12 @@ where
 
         let (callback, playback) = match pw_stream_time(stream) {
             Some(t) => {
-                let delay_ns = t.delay() * 1_000_000_000i64 / t.rate().denom as i64;
+                // `pw_stream_time` guarantees `now > 0` and `denom != 0`.
+                let now = t.now() as u64;
+                let delay_ns = (t.delay() * 1_000_000_000i64 / t.rate().denom as i64).max(0) as u64;
                 (
-                    StreamInstant::from_nanos(t.now().max(0) as u64),
-                    StreamInstant::from_nanos((t.now() + delay_ns.max(0)).max(0) as u64),
+                    StreamInstant::from_nanos(now),
+                    StreamInstant::from_nanos(now.saturating_add(delay_ns)),
                 )
             }
             None => {


### PR DESCRIPTION
Similar in spirit to #1246 but without the race.