### PR TITLE
Channel names for CoreAudio and ASIO

### DIFF
--- a/asio-sys/src/bindings/mod.rs
+++ b/asio-sys/src/bindings/mod.rs
@@ -926,6 +926,18 @@ impl Driver {
         let mut dcb = DRIVER_EVENT_CALLBACKS.lock().unwrap();
         dcb.retain(|&(id, _)| id != rem_id);
     }
+
+    /// Returns the name of the channel at the given index.
+    ///
+    /// `channel` is a 0-based channel index. `is_input` selects the input (`true`) or output
+    /// (`false`) direction.
+    ///
+    /// The driver must already be loaded (i.e. this `Driver` instance must be alive).
+    pub fn channel_name(&self, channel: i32, is_input: bool) -> Result<String, AsioError> {
+        let _guard = self.inner.lock_state();
+        let info = asio_channel_info(channel, is_input)?;
+        Ok(driver_name_to_utf8(&info.name).into_owned())
+    }
 }
 
 impl DriverState {

--- a/examples/custom.rs
+++ b/examples/custom.rs
@@ -187,6 +187,13 @@ impl DeviceTrait for MyDevice {
             handle: Some(handle),
         })
     }
+
+    fn get_channel_name(&self, channel_index: u16, input: bool) -> Result<String, Error> {
+        Ok(format!(
+            "{} {channel_index}",
+            if input { "Input" } else { "Output" }
+        ))
+    }
 }
 
 impl StreamTrait for MyStream {

--- a/src/host/aaudio/mod.rs
+++ b/src/host/aaudio/mod.rs
@@ -738,7 +738,7 @@ impl DeviceTrait for Device {
     }
 
     fn get_channel_name(&self, channel_index: u16, input: bool) -> Result<String, Error> {
-        Err(Error::UnsupportedOperation)
+        Err(Error::new(ErrorKind::UnsupportedOperation))
     }
 }
 

--- a/src/host/aaudio/mod.rs
+++ b/src/host/aaudio/mod.rs
@@ -679,6 +679,10 @@ impl DeviceTrait for Device {
             sample_format,
         )
     }
+
+    fn get_channel_name(&self, channel_index: u16, input: bool) -> Result<String, Error> {
+        Err(Error::UnsupportedOperation)
+    }
 }
 
 impl StreamTrait for Stream {

--- a/src/host/alsa/mod.rs
+++ b/src/host/alsa/mod.rs
@@ -266,6 +266,10 @@ impl DeviceTrait for Device {
         );
         Ok(stream)
     }
+
+    fn get_channel_name(&self, channel_index: u16, input: bool) -> Result<String, Error> {
+        Err(Error::UnsupportedOperation)
+    }
 }
 
 #[derive(Debug)]

--- a/src/host/alsa/mod.rs
+++ b/src/host/alsa/mod.rs
@@ -306,7 +306,7 @@ impl DeviceTrait for Device {
     }
 
     fn get_channel_name(&self, channel_index: u16, input: bool) -> Result<String, Error> {
-        Err(Error::UnsupportedOperation)
+        Err(Error::new(ErrorKind::UnsupportedOperation))
     }
 }
 

--- a/src/host/asio/device.rs
+++ b/src/host/asio/device.rs
@@ -25,6 +25,8 @@ pub struct Device {
     input_sample_format: Option<SampleFormat>,
     output_sample_format: Option<SampleFormat>,
     supported_sample_rates: Vec<SampleRate>,
+    input_channel_names: Vec<String>,
+    output_channel_names: Vec<String>,
 
     // Input and/or Output stream.
     // A driver can only have one of each.
@@ -140,6 +142,26 @@ impl Device {
         }
         configs
     }
+
+    pub fn get_channel_name(&self, channel_index: u16, input: bool) -> Result<String, Error> {
+        let names = if input {
+            &self.input_channel_names
+        } else {
+            &self.output_channel_names
+        };
+
+        names.get(channel_index as usize).cloned().ok_or_else(|| {
+            Error::with_message(
+                ErrorKind::InvalidInput,
+                format!(
+                    "channel index {} is out of range (device has {} {} channels)",
+                    channel_index,
+                    names.len(),
+                    if input { "input" } else { "output" },
+                ),
+            )
+        })
+    }
 }
 
 impl Devices {
@@ -197,6 +219,13 @@ impl Iterator for Devices {
                             .filter(|&r| driver.can_sample_rate(r.into()).unwrap_or(false))
                             .collect();
 
+                        let input_channel_names: Vec<String> = (0..channels.ins)
+                            .map(|ch| driver.channel_name(ch, true).unwrap_or_default())
+                            .collect();
+                        let output_channel_names: Vec<String> = (0..channels.outs)
+                            .map(|ch| driver.channel_name(ch, false).unwrap_or_default())
+                            .collect();
+
                         self.current_driver = Some(driver);
 
                         let asio_streams = Arc::new(Mutex::new(sys::AsioStreams {
@@ -214,6 +243,8 @@ impl Iterator for Devices {
                             input_sample_format,
                             output_sample_format,
                             supported_sample_rates,
+                            input_channel_names,
+                            output_channel_names,
                             asio_streams,
                             // Initialize with sentinel value so it never matches global flag state (0 or 1).
                             current_callback_flag: Arc::new(AtomicU32::new(u32::MAX)),

--- a/src/host/asio/mod.rs
+++ b/src/host/asio/mod.rs
@@ -143,6 +143,10 @@ impl DeviceTrait for Device {
             timeout,
         )
     }
+
+    fn get_channel_name(&self, channel_index: u16, input: bool) -> Result<String, Error> {
+        Device::get_channel_name(self, channel_index, input)
+    }
 }
 
 impl StreamTrait for Stream {

--- a/src/host/audioworklet/mod.rs
+++ b/src/host/audioworklet/mod.rs
@@ -445,7 +445,7 @@ impl DeviceTrait for Device {
     }
 
     fn get_channel_name(&self, channel_index: u16, input: bool) -> Result<String, Error> {
-        Err(Error::UnsupportedOperation)
+        Err(Error::new(ErrorKind::UnsupportedOperation))
     }
 }
 

--- a/src/host/audioworklet/mod.rs
+++ b/src/host/audioworklet/mod.rs
@@ -350,6 +350,10 @@ impl DeviceTrait for Device {
             buffer_size_frames,
         })
     }
+
+    fn get_channel_name(&self, channel_index: u16, input: bool) -> Result<String, Error> {
+        Err(Error::UnsupportedOperation)
+    }
 }
 
 impl StreamTrait for Stream {

--- a/src/host/coreaudio/macos/device.rs
+++ b/src/host/coreaudio/macos/device.rs
@@ -28,11 +28,11 @@ use objc2_core_audio::{
     kAudioDevicePropertyDeviceUID, kAudioDevicePropertyLatency,
     kAudioDevicePropertyNominalSampleRate, kAudioDevicePropertySafetyOffset,
     kAudioDevicePropertyStreamConfiguration, kAudioDevicePropertyStreamFormat,
-    kAudioObjectPropertyClass, kAudioObjectPropertyElementMain, kAudioObjectPropertyElementMaster,
-    kAudioObjectPropertyElementName, kAudioObjectPropertyScopeGlobal,
-    kAudioObjectPropertyScopeInput, kAudioObjectPropertyScopeOutput, AudioClassID, AudioDeviceID,
-    AudioObjectGetPropertyData, AudioObjectGetPropertyDataSize, AudioObjectID,
-    AudioObjectPropertyAddress, AudioObjectPropertyScope, AudioObjectSetPropertyData,
+    kAudioObjectPropertyClass, kAudioObjectPropertyElementMain, kAudioObjectPropertyElementName,
+    kAudioObjectPropertyScopeGlobal, kAudioObjectPropertyScopeInput,
+    kAudioObjectPropertyScopeOutput, AudioClassID, AudioDeviceID, AudioObjectGetPropertyData,
+    AudioObjectGetPropertyDataSize, AudioObjectID, AudioObjectPropertyAddress,
+    AudioObjectPropertyScope, AudioObjectSetPropertyData,
 };
 use objc2_core_audio_types::{
     AudioBuffer, AudioBufferList, AudioStreamBasicDescription, AudioValueRange,
@@ -1138,7 +1138,7 @@ unsafe fn get_channel_name_for_device(
     check_os_status(status)?;
 
     if !channel_name.is_null() {
-        Ok(CFString::wrap_under_create_rule(channel_name).to_string())
+        Ok(CFRetained::from_raw(NonNull::new(channel_name).unwrap()).to_string())
     } else {
         Err(Error::with_message(
             ErrorKind::Other,

--- a/src/host/coreaudio/macos/device.rs
+++ b/src/host/coreaudio/macos/device.rs
@@ -25,18 +25,17 @@ use objc2_audio_toolbox::{
     kAudioOutputUnitProperty_CurrentDevice, kAudioOutputUnitProperty_EnableIO,
     kAudioUnitProperty_StreamFormat,
 };
-use objc2_core_audio::kAudioDevicePropertyDeviceUID;
-use objc2_core_audio::kAudioObjectPropertyElementMain;
 use objc2_core_audio::{
     kAudioAggregateDeviceClassID, kAudioDevicePropertyAvailableNominalSampleRates,
     kAudioDevicePropertyBufferFrameSize, kAudioDevicePropertyBufferFrameSizeRange,
-    kAudioDevicePropertyLatency, kAudioDevicePropertyNominalSampleRate,
-    kAudioDevicePropertySafetyOffset, kAudioDevicePropertyStreamConfiguration,
-    kAudioDevicePropertyStreamFormat, kAudioObjectPropertyClass, kAudioObjectPropertyElementMaster,
-    kAudioObjectPropertyScopeGlobal, kAudioObjectPropertyScopeInput,
-    kAudioObjectPropertyScopeOutput, AudioClassID, AudioDeviceID, AudioObjectGetPropertyData,
-    AudioObjectGetPropertyDataSize, AudioObjectID, AudioObjectPropertyAddress,
-    AudioObjectPropertyScope, AudioObjectSetPropertyData,
+    kAudioDevicePropertyDeviceUID, kAudioDevicePropertyLatency,
+    kAudioDevicePropertyNominalSampleRate, kAudioDevicePropertySafetyOffset,
+    kAudioDevicePropertyStreamConfiguration, kAudioDevicePropertyStreamFormat,
+    kAudioObjectPropertyClass, kAudioObjectPropertyElementMain, kAudioObjectPropertyElementMaster,
+    kAudioObjectPropertyElementName, kAudioObjectPropertyScopeGlobal,
+    kAudioObjectPropertyScopeInput, kAudioObjectPropertyScopeOutput, AudioClassID, AudioDeviceID,
+    AudioObjectGetPropertyData, AudioObjectGetPropertyDataSize, AudioObjectID,
+    AudioObjectPropertyAddress, AudioObjectPropertyScope, AudioObjectSetPropertyData,
 };
 use objc2_core_audio_types::{
     AudioBuffer, AudioBufferList, AudioStreamBasicDescription, AudioValueRange,
@@ -343,6 +342,10 @@ impl DeviceTrait for Device {
             error_callback,
             timeout,
         )
+    }
+
+    fn get_channel_name(&self, channel_index: u16, input: bool) -> Result<String, Error> {
+        Device::get_channel_name(self, channel_index, input)
     }
 }
 
@@ -703,6 +706,24 @@ impl Device {
             .map(|mut configs| configs.next().is_some())
             .unwrap_or(false)
     }
+
+    fn get_channel_name(&self, channel_index: u16, input: bool) -> Result<String, Error> {
+        if input && !self.supports_input() {
+            return Err(Error::with_message(
+                ErrorKind::InvalidInput,
+                "Device does not support input",
+            ));
+        }
+
+        if !input && !self.supports_output() {
+            return Err(Error::with_message(
+                ErrorKind::InvalidInput,
+                "Device does not support output",
+            ));
+        }
+
+        unsafe { get_channel_name_for_device(self.audio_device_id, channel_index, input) }
+    }
 }
 
 impl fmt::Debug for Device {
@@ -1028,4 +1049,43 @@ pub(crate) fn get_device_buffer_frame_size(
         Element::Output,
     )?;
     Ok(frames as usize)
+}
+
+unsafe fn get_channel_name_for_device(
+    device_id: AudioDeviceID,
+    channel_index: u16,
+    input: bool,
+) -> Result<String, Error> {
+    let mut channel_name: *mut CFString = std::ptr::null_mut();
+    let mut data_size = size_of::<*mut CFString>() as u32;
+
+    let property_address = AudioObjectPropertyAddress {
+        mSelector: kAudioObjectPropertyElementName,
+        mScope: if input {
+            kAudioObjectPropertyScopeInput
+        } else {
+            kAudioObjectPropertyScopeOutput
+        },
+        // Channels numbers start at 1 here
+        mElement: channel_index as u32 + 1,
+    };
+
+    let status = AudioObjectGetPropertyData(
+        device_id,
+        NonNull::from(&property_address),
+        0,
+        null(),
+        NonNull::from(&mut data_size),
+        NonNull::from(&mut channel_name).cast(),
+    );
+    check_os_status(status)?;
+
+    if !channel_name.is_null() {
+        Ok(CFString::wrap_under_create_rule(channel_name).to_string())
+    } else {
+        Err(Error::with_message(
+            ErrorKind::Other,
+            "channel name is null",
+        ))
+    }
 }

--- a/src/host/custom/mod.rs
+++ b/src/host/custom/mod.rs
@@ -431,6 +431,10 @@ impl DeviceTrait for Device {
             timeout,
         )
     }
+
+    fn get_channel_name(&self, channel_index: u16, input: bool) -> Result<String, Error> {
+        Err(Error::UnsupportedOperation)
+    }
 }
 
 impl StreamTrait for Stream {

--- a/src/host/custom/mod.rs
+++ b/src/host/custom/mod.rs
@@ -453,7 +453,7 @@ impl DeviceTrait for Device {
     }
 
     fn get_channel_name(&self, channel_index: u16, input: bool) -> Result<String, Error> {
-        Err(Error::UnsupportedOperation)
+        Err(Error::new(ErrorKind::UnsupportedOperation))
     }
 }
 

--- a/src/host/jack/device.rs
+++ b/src/host/jack/device.rs
@@ -324,6 +324,10 @@ impl DeviceTrait for Device {
             build()
         }
     }
+
+    fn get_channel_name(&self, channel_index: u16, input: bool) -> Result<String, Error> {
+        Err(Error::UnsupportedOperation)
+    }
 }
 
 impl PartialEq for Device {

--- a/src/host/jack/device.rs
+++ b/src/host/jack/device.rs
@@ -349,7 +349,7 @@ impl DeviceTrait for Device {
     }
 
     fn get_channel_name(&self, channel_index: u16, input: bool) -> Result<String, Error> {
-        Err(Error::UnsupportedOperation)
+        Err(Error::new(ErrorKind::UnsupportedOperation))
     }
 }
 

--- a/src/host/null/mod.rs
+++ b/src/host/null/mod.rs
@@ -103,6 +103,10 @@ impl DeviceTrait for Device {
     {
         unimplemented!()
     }
+
+    fn get_channel_name(&self, channel_index: u16, input: bool) -> Result<String, Error> {
+        Err(Error::UnsupportedOperation)
+    }
 }
 
 impl HostTrait for Host {

--- a/src/host/null/mod.rs
+++ b/src/host/null/mod.rs
@@ -106,7 +106,7 @@ impl DeviceTrait for Device {
     }
 
     fn get_channel_name(&self, channel_index: u16, input: bool) -> Result<String, Error> {
-        Err(Error::UnsupportedOperation)
+        Err(Error::new(ErrorKind::UnsupportedOperation))
     }
 }
 

--- a/src/host/pipewire/device.rs
+++ b/src/host/pipewire/device.rs
@@ -454,6 +454,10 @@ impl DeviceTrait for Device {
             )),
         }
     }
+
+    fn get_channel_name(&self, channel_index: u16, input: bool) -> Result<String, Error> {
+        Err(Error::UnsupportedOperation)
+    }
 }
 
 #[derive(Debug, Clone, Default)]

--- a/src/host/pipewire/device.rs
+++ b/src/host/pipewire/device.rs
@@ -694,7 +694,7 @@ impl DeviceTrait for Device {
     }
 
     fn get_channel_name(&self, channel_index: u16, input: bool) -> Result<String, Error> {
-        Err(Error::UnsupportedOperation)
+        Err(Error::new(ErrorKind::UnsupportedOperation))
     }
 }
 

--- a/src/host/pulseaudio/mod.rs
+++ b/src/host/pulseaudio/mod.rs
@@ -468,6 +468,10 @@ impl DeviceTrait for Device {
 
         Ok(DeviceId(HostId::PulseAudio, id.to_string()))
     }
+
+    fn get_channel_name(&self, channel_index: u16, input: bool) -> Result<String, Error> {
+        Err(Error::UnsupportedOperation)
+    }
 }
 
 fn make_sample_spec(config: StreamConfig, format: protocol::SampleFormat) -> protocol::SampleSpec {

--- a/src/host/pulseaudio/mod.rs
+++ b/src/host/pulseaudio/mod.rs
@@ -526,7 +526,7 @@ impl DeviceTrait for Device {
     }
 
     fn get_channel_name(&self, channel_index: u16, input: bool) -> Result<String, Error> {
-        Err(Error::UnsupportedOperation)
+        Err(Error::new(ErrorKind::UnsupportedOperation))
     }
 }
 

--- a/src/host/wasapi/device.rs
+++ b/src/host/wasapi/device.rs
@@ -154,6 +154,10 @@ impl DeviceTrait for Device {
             error_callback,
         ))
     }
+
+    fn get_channel_name(&self, channel_index: u16, input: bool) -> Result<String, Error> {
+        Err(Error::UnsupportedOperation)
+    }
 }
 
 struct Endpoint {

--- a/src/host/wasapi/device.rs
+++ b/src/host/wasapi/device.rs
@@ -158,7 +158,7 @@ impl DeviceTrait for Device {
     }
 
     fn get_channel_name(&self, channel_index: u16, input: bool) -> Result<String, Error> {
-        Err(Error::UnsupportedOperation)
+        Err(Error::new(ErrorKind::UnsupportedOperation))
     }
 }
 

--- a/src/host/webaudio/mod.rs
+++ b/src/host/webaudio/mod.rs
@@ -578,7 +578,7 @@ impl DeviceTrait for Device {
     }
 
     fn get_channel_name(&self, channel_index: u16, input: bool) -> Result<String, Error> {
-        Err(Error::UnsupportedOperation)
+        Err(Error::new(ErrorKind::UnsupportedOperation))
     }
 }
 

--- a/src/host/webaudio/mod.rs
+++ b/src/host/webaudio/mod.rs
@@ -508,6 +508,10 @@ impl DeviceTrait for Device {
             is_started,
         })
     }
+
+    fn get_channel_name(&self, channel_index: u16, input: bool) -> Result<String, Error> {
+        Err(Error::UnsupportedOperation)
+    }
 }
 
 impl Stream {

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -537,6 +537,15 @@ macro_rules! impl_platform_host {
                     )*
                 }
             }
+
+            fn get_channel_name(&self, channel_index: u16, input: bool) -> Result<String, crate::Error> {
+                match self.0 {
+                    $(
+                        $(#[cfg($feat)])?
+                        DeviceInner::$HostVariant(ref d) => d.get_channel_name(channel_index, input),
+                    )*
+                }
+            }
         }
 
         impl crate::traits::HostTrait for Host {

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -414,6 +414,30 @@ pub trait DeviceTrait {
     where
         D: FnMut(&mut Data, &OutputCallbackInfo) + Send + 'static,
         E: FnMut(Error) + Send + 'static;
+
+    /// Obtain the associated string name for a channel index.
+    ///
+    /// This method is only implemented for CoreAudio (macOS) and ASIO (Windows). All other
+    /// backends will return [`ErrorKind::UnsupportedOperation`].
+    ///
+    /// # Parameters
+    ///
+    /// * `channel_index` - Channel index to query name for.
+    /// * `input` - Whether to query an input channel (true) or output channel (false).
+    ///
+    /// # Errors
+    ///
+    /// - [`ErrorKind::UnsupportedOperation`] if the backend does not implement channel name
+    ///   queries.
+    /// - [`ErrorKind::InvalidInput`] if the channel index is out of range for the device,
+    ///   or if the device does not support the requested direction (input/output).
+    /// - [`ErrorKind::Other`] for unclassifiable backend failures (e.g., the channel name could
+    ///   not be retrieved from the device).
+    ///
+    /// [`ErrorKind::UnsupportedOperation`]: crate::ErrorKind::UnsupportedOperation
+    /// [`ErrorKind::InvalidInput`]: crate::ErrorKind::InvalidInput
+    /// [`ErrorKind::Other`]: crate::ErrorKind::Other
+    fn get_channel_name(&self, channel_index: u16, input: bool) -> Result<String, Error>;
 }
 
 /// A stream created from [`Device`](DeviceTrait), with methods to control playback.


### PR DESCRIPTION
This PR refers to this [issue](https://github.com/RustAudio/cpal/issues/879).

I implemented a version of this to showcase how I imagined it. When I wrote the issue, I hadn't realized that the error convention had changed from 0.16 to 0.17. This PR adheres to the current error convention.