### PR TITLE
feat(coreaudio): check macOS system audio permission

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,6 +156,8 @@ objc2 = { version = "0.6" }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 jack = { version = "0.13.5", optional = true }
+libloading = "0.8"
+block2 = "0.6"
 
 [target.'cfg(any(target_os = "ios", target_os = "tvos"))'.dependencies]
 block2 = "0.6"

--- a/examples/macos_system_audio_permission.rs
+++ b/examples/macos_system_audio_permission.rs
@@ -1,0 +1,29 @@
+/*
+Demonstrates the app-controlled macOS system audio recording permission flow.
+
+Run with:
+    cargo run --example macos_system_audio_permission
+*/
+
+#[cfg(target_os = "macos")]
+fn main() {
+    if cpal::platform::check_system_audio_permission() {
+        println!("System audio recording permission is already granted");
+        return;
+    }
+
+    println!("Requesting system audio recording permission...");
+    if cpal::platform::request_system_audio_permission() {
+        println!("System audio recording permission granted");
+    } else {
+        println!(
+            "System audio recording permission denied or unavailable; opening System Settings"
+        );
+        cpal::platform::open_system_audio_settings();
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn main() {
+    eprintln!("This example is only available on macOS");
+}

--- a/src/host/coreaudio/macos/loopback.rs
+++ b/src/host/coreaudio/macos/loopback.rs
@@ -84,6 +84,13 @@ impl LoopbackDevice {
     /// Create a [`LoopbackDevice`] that records the sound
     /// output of `device`.
     pub fn from_device(device: &Device) -> Result<Self, Error> {
+        if !super::permissions::check_system_audio_permission() {
+            return Err(Error::with_message(
+                ErrorKind::PermissionDenied,
+                "System audio recording permission is required for macOS loopback recording; call cpal::platform::request_system_audio_permission() or grant it in System Settings",
+            ));
+        }
+
         // 1 - Create tap
 
         let pid = std::process::id();

--- a/src/host/coreaudio/macos/mod.rs
+++ b/src/host/coreaudio/macos/mod.rs
@@ -23,6 +23,7 @@ use crate::{
 mod device;
 pub mod enumerate;
 mod loopback;
+pub(crate) mod permissions;
 mod property_listener;
 pub use device::Device;
 

--- a/src/host/coreaudio/macos/permissions.rs
+++ b/src/host/coreaudio/macos/permissions.rs
@@ -1,0 +1,90 @@
+//! macOS system audio recording permission helpers.
+//!
+//! CoreAudio process taps require the "System Audio Recording" permission
+//! (`kTCCServiceAudioCapture`). Without it, loopback recording can produce
+//! silence without surfacing an OS error or permission prompt.
+
+use block2::StackBlock;
+use libloading::{Library, Symbol};
+use objc2_core_foundation::{CFRetained, CFString};
+use std::{ffi::c_void, sync::OnceLock};
+
+const TCC_FRAMEWORK: &str = "/System/Library/PrivateFrameworks/TCC.framework/Versions/A/TCC";
+const TCC_SERVICE: &str = "kTCCServiceAudioCapture";
+
+fn load_tcc() -> Option<&'static Library> {
+    static LIBRARY: OnceLock<Option<Library>> = OnceLock::new();
+
+    LIBRARY
+        .get_or_init(|| unsafe { Library::new(TCC_FRAMEWORK) }.ok())
+        .as_ref()
+}
+
+fn tcc_service() -> CFRetained<CFString> {
+    CFString::from_str(TCC_SERVICE)
+}
+
+/// Check whether the process currently has system audio recording permission.
+///
+/// This is non-blocking and never shows UI. It returns `false` if permission is
+/// denied, not yet granted, or cannot be determined.
+pub fn check_system_audio_permission() -> bool {
+    let Some(lib) = load_tcc() else { return false };
+    unsafe {
+        let Ok(preflight_fn): Result<
+            Symbol<unsafe extern "C" fn(*const c_void, *const c_void) -> i32>,
+            _,
+        > = lib.get(b"TCCAccessPreflight\0") else {
+            return false;
+        };
+
+        let service = tcc_service();
+        preflight_fn(&*service as *const _ as *const c_void, std::ptr::null()) == 0
+    }
+}
+
+/// Request system audio recording permission, showing the system prompt if needed.
+///
+/// **Blocking** - does not return until the user responds. Returns `false`
+/// immediately if the permission was previously denied without showing UI; call
+/// [`open_system_audio_settings`] in that case.
+pub fn request_system_audio_permission() -> bool {
+    let Some(lib) = load_tcc() else { return false };
+    unsafe {
+        let Ok(request_fn): Result<
+            Symbol<unsafe extern "C" fn(*const c_void, *const c_void, *const c_void)>,
+            _,
+        > = lib.get(b"TCCAccessRequest\0") else {
+            return false;
+        };
+
+        let (tx, rx) = std::sync::mpsc::sync_channel::<bool>(1);
+        // Store as usize (Copy) so TCC's internal block memcpy doesn't double-drop the sender.
+        let tx_ptr = Box::into_raw(Box::new(tx)) as usize;
+
+        let completion = StackBlock::new(move |granted: u8| {
+            let tx = Box::from_raw(tx_ptr as *mut std::sync::mpsc::SyncSender<bool>);
+            tx.send(granted != 0).ok();
+        });
+
+        let service = tcc_service();
+        request_fn(
+            &*service as *const _ as *const c_void,
+            std::ptr::null(),
+            &completion as *const _ as *const c_void,
+        );
+
+        rx.recv().unwrap_or(false)
+    }
+}
+
+/// Open Privacy & Security > System Audio Recording in System Settings.
+///
+/// Call this when [`request_system_audio_permission`] returns `false` after the
+/// permission was previously denied.
+pub fn open_system_audio_settings() {
+    std::process::Command::new("open")
+        .arg("x-apple.systempreferences:com.apple.settings.PrivacySecurity.extension?Privacy_AudioCapture")
+        .spawn()
+        .ok();
+}

--- a/src/host/coreaudio/mod.rs
+++ b/src/host/coreaudio/mod.rs
@@ -14,7 +14,7 @@ use crate::{Error, ErrorKind, SampleFormat, StreamConfig, StreamInstant};
 #[cfg(not(target_os = "macos"))]
 mod ios;
 #[cfg(target_os = "macos")]
-mod macos;
+pub(crate) mod macos;
 
 #[cfg(not(target_os = "macos"))]
 #[allow(unused_imports)]

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -853,7 +853,13 @@ mod platform_impl {
 mod platform_impl {
     #[cfg(all(feature = "jack", target_os = "macos"))]
     use super::JackHost;
-    use crate::host::coreaudio::Host as CoreAudioHost;
+    #[cfg(target_os = "macos")]
+    #[cfg_attr(docsrs, doc(cfg(target_os = "macos")))]
+    pub use crate::host::coreaudio::macos::permissions::{
+        check_system_audio_permission, open_system_audio_settings, request_system_audio_permission,
+    };
+    #[cfg_attr(docsrs, doc(cfg(any(target_os = "macos", target_os = "ios"))))]
+    pub use crate::host::coreaudio::Host as CoreAudioHost;
 
     impl_platform_host!(
         CoreAudio => CoreAudioHost,


### PR DESCRIPTION
## Summary

This adds macOS System Audio Recording permission helpers and uses the non-blocking check before constructing a CoreAudio loopback process tap.

The goal is to avoid the current failure mode where CoreAudio tap loopback can build successfully but record silence when the process is missing the `kTCCServiceAudioCapture` permission. Stream construction now fails early with `ErrorKind::PermissionDenied` instead of silently producing empty audio.

## Design

- Add `cpal::platform::check_system_audio_permission()` as a non-blocking permission check.
- Add explicit app-controlled helpers:
  - `cpal::platform::request_system_audio_permission()`
  - `cpal::platform::open_system_audio_settings()`
- Call only the non-blocking check from `LoopbackDevice::from_device()`.
- Return `ErrorKind::PermissionDenied` when permission is missing.
- Keep the macOS backend module crate-visible rather than making `coreaudio::macos` public.
- Add a minimal example showing the check/request/settings flow.

This follows the middle-ground approach discussed in #1124: CPAL does not show blocking permission UI during stream construction, but applications can explicitly request permission at an appropriate time.

## Related context

- Closes/addresses system-audio permission part of #876
- Builds on the CoreAudio Tap loopback work from #1003
- Follow-up to #1124
- Related permission behavior discussion: https://github.com/RustAudio/cpal/pull/894#issuecomment-3823323664

## Testing

Ran on macOS/aarch64:

```console
cargo fmt --check
cargo check --target aarch64-apple-darwin
cargo clippy --target aarch64-apple-darwin --lib -- -D warnings
cargo clippy --target aarch64-apple-darwin --example macos_system_audio_permission -- -D warnings
cargo check --target aarch64-apple-darwin --example macos_system_audio_permission
```

Manual probes:

- `check_system_audio_permission()` returned the current permission state.
- `request_system_audio_permission()` returned successfully after granting permission.
- `open_system_audio_settings()` opened System Settings.
- Building an input stream from the default output device with missing permission returned:

```text
kind=PermissionDenied
msg=System audio recording permission is required for macOS loopback recording; call cpal::platform::request_system_audio_permission() or grant it in System Settings
```
