### PR TITLE
feat: rename StreamTrait::play to start, add draining stop

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -56,7 +56,7 @@ jobs:
           # Android - Oboe backend
           - target: armv7-linux-androideabi
             name: Android
-            features: ""
+            features: --features realtime
             os: ubuntu-latest
 
           # iOS - CoreAudio (iOS) backend

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `StreamTrait::stop` ends a stream gracefully, draining buffered audio before halting (blocking up to a caller-supplied timeout). Dropping a stream still halts immediately without draining.
+
 ### Changed
 
 - Migrated to Rust 2024.
 - `DeviceTrait` and `StreamTrait` now require `Send + Sync` as supertrait bounds.
+- `StreamTrait::play` is renamed to `start`.
 - **ALSA**: Update `alsa` dependency to 0.12.
 - **WASAPI**: The `windows` and `windows-core` dependencies are now both pinned to 0.62.
 
 ### Deprecated
 
+- `StreamTrait::play` is deprecated in favor of `start`.
 - `assert_stream_send!` and `assert_stream_sync!` are deprecated; `StreamTrait: Send + Sync` makes them redundant.
 
 ### Fixed
@@ -23,13 +29,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Timestamps now stay monotonic across device and graph changes.
 - **ALSA**: A nonzero but sub-millisecond stream timeout is no longer treated as a non-blocking poll.
 - **AudioWorklet**: Fix `Stream` operations to work when called from any thread.
-- **WebAudio**: Fix unsound `Send + Sync` on `Stream` when compiled with `+atomics`.
-- **WebAudio**: Fix `Host::is_available()` always returning `true`, even in non-window contexts.
 - **CoreAudio**: Bump `objc2-core-foundation` dependency lower bound to 0.3.1.
+- **CoreAudio**: Fix stale audio output when a data callback wrote a partial buffer.
 - **iOS**: Timestamps now include hardware latency and update when the audio route changes.
 - **JACK**: Timestamps now include port latency.
-- **WASAPI**: The `windows` and `windows-core` dependencies are now both pinned to 0.62.
+- **PipeWire**: Fix streams starting audio before `start()` is called.
 - **WASAPI**: Reported buffer sizes are no longer off by one frame.
+- **WebAudio**: Fix unsound `Send + Sync` on `Stream` when compiled with `+atomics`.
+- **WebAudio**: Fix `Host::is_available()` always returning `true`, even in non-window contexts.
 
 ## [0.18.1] - 2026-06-07
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -7,7 +7,7 @@ This guide covers breaking changes requiring code updates. See [CHANGELOG.md](CH
 - [ ] If you implement a custom host, ensure your `Device` and `Stream` types are `Send + Sync`.
 - [ ] Remove any calls to the deprecated `assert_stream_send!` and `assert_stream_sync!` macros.
 - [ ] Rename `StreamTrait::play` calls to `start` (the old name still works but is deprecated).
-- [ ] If you implement a custom host, consider overriding `StreamTrait::stop` for true draining support (the default falls back to `pause`).
+- [ ] If you implement a custom host, add a `StreamTrait::stop` implementation.
 
 ## 1. `DeviceTrait` and `StreamTrait` require `Send + Sync`
 
@@ -24,17 +24,17 @@ This only affects authors of `custom` host implementations. Users of built-in ho
 `start`, `pause`, and `stop` now form the transport controls:
 
 - `start` begins or resumes the stream (the rename reflects that it applies to capture streams too, not just playback).
-- `pause` halts the data callback as soon as possible, discarding any audio already buffered.
-- `stop(timeout)` drains: on output streams it lets buffered audio finish playing, blocking the calling thread until the buffer empties or `timeout` elapses, then halts. `None` waits indefinitely; `Some(Duration::ZERO)` halts immediately without draining. All three leave the stream resumable; dropping the stream still halts immediately without draining.
+- `pause` halts the data callback as soon as possible without waiting for buffered audio to finish.
+- `stop(timeout)` drains: on output streams it lets buffered audio finish playing, blocking the calling thread until the buffer empties or `timeout` elapses, then halts. `None` waits until drained; `Some(Duration::ZERO)` halts immediately without draining. All three leave the stream resumable; dropping the stream still halts immediately without draining.
 
 **Impact (built-in host users):** Replace `stream.play()` with `stream.start()`. Optionally adopt `stream.stop(timeout)` where you want playback to end cleanly rather than be cut off.
 
-**Impact (custom host authors):** Rename your `StreamTrait::play` implementation to `start`. `stop` has a default that falls back to `pause`; override it if your host has audio buffered outside the data callback.
+**Impact (custom host authors):** Rename your `StreamTrait::play` implementation to `start`. Add a `stop` implementation; if your host has no audio buffered outside the data callback, it can simply call `self.pause()`.
 
 Draining is best-effort and varies by backend: most built-in output backends respect the drain window. The exceptions are WebAudio, AudioWorklet, and ASIO, where `stop` halts immediately and `timeout` is ignored. On capture streams, `stop` also halts immediately.
 
 [`start`]: https://docs.rs/cpal/latest/cpal/traits/trait.StreamTrait.html#tymethod.start
-[`stop`]: https://docs.rs/cpal/latest/cpal/traits/trait.StreamTrait.html#method.stop
+[`stop`]: https://docs.rs/cpal/latest/cpal/traits/trait.StreamTrait.html#tymethod.stop
 
 ---
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -6,6 +6,8 @@ This guide covers breaking changes requiring code updates. See [CHANGELOG.md](CH
 
 - [ ] If you implement a custom host, ensure your `Device` and `Stream` types are `Send + Sync`.
 - [ ] Remove any calls to the deprecated `assert_stream_send!` and `assert_stream_sync!` macros.
+- [ ] Rename `StreamTrait::play` calls to `start` (the old name still works but is deprecated).
+- [ ] If you implement a custom host, consider overriding `StreamTrait::stop` for true draining support (the default falls back to `pause`).
 
 ## 1. `DeviceTrait` and `StreamTrait` require `Send + Sync`
 
@@ -14,6 +16,25 @@ This guide covers breaking changes requiring code updates. See [CHANGELOG.md](CH
 This only affects authors of `custom` host implementations. Users of built-in hosts are unaffected.
 
 **Impact:** Remove any `assert_stream_send!` and `assert_stream_sync!` calls from your custom host; they are now deprecated. If your `Device` or `Stream` type contains raw pointers or other non-`Send`/non-`Sync` internals (e.g. COM handles, JS objects), audit that concurrent access is actually safe, then add `unsafe impl Send` and `unsafe impl Sync`.
+
+## 2. `StreamTrait::play` renamed to `start`, and a new `stop` method
+
+**What changed:** `StreamTrait::play` is renamed to [`start`]. The old `play` remains as a deprecated default method that forwards to `start`, so existing code keeps compiling with a deprecation warning. A new [`stop`] method performs a *draining* stop.
+
+`start`, `pause`, and `stop` now form the transport controls:
+
+- `start` begins or resumes the stream (the rename reflects that it applies to capture streams too, not just playback).
+- `pause` halts the data callback as soon as possible, discarding any audio already buffered.
+- `stop(timeout)` drains: on output streams it lets buffered audio finish playing, blocking the calling thread until the buffer empties or `timeout` elapses, then halts. `None` waits indefinitely; `Some(Duration::ZERO)` halts immediately without draining. All three leave the stream resumable; dropping the stream still halts immediately without draining.
+
+**Impact (built-in host users):** Replace `stream.play()` with `stream.start()`. Optionally adopt `stream.stop(timeout)` where you want playback to end cleanly rather than be cut off.
+
+**Impact (custom host authors):** Rename your `StreamTrait::play` implementation to `start`. `stop` has a default that falls back to `pause`; override it if your host has audio buffered outside the data callback.
+
+Draining is best-effort and varies by backend: most built-in output backends respect the drain window. The exceptions are WebAudio, AudioWorklet, and ASIO, where `stop` halts immediately and `timeout` is ignored. On capture streams, `stop` also halts immediately.
+
+[`start`]: https://docs.rs/cpal/latest/cpal/traits/trait.StreamTrait.html#tymethod.start
+[`stop`]: https://docs.rs/cpal/latest/cpal/traits/trait.StreamTrait.html#method.stop
 
 ---
 

--- a/examples/android/src/lib.rs
+++ b/examples/android/src/lib.rs
@@ -65,7 +65,7 @@ where
         err_fn,
         None,
     )?;
-    stream.play()?;
+    stream.start()?;
 
     std::thread::sleep(std::time::Duration::from_millis(1000));
 

--- a/examples/audioworklet-beep/src/lib.rs
+++ b/examples/audioworklet-beep/src/lib.rs
@@ -94,7 +94,7 @@ where
             None,
         )
         .unwrap();
-    stream.play().unwrap();
+    stream.start().unwrap();
     stream
 }
 

--- a/examples/beep.rs
+++ b/examples/beep.rs
@@ -147,9 +147,12 @@ where
         err_fn,
         None,
     )?;
-    stream.play()?;
+    stream.start()?;
 
     std::thread::sleep(std::time::Duration::from_millis(1000));
+
+    // Let buffered audio finish playing (up to 200 ms) before halting, instead of cutting it off.
+    stream.stop(Some(std::time::Duration::from_millis(200)))?;
 
     Ok(())
 }

--- a/examples/custom.rs
+++ b/examples/custom.rs
@@ -194,12 +194,18 @@ impl fmt::Display for MyDevice {
 }
 
 impl StreamTrait for MyStream {
-    fn play(&self) -> Result<(), Error> {
+    fn start(&self) -> Result<(), Error> {
         self.controls.pause.store(false, Ordering::Relaxed);
         Ok(())
     }
 
     fn pause(&self) -> Result<(), Error> {
+        self.controls.pause.store(true, Ordering::Relaxed);
+        Ok(())
+    }
+
+    fn stop(&self, _timeout: Option<std::time::Duration>) -> Result<(), Error> {
+        // This example has no audio buffered outside the callback, so stop is an immediate halt.
         self.controls.pause.store(true, Ordering::Relaxed);
         Ok(())
     }
@@ -232,7 +238,7 @@ fn main() {
     let config = device.default_output_config().unwrap();
 
     let stream = make_stream(&device, config.into()).unwrap();
-    stream.play().unwrap();
+    stream.start().unwrap();
     std::thread::sleep(std::time::Duration::from_millis(4000));
 }
 

--- a/examples/feedback.rs
+++ b/examples/feedback.rs
@@ -145,8 +145,8 @@ fn main() -> anyhow::Result<()> {
         "Starting the input and output streams with `{}` milliseconds of latency.",
         opt.latency
     );
-    input_stream.play()?;
-    output_stream.play()?;
+    input_stream.start()?;
+    output_stream.start()?;
 
     // Run for 10 seconds before closing.
     println!("Playing for 10 seconds... ");

--- a/examples/ios-feedback/src/feedback.rs
+++ b/examples/ios-feedback/src/feedback.rs
@@ -76,8 +76,8 @@ pub fn run_example() -> Result<(), anyhow::Error> {
 
     // Play the streams.
     println!("Starting the input and output streams with `{LATENCY_MS}` milliseconds of latency.");
-    input_stream.play()?;
-    output_stream.play()?;
+    input_stream.start()?;
+    output_stream.start()?;
 
     // for the purposes of this demo, leak these so that after returning the audio units will
     // keep running

--- a/examples/record_wav.rs
+++ b/examples/record_wav.rs
@@ -159,7 +159,7 @@ fn main() -> Result<(), anyhow::Error> {
         }
     };
 
-    stream.play()?;
+    stream.start()?;
 
     // Let recording go for roughly three seconds.
     std::thread::sleep(std::time::Duration::from_secs(opt.duration));

--- a/examples/synth_tones.rs
+++ b/examples/synth_tones.rs
@@ -14,7 +14,7 @@ use cpal::{
 
 fn main() -> anyhow::Result<()> {
     let stream = stream_setup_for()?;
-    stream.play()?;
+    stream.start()?;
     std::thread::sleep(std::time::Duration::from_millis(4000));
     Ok(())
 }

--- a/examples/wasm-beep/src/lib.rs
+++ b/examples/wasm-beep/src/lib.rs
@@ -91,7 +91,7 @@ where
             None,
         )
         .unwrap();
-    stream.play().unwrap();
+    stream.start().unwrap();
     stream
 }
 

--- a/src/host/aaudio/mod.rs
+++ b/src/host/aaudio/mod.rs
@@ -7,7 +7,7 @@ use std::{
     hash::{Hash, Hasher},
     sync::{
         Arc, Mutex,
-        atomic::{AtomicI32, Ordering},
+        atomic::{AtomicBool, AtomicI32, Ordering},
     },
     time::Duration,
     vec::IntoIter as VecIntoIter,
@@ -138,6 +138,7 @@ pub struct Device(Option<AudioDeviceInfo>);
 pub struct Stream {
     inner: Arc<Mutex<AudioStream>>,
     direction: DeviceDirection,
+    draining: Arc<AtomicBool>,
 }
 
 // SAFETY: AudioStream can be safely sent between threads. The AAudio C API is thread-safe
@@ -319,6 +320,9 @@ where
     let error_callback_for_stream = error_callback.clone();
     let error_callback_for_data = error_callback.clone();
 
+    let draining = Arc::new(AtomicBool::new(false));
+    let draining_for_data = draining.clone();
+
     #[cfg(feature = "realtime")]
     let mut rt_checked = false;
     #[cfg(feature = "realtime")]
@@ -358,16 +362,18 @@ where
                 );
                 return ndk::audio::AudioCallbackResult::Stop;
             };
-            let cb_info = InputCallbackInfo {
-                timestamp: InputStreamTimestamp {
-                    callback: now_stream_instant(),
-                    capture: input_stream_instant(stream, sample_rate),
-                },
-            };
-            (data_callback)(
-                &unsafe { Data::from_parts(data as *mut _, n_samples, sample_format) },
-                &cb_info,
-            );
+            if !draining_for_data.load(Ordering::Relaxed) {
+                let cb_info = InputCallbackInfo {
+                    timestamp: InputStreamTimestamp {
+                        callback: now_stream_instant(),
+                        capture: input_stream_instant(stream, sample_rate),
+                    },
+                };
+                (data_callback)(
+                    &unsafe { Data::from_parts(data as *mut _, n_samples, sample_format) },
+                    &cb_info,
+                );
+            }
             ndk::audio::AudioCallbackResult::Continue
         }))
         .error_callback(Box::new(move |_stream, error| {
@@ -382,6 +388,7 @@ where
     Ok(Stream {
         inner: Arc::new(Mutex::new(stream)),
         direction: DeviceDirection::Input,
+        draining,
     })
 }
 
@@ -408,6 +415,9 @@ where
     let error_callback: ErrorCallbackArc = Arc::new(Mutex::new(error_callback));
     let error_callback_for_stream = error_callback.clone();
     let error_callback_for_data = error_callback.clone();
+
+    let draining = Arc::new(AtomicBool::new(false));
+    let draining_for_data = draining.clone();
 
     #[cfg(feature = "realtime")]
     let mut rt_checked = false;
@@ -456,17 +466,18 @@ where
                 std::slice::from_raw_parts_mut(data as *mut u8, byte_count).fill(0);
             }
 
-            // Deliver audio data to user callback
-            let cb_info = OutputCallbackInfo {
-                timestamp: OutputStreamTimestamp {
-                    callback: now_stream_instant(),
-                    playback: output_stream_instant(stream, sample_rate),
-                },
-            };
-            (data_callback)(
-                &mut unsafe { Data::from_parts(data as *mut _, n_samples, sample_format) },
-                &cb_info,
-            );
+            if !draining_for_data.load(Ordering::Relaxed) {
+                let cb_info = OutputCallbackInfo {
+                    timestamp: OutputStreamTimestamp {
+                        callback: now_stream_instant(),
+                        playback: output_stream_instant(stream, sample_rate),
+                    },
+                };
+                (data_callback)(
+                    &mut unsafe { Data::from_parts(data as *mut _, n_samples, sample_format) },
+                    &cb_info,
+                );
+            }
 
             // Dynamic buffer tuning for output streams
             // See: https://developer.android.com/ndk/guides/audio/aaudio/aaudio#tuning-buffers
@@ -539,6 +550,7 @@ where
     Ok(Stream {
         inner: Arc::new(Mutex::new(stream)),
         direction: DeviceDirection::Output,
+        draining,
     })
 }
 
@@ -760,7 +772,8 @@ impl Hash for Device {
 }
 
 impl StreamTrait for Stream {
-    fn play(&self) -> Result<(), Error> {
+    fn start(&self) -> Result<(), Error> {
+        self.draining.store(false, Ordering::Relaxed);
         let stream = self.inner.lock().map_err(|_| {
             Error::with_message(ErrorKind::StreamInvalidated, "Stream lock poisoned")
         })?;
@@ -796,6 +809,38 @@ impl StreamTrait for Stream {
                 "Pause is not supported on input streams",
             )),
         }
+    }
+
+    fn stop(&self, timeout: Option<Duration>) -> Result<(), Error> {
+        self.draining.store(true, Ordering::Relaxed);
+
+        let stream = self.inner.lock().map_err(|_| {
+            Error::with_message(ErrorKind::StreamInvalidated, "Stream lock poisoned")
+        })?;
+
+        if self.direction != DeviceDirection::Output {
+            stream.request_stop().context("Failed to stop stream")?;
+            return Ok(());
+        }
+
+        // Duration::ZERO: flush (discard) instead of drain; return immediately.
+        if timeout == Some(Duration::ZERO) {
+            stream.request_flush().context("Failed to flush stream")?;
+            return Ok(());
+        }
+
+        // AAudio output drains remaining audio during the Stopping state.
+        stream.request_stop().context("Failed to stop stream")?;
+        let wait_nanos = timeout.map_or(i64::MAX, |t| t.as_nanos().min(i64::MAX as u128) as i64);
+
+        // Best effort past this point: the stop already succeeded above.
+        if stream
+            .wait_for_state_change(ndk::audio::AudioStreamState::Stopping, wait_nanos)
+            .is_err()
+        {
+            let _ = stream.request_flush();
+        }
+        Ok(())
     }
 
     fn now(&self) -> StreamInstant {

--- a/src/host/alsa/mod.rs
+++ b/src/host/alsa/mod.rs
@@ -626,10 +626,7 @@ impl Device {
     // ALSA does not offer default stream formats, so instead we compare all supported formats by
     // the `SupportedStreamConfigRange::cmp_default_heuristics` order and select the greatest.
     fn default_config(&self, stream_t: alsa::Direction) -> Result<SupportedStreamConfig, Error> {
-        let mut formats: Vec<_> = match self.supported_configs(stream_t) {
-            Err(err) => return Err(err),
-            Ok(fmts) => fmts.collect(),
-        };
+        let mut formats: Vec<_> = self.supported_configs(stream_t)?.collect();
 
         formats.sort_by(|a, b| a.cmp_default_heuristics(b));
 

--- a/src/host/alsa/mod.rs
+++ b/src/host/alsa/mod.rs
@@ -9,13 +9,13 @@ extern crate libc;
 
 use std::{
     collections::HashMap,
-    fmt,
+    fmt, mem,
     sync::{
         Arc, Mutex,
         atomic::{AtomicBool, Ordering},
     },
     thread::{self, JoinHandle},
-    time::Duration,
+    time::{Duration, Instant},
     vec::IntoIter as VecIntoIter,
 };
 
@@ -28,6 +28,7 @@ use crate::{
     SampleFormat, SampleRate, StreamConfig, StreamInstant, SupportedBufferSize,
     SupportedStreamConfig, SupportedStreamConfigRange,
     host::{
+        Notify,
         equilibrium::{DSD_EQUILIBRIUM_BYTE, U8_EQUILIBRIUM_BYTE, fill_equilibrium},
         frames_to_duration,
         latch::Latch,
@@ -91,6 +92,9 @@ mod enumerate;
 
 const DEFAULT_DEVICE: &str = "default";
 const DEFAULT_PERIODS: alsa::pcm::Frames = 2;
+
+const POLL_INFINITE: i32 = -1; // "block until an event arrives"
+const TRIGGER_PAYLOAD_SIZE: libc::ssize_t = mem::size_of::<u64>() as libc::ssize_t;
 
 // Some ALSA plugins (e.g. alsaequal, certain USB drivers) are not reentrant.
 static ALSA_OPEN_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
@@ -314,10 +318,16 @@ struct TriggerReceiver(libc::c_int);
 
 impl TriggerSender {
     fn wakeup(&self) {
-        let buf = 1u64;
+        let buf = !0u64; // any non-zero value wakes poll()
         loop {
-            let ret = unsafe { libc::write(self.0, &buf as *const u64 as *const _, 8) };
-            if ret == 8 {
+            let ret = unsafe {
+                libc::write(
+                    self.0,
+                    &buf as *const u64 as *const _,
+                    TRIGGER_PAYLOAD_SIZE as _,
+                )
+            };
+            if ret == TRIGGER_PAYLOAD_SIZE {
                 return;
             }
             // write() can be interrupted by a signal before writing any bytes; retry.
@@ -334,8 +344,14 @@ impl TriggerReceiver {
     fn clear_pipe(&self) {
         let mut out = 0u64;
         loop {
-            let ret = unsafe { libc::read(self.0, &mut out as *mut u64 as *mut _, 8) };
-            if ret == 8 {
+            let ret = unsafe {
+                libc::read(
+                    self.0,
+                    &mut out as *mut u64 as *mut _,
+                    TRIGGER_PAYLOAD_SIZE as _,
+                )
+            };
+            if ret == TRIGGER_PAYLOAD_SIZE {
                 return;
             }
             // read() can be interrupted by a signal before reading any bytes; retry.
@@ -420,6 +436,9 @@ impl Device {
 
         let stream_inner = StreamInner {
             dropping: AtomicBool::new(false),
+            draining: AtomicBool::new(false),
+            parked: AtomicBool::new(false),
+            park: Notify::default(),
             direction: stream_type.into(),
             handle,
             sample_format,
@@ -716,6 +735,13 @@ struct StreamInner {
     // (e.g. broken due to a disconnected device).
     dropping: AtomicBool,
 
+    // Whether the user callback is currently suppressed.
+    draining: AtomicBool,
+
+    // Set by stop() to request the worker pause for exclusive PCM access during drain.
+    parked: AtomicBool,
+    park: Notify,
+
     // Stream direction.
     direction: DeviceDirection,
 
@@ -847,6 +873,51 @@ impl StreamInner {
                 | SND_PCM_TYPE_IEC958
         )
     }
+
+    // Signals the worker to pause at the top of its next loop iteration and waits for it to
+    // acknowledge. Returns early if the worker has already exited. The caller holds exclusive
+    // PCM access until unpark_worker() is called.
+    fn park_worker(&self) {
+        self.parked.store(true, Ordering::Relaxed);
+        let (lock, cvar) = &self.park;
+        let mut guard = lock.lock().unwrap_or_else(|e| e.into_inner());
+        // Exit if the worker acknowledged the park OR if the worker has exited (dropping=true).
+        while !*guard && !self.dropping.load(Ordering::Relaxed) {
+            guard = cvar.wait(guard).unwrap_or_else(|e| e.into_inner());
+        }
+    }
+
+    // Called by the worker when it sees parked=true: acknowledges the park, then sleeps
+    // until the caller calls unpark_worker().
+    fn acknowledge_park(&self) {
+        let (lock, cvar) = &self.park;
+        let mut guard = lock.lock().unwrap_or_else(|e| e.into_inner());
+        *guard = true;
+        cvar.notify_one();
+        while self.parked.load(Ordering::Relaxed) {
+            guard = cvar.wait(guard).unwrap_or_else(|e| e.into_inner());
+        }
+        *guard = false;
+    }
+
+    // Called by the worker on any exit that is not a normal drop: marks the stream dead and
+    // wakes any thread blocked in park_worker() so it doesn't hang indefinitely.
+    fn signal_worker_exit(&self) {
+        self.dropping.store(true, Ordering::Relaxed);
+        let (lock, cvar) = &self.park;
+        let _guard = lock.lock().unwrap_or_else(|e| e.into_inner());
+        cvar.notify_one();
+    }
+
+    // Releases the park: clears parked and wakes the worker from acknowledge_park().
+    fn unpark_worker(&self) {
+        let (lock, cvar) = &self.park;
+        let mut guard = lock.lock().unwrap_or_else(|e| e.into_inner());
+        *guard = false;
+        self.parked.store(false, Ordering::Relaxed);
+        drop(guard);
+        cvar.notify_one();
+    }
 }
 
 struct StreamWorkerContext {
@@ -862,7 +933,7 @@ impl StreamWorkerContext {
             // but an explicit Duration::ZERO stays 0 so a non-blocking poll can still be requested.
             d.as_nanos().div_ceil(1_000_000).min(i32::MAX as u128) as i32
         } else {
-            -1 // Don't timeout, wait forever.
+            POLL_INFINITE
         };
 
         // Pre-allocate a period-sized working buffer. Contents are overwritten each callback.
@@ -925,8 +996,11 @@ fn input_stream_worker(
 
     let mut ctxt = StreamWorkerContext::new(&timeout, stream, &rx);
     loop {
-        if stream.dropping.load(Ordering::Acquire) {
+        if stream.dropping.load(Ordering::Relaxed) {
             return;
+        }
+        if stream.parked.load(Ordering::Relaxed) {
+            stream.acknowledge_park();
         }
         let result = match poll_for_period(&rx, stream, &mut ctxt) {
             Ok(Poll::Pending) => continue,
@@ -954,6 +1028,7 @@ fn input_stream_worker(
                 }
                 ErrorKind::DeviceNotAvailable => {
                     error_callback(err);
+                    stream.signal_worker_exit();
                     return;
                 }
                 _ => error_callback(err),
@@ -983,8 +1058,11 @@ fn output_stream_worker(
     let mut ctxt = StreamWorkerContext::new(&timeout, stream, &rx);
 
     loop {
-        if stream.dropping.load(Ordering::Acquire) {
+        if stream.dropping.load(Ordering::Relaxed) {
             return;
+        }
+        if stream.parked.load(Ordering::Relaxed) {
+            stream.acknowledge_park();
         }
         let result = match poll_for_period(&rx, stream, &mut ctxt) {
             Ok(Poll::Pending) => continue,
@@ -1013,6 +1091,7 @@ fn output_stream_worker(
                 }
                 ErrorKind::DeviceNotAvailable => {
                     error_callback(err);
+                    stream.signal_worker_exit();
                     return;
                 }
                 _ => error_callback(err),
@@ -1193,19 +1272,20 @@ fn process_input(
             Err(err) => return Err(err.into()),
         }
     }
-    let data = buffer.as_mut_ptr() as *mut ();
-    let data = unsafe { Data::from_parts(data, stream.period_samples, stream.sample_format) };
-    let callback_instant = stream.callback_instant(&status);
-    let delay_duration = frames_to_duration(delay_frames as FrameCount, stream.sample_rate);
-    let capture = callback_instant
-        .checked_sub(delay_duration)
-        .unwrap_or(StreamInstant::ZERO);
-    let timestamp = InputStreamTimestamp {
-        callback: callback_instant,
-        capture,
-    };
-    let info = InputCallbackInfo { timestamp };
-    data_callback(&data, &info);
+    if !stream.draining.load(Ordering::Relaxed) {
+        let data = buffer.as_mut_ptr() as *mut ();
+        let data = unsafe { Data::from_parts(data, stream.period_samples, stream.sample_format) };
+        let callback_instant = stream.callback_instant(&status);
+        let delay_duration = frames_to_duration(delay_frames as FrameCount, stream.sample_rate);
+        let capture = callback_instant
+            .checked_sub(delay_duration)
+            .unwrap_or(StreamInstant::ZERO);
+        let timestamp = InputStreamTimestamp {
+            callback: callback_instant,
+            capture,
+        };
+        data_callback(&data, &InputCallbackInfo { timestamp });
+    }
 
     Ok(())
 }
@@ -1221,17 +1301,19 @@ fn process_output(
     // Pre-fill buffer with equilibrium; user callback overwrites what it wants.
     stream.equilibrium.fill(buffer);
 
-    let data = buffer.as_mut_ptr() as *mut ();
-    let mut data = unsafe { Data::from_parts(data, stream.period_samples, stream.sample_format) };
-    let callback_instant = stream.callback_instant(&status);
-    let delay_duration = frames_to_duration(delay_frames as FrameCount, stream.sample_rate);
-    let playback = callback_instant + delay_duration;
-    let timestamp = OutputStreamTimestamp {
-        callback: callback_instant,
-        playback,
-    };
-    let info = OutputCallbackInfo { timestamp };
-    data_callback(&mut data, &info);
+    if !stream.draining.load(Ordering::Relaxed) {
+        let data = buffer.as_mut_ptr() as *mut ();
+        let mut data =
+            unsafe { Data::from_parts(data, stream.period_samples, stream.sample_format) };
+        let callback_instant = stream.callback_instant(&status);
+        let delay_duration = frames_to_duration(delay_frames as FrameCount, stream.sample_rate);
+        let playback = callback_instant + delay_duration;
+        let timestamp = OutputStreamTimestamp {
+            callback: callback_instant,
+            playback,
+        };
+        data_callback(&mut data, &OutputCallbackInfo { timestamp });
+    }
 
     let mut frames_written = 0;
     while frames_written < stream.period_size {
@@ -1288,9 +1370,13 @@ fn htstamp_elapsed(status: &alsa::pcm::Status, origin: libc::timespec) -> Stream
 }
 
 impl Stream {
-    /// Releases the latch so the worker thread can begin processing audio callbacks.
-    fn signal_ready(&self) {
+    /// Parks the worker and gets exclusive access to the PCM handle.
+    fn park_worker(&self) {
         self.latch.release();
+        // Must be true before the trigger fires, so the worker sees it on the next loop iteration.
+        self.inner.parked.store(true, Ordering::Relaxed);
+        self.trigger.wakeup();
+        self.inner.park_worker();
     }
 
     fn new_input<D, E>(
@@ -1378,15 +1464,132 @@ impl Stream {
             latch,
         }
     }
+
+    fn suspend_pcm(&self) -> Result<(), Error> {
+        let hw_params = self.inner.handle.hw_params_current()?;
+        if hw_params.can_pause() {
+            if self.inner.handle.state() != alsa::pcm::State::Paused {
+                self.inner.handle.pause(true)?;
+            }
+        } else {
+            self.park_worker();
+            let result = if self.inner.handle.state() == alsa::pcm::State::Running {
+                self.inner
+                    .handle
+                    .drop()
+                    .and_then(|_| self.inner.handle.prepare())
+                    .map_err(Error::from)
+            } else {
+                Ok(())
+            };
+            self.inner.unpark_worker();
+            return result;
+        }
+        Ok(())
+    }
+
+    // Drops buffered PCM data so a resumed stream doesn't deliver stale audio.
+    fn discard_pcm(&self) -> Result<(), Error> {
+        self.park_worker();
+        let result = if self.inner.handle.state() != alsa::pcm::State::Setup {
+            self.inner
+                .handle
+                .drop()
+                .and_then(|_| self.inner.handle.prepare())
+                .map_err(Error::from)
+        } else {
+            Ok(())
+        };
+        self.inner.unpark_worker();
+        result
+    }
+
+    // Drains a parked output PCM: caller holds exclusive access via park_worker()/unpark_worker().
+    fn drain_output(&self, timeout: Option<Duration>) -> Result<(), Error> {
+        if timeout == Some(Duration::ZERO) {
+            self.inner.handle.drop().ok();
+            return self.inner.handle.prepare().map_err(Into::into);
+        }
+
+        // Non-blocking drain: the PCM is opened non-blocking, so snd_pcm_drain returns EAGAIN
+        // immediately. Poll the ALSA fds until drain completes or the deadline expires.
+        let deadline = timeout.and_then(|t| Instant::now().checked_add(t));
+        let mut fds = self.inner.handle.get()?;
+        let mut result: Result<(), Error> = Ok(());
+
+        'drain: loop {
+            match self.inner.handle.drain() {
+                Ok(()) => break,
+                Err(e) if e.errno() == libc::EAGAIN => {
+                    let timeout_ms = match deadline {
+                        None => POLL_INFINITE,
+                        Some(deadline) => {
+                            let remaining = deadline.saturating_duration_since(Instant::now());
+                            if remaining.is_zero() {
+                                self.inner.handle.drop().ok();
+                                break 'drain;
+                            }
+                            remaining.as_millis().min(i32::MAX as u128) as i32
+                        }
+                    };
+                    match alsa::poll::poll(&mut fds, timeout_ms) {
+                        Ok(0) => {
+                            self.inner.handle.drop().ok();
+                            break 'drain;
+                        }
+                        Ok(_) => continue,
+                        Err(e) => {
+                            result = Err(e.into());
+                            break;
+                        }
+                    }
+                }
+                Err(e) => {
+                    result = Err(e.into());
+                    break;
+                }
+            }
+        }
+
+        // Leave PCM in PREPARED so the worker can resume normally.
+        match self.inner.handle.state() {
+            alsa::pcm::State::Setup => {
+                // Drain completed or drop-on-timeout succeeded.
+                if let Err(e) = self.inner.handle.prepare() {
+                    result = result.and(Err(e.into()));
+                }
+            }
+            alsa::pcm::State::Draining => {
+                // A poll error interrupted an in-progress drain; abort it.
+                self.inner.handle.drop().ok();
+                if let Err(e) = self.inner.handle.prepare() {
+                    result = result.and(Err(e.into()));
+                }
+            }
+            _ => {} // XRun, Running, Disconnected: worker's own recovery handles it
+        }
+
+        result
+    }
+}
+
+impl Stream {
+    // Signals the worker to exit: marks it dropping, unblocks it from acknowledge_park()
+    // if parked, and wakes it from poll_for_period(). dropping must be set first so the
+    // worker exits on re-entry rather than polling again.
+    fn shutdown_worker(&self) {
+        self.inner.dropping.store(true, Ordering::Relaxed);
+        self.inner.unpark_worker();
+        self.trigger.wakeup();
+    }
 }
 
 impl Drop for Stream {
     fn drop(&mut self) {
-        // Unblock the worker in case the stream is dropped before play() was called.
+        // Unblock the worker in case the stream is dropped before start() was called.
         // Idempotent: no effect if the worker is already running.
-        self.signal_ready();
-        self.inner.dropping.store(true, Ordering::Release);
-        self.trigger.wakeup();
+        self.latch.release();
+        self.shutdown_worker();
         if let Some(handle) = self.thread.take() {
             let _ = handle.join();
         }
@@ -1394,8 +1597,10 @@ impl Drop for Stream {
 }
 
 impl StreamTrait for Stream {
-    fn play(&self) -> Result<(), Error> {
-        self.signal_ready(); // idempotent: no-op after first call
+    fn start(&self) -> Result<(), Error> {
+        self.inner.draining.store(false, Ordering::Relaxed);
+        self.latch.release(); // idempotent: no-op after first call
+        self.inner.unpark_worker(); // resume if stop() left it parked; no-op otherwise
         match self.inner.handle.state() {
             // Calling start() on an empty output buffer would trigger an immediate XRUN.
             alsa::pcm::State::Prepared if self.inner.direction == DeviceDirection::Input => {
@@ -1404,24 +1609,35 @@ impl StreamTrait for Stream {
             alsa::pcm::State::Paused => {
                 self.inner.handle.pause(false)?;
             }
+            // Guard against Setup in case prepare() in stop() failed silently.
+            alsa::pcm::State::Setup => {
+                self.inner.handle.prepare()?;
+                if self.inner.direction == DeviceDirection::Input {
+                    self.inner.handle.start()?;
+                }
+            }
             _ => {}
         }
         Ok(())
     }
 
     fn pause(&self) -> Result<(), Error> {
-        let hw_params = self.inner.handle.hw_params_current()?;
-        if !hw_params.can_pause() {
-            return Err(Error::with_message(
-                ErrorKind::UnsupportedOperation,
-                "Device does not support pausing",
-            ));
+        self.inner.draining.store(true, Ordering::Relaxed);
+        self.suspend_pcm()
+    }
+
+    fn stop(&self, timeout: Option<Duration>) -> Result<(), Error> {
+        self.inner.draining.store(true, Ordering::Relaxed);
+
+        if self.inner.direction != DeviceDirection::Output {
+            // Unlike pause(), stop() discards rather than preserves buffered samples.
+            return self.discard_pcm();
         }
-        if self.inner.handle.state() != alsa::pcm::State::Paused {
-            self.inner.handle.pause(true)?;
-        }
-        // TODO: when can_pause() is false, considering implementing a software fallback
-        Ok(())
+
+        self.park_worker();
+        let result = self.drain_output(timeout);
+        self.inner.unpark_worker();
+        result
     }
 
     fn now(&self) -> StreamInstant {

--- a/src/host/asio/device.rs
+++ b/src/host/asio/device.rs
@@ -180,68 +180,66 @@ impl Iterator for Devices {
         self.current_driver = None;
 
         loop {
-            match self.drivers.next() {
-                Some(name) => match self.asio.load_driver(&name) {
-                    Ok(driver) => {
-                        let Ok(channels) = driver.channels() else {
-                            continue;
-                        };
-                        if channels.ins == 0 && channels.outs == 0 {
-                            continue;
-                        }
-
-                        // Some drivers (e.g. Realtek ASIO) return 0 for sample_rate() until a
-                        // stream is active. Treat 0 as "not yet known" rather than skipping.
-                        let sample_rate = driver.sample_rate().unwrap_or(0.0);
-
-                        let Ok(buffer_size_range) = driver.buffersize_range() else {
-                            continue;
-                        };
-
-                        let input_sample_format = driver
-                            .input_data_type()
-                            .ok()
-                            .and_then(|t| convert_data_type(&t));
-                        let output_sample_format = driver
-                            .output_data_type()
-                            .ok()
-                            .and_then(|t| convert_data_type(&t));
-
-                        let supported_sample_rates: Box<[SampleRate]> = crate::COMMON_SAMPLE_RATES
-                            .iter()
-                            .copied()
-                            .filter(|&r| driver.can_sample_rate(r.into()).unwrap_or(false))
-                            .collect();
-
-                        self.current_driver = Some(driver);
-
-                        let asio_streams = Arc::new(Mutex::new(sys::AsioStreams {
-                            input: None,
-                            output: None,
-                        }));
-
-                        return Some(Device {
-                            name,
-                            channels_in: channels.ins as ChannelCount,
-                            channels_out: channels.outs as ChannelCount,
-                            sample_rate: sample_rate as SampleRate,
-                            buffer_size_min: buffer_size_range.min as FrameCount,
-                            buffer_size_max: buffer_size_range.max as FrameCount,
-                            input_sample_format,
-                            output_sample_format,
-                            supported_sample_rates,
-                            asio_streams,
-                            // Initialize with sentinel value so it never matches global flag state (0 or 1).
-                            current_callback_flag: Arc::new(AtomicU32::new(u32::MAX)),
-                        });
+            let name = self.drivers.next()?;
+            match self.asio.load_driver(&name) {
+                Ok(driver) => {
+                    let Ok(channels) = driver.channels() else {
+                        continue;
+                    };
+                    if channels.ins == 0 && channels.outs == 0 {
+                        continue;
                     }
-                    // A different driver is already loaded (e.g. an active Stream holds it). Stop
-                    // cleanly rather than spinning through the rest of the list.
-                    Err(sys::LoadDriverError::DriverAlreadyExists) => return None,
-                    // Driver failed to load for its own reasons; skip and try the next.
-                    Err(_) => continue,
-                },
-                None => return None,
+
+                    // Some drivers (e.g. Realtek ASIO) return 0 for sample_rate() until a
+                    // stream is active. Treat 0 as "not yet known" rather than skipping.
+                    let sample_rate = driver.sample_rate().unwrap_or(0.0);
+
+                    let Ok(buffer_size_range) = driver.buffersize_range() else {
+                        continue;
+                    };
+
+                    let input_sample_format = driver
+                        .input_data_type()
+                        .ok()
+                        .and_then(|t| convert_data_type(&t));
+                    let output_sample_format = driver
+                        .output_data_type()
+                        .ok()
+                        .and_then(|t| convert_data_type(&t));
+
+                    let supported_sample_rates: Box<[SampleRate]> = crate::COMMON_SAMPLE_RATES
+                        .iter()
+                        .copied()
+                        .filter(|&r| driver.can_sample_rate(r.into()).unwrap_or(false))
+                        .collect();
+
+                    self.current_driver = Some(driver);
+
+                    let asio_streams = Arc::new(Mutex::new(sys::AsioStreams {
+                        input: None,
+                        output: None,
+                    }));
+
+                    return Some(Device {
+                        name,
+                        channels_in: channels.ins as ChannelCount,
+                        channels_out: channels.outs as ChannelCount,
+                        sample_rate: sample_rate as SampleRate,
+                        buffer_size_min: buffer_size_range.min as FrameCount,
+                        buffer_size_max: buffer_size_range.max as FrameCount,
+                        input_sample_format,
+                        output_sample_format,
+                        supported_sample_rates,
+                        asio_streams,
+                        // Initialize with sentinel value so it never matches global flag state (0 or 1).
+                        current_callback_flag: Arc::new(AtomicU32::new(u32::MAX)),
+                    });
+                }
+                // A different driver is already loaded (e.g. an active Stream holds it). Stop
+                // cleanly rather than spinning through the rest of the list.
+                Err(sys::LoadDriverError::DriverAlreadyExists) => return None,
+                // Driver failed to load for its own reasons; skip and try the next.
+                Err(_) => continue,
             }
         }
     }

--- a/src/host/asio/mod.rs
+++ b/src/host/asio/mod.rs
@@ -146,8 +146,8 @@ impl DeviceTrait for Device {
 }
 
 impl StreamTrait for Stream {
-    fn play(&self) -> Result<(), Error> {
-        Stream::play(self)
+    fn start(&self) -> Result<(), Error> {
+        Stream::start(self)
     }
 
     fn pause(&self) -> Result<(), Error> {

--- a/src/host/asio/mod.rs
+++ b/src/host/asio/mod.rs
@@ -154,6 +154,10 @@ impl StreamTrait for Stream {
         Stream::pause(self)
     }
 
+    fn stop(&self, _timeout: Option<Duration>) -> Result<(), Error> {
+        Stream::pause(self)
+    }
+
     fn now(&self) -> StreamInstant {
         Stream::now(self)
     }

--- a/src/host/asio/stream.rs
+++ b/src/host/asio/stream.rs
@@ -95,12 +95,12 @@ impl Stream {
     }
 
     pub fn play(&self) -> Result<(), Error> {
-        StreamState::Playing.store(&self.state, Ordering::Release);
+        StreamState::Playing.store(&self.state, Ordering::Relaxed);
         Ok(())
     }
 
     pub fn pause(&self) -> Result<(), Error> {
-        StreamState::Paused.store(&self.state, Ordering::Release);
+        StreamState::Paused.store(&self.state, Ordering::Relaxed);
         Ok(())
     }
 
@@ -213,7 +213,7 @@ impl Device {
         // This is most performance critical part of the ASIO bindings.
         let callback_id = driver.add_callback(move |callback_info| unsafe {
             // If not playing, return early.
-            if StreamState::load(&state_cb, Ordering::Acquire) != StreamState::Playing {
+            if StreamState::load(&state_cb, Ordering::Relaxed) != StreamState::Playing {
                 return;
             }
 
@@ -446,7 +446,7 @@ impl Device {
             return Err(build_stream_err(e));
         }
 
-        StreamState::Paused.store(&state, Ordering::Release);
+        StreamState::Paused.store(&state, Ordering::Relaxed);
         Ok(Stream {
             state,
             driver,
@@ -551,7 +551,7 @@ impl Device {
 
         let callback_id = driver.add_callback(move |callback_info| unsafe {
             // If not playing, return early.
-            if StreamState::load(&state_cb, Ordering::Acquire) != StreamState::Playing {
+            if StreamState::load(&state_cb, Ordering::Relaxed) != StreamState::Playing {
                 return;
             }
 
@@ -836,7 +836,7 @@ impl Device {
             return Err(build_stream_err(e));
         }
 
-        StreamState::Paused.store(&state, Ordering::Release);
+        StreamState::Paused.store(&state, Ordering::Relaxed);
         Ok(Stream {
             state,
             driver,
@@ -1012,7 +1012,7 @@ impl Device {
                     sys::AsioMessageSelectors::kAsioResetRequest => {
                         // Guard on Starting: some USB ASIO drivers (ASIO4ALL, Focusrite, etc.)
                         // fire spurious reset/resync requests during driver.start().
-                        if StreamState::load(&state, Ordering::Acquire) != StreamState::Starting {
+                        if StreamState::load(&state, Ordering::Relaxed) != StreamState::Starting {
                             let _ = timer_tx.send(Error::with_message(
                                 ErrorKind::StreamInvalidated,
                                 "Stream reset was requested by the ASIO driver",
@@ -1024,7 +1024,7 @@ impl Device {
                         // Per the ASIO spec (and matching JUCE's behavior), kAsioResyncRequest
                         // means the driver needs a full stop/reinit/start. It is *not* a simple
                         // xrun notification.
-                        if StreamState::load(&state, Ordering::Acquire) != StreamState::Starting {
+                        if StreamState::load(&state, Ordering::Relaxed) != StreamState::Starting {
                             let _ = timer_tx.send(Error::with_message(
                                 ErrorKind::StreamInvalidated,
                                 "Stream resynchronization was requested by the ASIO driver",
@@ -1033,7 +1033,7 @@ impl Device {
                         true
                     }
                     sys::AsioMessageSelectors::kAsioOverload => {
-                        if StreamState::load(&state, Ordering::Acquire) == StreamState::Playing {
+                        if StreamState::load(&state, Ordering::Relaxed) == StreamState::Playing {
                             let _ =
                                 try_emit_error(&error_callback_shared, Error::new(ErrorKind::Xrun));
                         }
@@ -1077,7 +1077,7 @@ impl Device {
                         }
                     };
                     if should_notify
-                        && StreamState::load(&state, Ordering::Acquire) != StreamState::Starting
+                        && StreamState::load(&state, Ordering::Relaxed) != StreamState::Starting
                     {
                         let _ = timer_tx.send(Error::with_message(
                             ErrorKind::StreamInvalidated,

--- a/src/host/asio/stream.rs
+++ b/src/host/asio/stream.rs
@@ -94,7 +94,7 @@ impl Stream {
         self.time_base.to_stream_instant(ms as u64 * 1_000_000)
     }
 
-    pub fn play(&self) -> Result<(), Error> {
+    pub fn start(&self) -> Result<(), Error> {
         StreamState::Playing.store(&self.state, Ordering::Relaxed);
         Ok(())
     }

--- a/src/host/audioworklet/mod.rs
+++ b/src/host/audioworklet/mod.rs
@@ -258,7 +258,7 @@ impl DeviceTrait for Device {
     /// delivered to `error_callback` after the caller already holds a [`Stream`]. There is no
     /// way to surface such errors synchronously given the Web Audio API's design.
     ///
-    /// [`play`](crate::traits::StreamTrait::play) and [`pause`](crate::traits::StreamTrait::pause)
+    /// [`start`](crate::traits::StreamTrait::start) and [`pause`](crate::traits::StreamTrait::pause)
     /// calls made before initialization completes return `Ok` immediately and are queued. If
     /// initialization succeeds, then the queued commands take effect; if it fails they are
     /// discarded and the error is delivered to `error_callback`.
@@ -510,7 +510,7 @@ impl StreamTrait for Stream {
         Ok(self.buffer_size_frames.load(Ordering::Relaxed) as FrameCount)
     }
 
-    fn play(&self) -> Result<(), Error> {
+    fn start(&self) -> Result<(), Error> {
         self.command_tx.unbounded_send(Command::Play).map_err(|_| {
             Error::with_message(
                 ErrorKind::HostUnavailable,

--- a/src/host/audioworklet/mod.rs
+++ b/src/host/audioworklet/mod.rs
@@ -528,6 +528,10 @@ impl StreamTrait for Stream {
         })
     }
 
+    fn stop(&self, _timeout: Option<std::time::Duration>) -> Result<(), Error> {
+        self.pause()
+    }
+
     fn now(&self) -> StreamInstant {
         StreamInstant::from_secs_f64(f64::from_bits(
             self.current_time_bits.load(Ordering::Relaxed),

--- a/src/host/coreaudio/ios/mod.rs
+++ b/src/host/coreaudio/ios/mod.rs
@@ -5,7 +5,7 @@ use std::{
     ptr::NonNull,
     sync::{
         Arc, Mutex,
-        atomic::{AtomicUsize, Ordering},
+        atomic::{AtomicBool, AtomicUsize, Ordering},
     },
     time::Duration,
 };
@@ -28,7 +28,10 @@ use crate::{
     ErrorKind, FrameCount, InputCallbackInfo, InputStreamTimestamp, OutputCallbackInfo,
     OutputStreamTimestamp, ResultExt, SampleFormat, SampleRate, StreamConfig, StreamInstant,
     SupportedBufferSize, SupportedStreamConfig, SupportedStreamConfigRange,
-    host::{ErrorCallbackArc, frames_to_duration, latch::Latch, try_emit_error},
+    host::{
+        ErrorCallbackArc, equilibrium::fill_equilibrium, frames_to_duration, latch::Latch,
+        try_emit_error,
+    },
     traits::{DeviceTrait, HostTrait, StreamTrait},
 };
 
@@ -193,12 +196,15 @@ impl DeviceTrait for Device {
             Some((latency_frames.clone(), true)),
         );
 
+        let draining = Arc::new(AtomicBool::new(false));
+
         // Set up input callback
         setup_input_callback(
             &mut audio_unit,
             sample_format,
             config.sample_rate,
             latency_frames,
+            draining.clone(),
             data_callback,
             move |e| {
                 let _ = try_emit_error(&error_callback, e);
@@ -211,6 +217,9 @@ impl DeviceTrait for Device {
                 audio_unit,
             },
             session_manager,
+            // Draining is meaningless for capture, so the drain window is zero.
+            draining,
+            Duration::ZERO,
         );
         stream.signal_ready();
         Ok(stream)
@@ -248,12 +257,17 @@ impl DeviceTrait for Device {
             Some((latency_frames.clone(), false)),
         );
 
+        let draining = Arc::new(AtomicBool::new(false));
+        let drain_window =
+            frames_to_duration(get_device_buffer_frames() as FrameCount, config.sample_rate);
+
         // Set up output callback
         setup_output_callback(
             &mut audio_unit,
             sample_format,
             config.sample_rate,
             latency_frames,
+            draining.clone(),
             data_callback,
             move |e| {
                 let _ = try_emit_error(&error_callback, e);
@@ -266,6 +280,8 @@ impl DeviceTrait for Device {
                 audio_unit,
             },
             session_manager,
+            draining,
+            drain_window,
         );
         stream.signal_ready();
         Ok(stream)
@@ -275,13 +291,22 @@ impl DeviceTrait for Device {
 pub struct Stream {
     inner: Mutex<StreamInner>,
     session_manager: SessionEventManager,
+    draining: Arc<AtomicBool>,
+    drain_window: Duration,
 }
 
 impl Stream {
-    fn new(inner: StreamInner, session_manager: SessionEventManager) -> Self {
+    fn new(
+        inner: StreamInner,
+        session_manager: SessionEventManager,
+        draining: Arc<AtomicBool>,
+        drain_window: Duration,
+    ) -> Self {
         Self {
             inner: Mutex::new(inner),
             session_manager,
+            draining,
+            drain_window,
         }
     }
 
@@ -297,8 +322,26 @@ impl Drop for Stream {
     }
 }
 
+impl Stream {
+    fn halt(&self) -> Result<(), Error> {
+        let mut stream = self.inner.lock().map_err(|_| {
+            Error::with_message(ErrorKind::StreamInvalidated, "Stream lock poisoned")
+        })?;
+        if stream.playing {
+            stream
+                .audio_unit
+                .stop()
+                .context("Failed to stop audio unit")?;
+            stream.playing = false;
+        }
+        Ok(())
+    }
+}
+
 impl StreamTrait for Stream {
-    fn play(&self) -> Result<(), Error> {
+    fn start(&self) -> Result<(), Error> {
+        // Clear any pending drain so the render callback resumes pulling real audio.
+        self.draining.store(false, Ordering::Relaxed);
         let mut stream = self.inner.lock().map_err(|_| {
             Error::with_message(ErrorKind::StreamInvalidated, "Stream lock poisoned")
         })?;
@@ -313,17 +356,20 @@ impl StreamTrait for Stream {
     }
 
     fn pause(&self) -> Result<(), Error> {
-        let mut stream = self.inner.lock().map_err(|_| {
-            Error::with_message(ErrorKind::StreamInvalidated, "Stream lock poisoned")
-        })?;
-        if stream.playing {
-            stream
-                .audio_unit
-                .stop()
-                .context("Failed to stop audio unit")?;
-            stream.playing = false;
+        self.halt()
+    }
+
+    fn stop(&self, timeout: Option<Duration>) -> Result<(), Error> {
+        self.draining.store(true, Ordering::Relaxed);
+
+        if timeout != Some(Duration::ZERO) {
+            let wait = timeout.map_or(self.drain_window, |t| self.drain_window.min(t));
+            if !wait.is_zero() {
+                std::thread::sleep(wait);
+            }
         }
-        Ok(())
+
+        self.halt()
     }
 
     fn now(&self) -> StreamInstant {
@@ -562,6 +608,7 @@ fn setup_input_callback<D, E>(
     sample_format: SampleFormat,
     sample_rate: SampleRate,
     latency_frames: Arc<AtomicUsize>,
+    draining: Arc<AtomicBool>,
     mut data_callback: D,
     mut error_callback: E,
 ) -> Result<(), Error>
@@ -577,29 +624,29 @@ where
         let (buffer, data) =
             unsafe { extract_audio_buffer(&args, bytes_per_channel, sample_format, true) };
 
-        let callback = match host_time_to_stream_instant(args.time_stamp.mHostTime) {
-            Err(err) => {
-                error_callback(err);
-                return Err(());
-            }
-            Ok(cb) => cb,
-        };
+        if !draining.load(Ordering::Relaxed) {
+            let callback = match host_time_to_stream_instant(args.time_stamp.mHostTime) {
+                Err(err) => {
+                    error_callback(err);
+                    return Err(());
+                }
+                Ok(cb) => cb,
+            };
 
-        // Refreshed on route changes by the session event manager; fall back to this buffer's
-        // own frame count if the depth is unknown (zero).
-        let latency_frames = match latency_frames.load(Ordering::Relaxed) {
-            0 => {
-                let channels = buffer.mNumberChannels as usize;
-                data.len().checked_div(channels).unwrap_or(0)
-            }
-            n => n,
-        };
-        let delay = frames_to_duration(latency_frames as FrameCount, sample_rate);
-        let capture = callback.checked_sub(delay).unwrap_or(StreamInstant::ZERO);
-        let timestamp = InputStreamTimestamp { callback, capture };
-
-        let info = InputCallbackInfo { timestamp };
-        data_callback(&data, &info);
+            // Refreshed on route changes by the session event manager; fall back to this buffer's
+            // own frame count if the depth is unknown (zero).
+            let latency_frames = match latency_frames.load(Ordering::Relaxed) {
+                0 => {
+                    let channels = buffer.mNumberChannels as usize;
+                    data.len().checked_div(channels).unwrap_or(0)
+                }
+                n => n,
+            };
+            let delay = frames_to_duration(latency_frames as FrameCount, sample_rate);
+            let capture = callback.checked_sub(delay).unwrap_or(StreamInstant::ZERO);
+            let timestamp = InputStreamTimestamp { callback, capture };
+            data_callback(&data, &InputCallbackInfo { timestamp });
+        }
         Ok(())
     })?;
 
@@ -612,6 +659,7 @@ fn setup_output_callback<D, E>(
     sample_format: SampleFormat,
     sample_rate: SampleRate,
     latency_frames: Arc<AtomicUsize>,
+    draining: Arc<AtomicBool>,
     mut data_callback: D,
     mut error_callback: E,
 ) -> Result<(), Error>
@@ -626,6 +674,20 @@ where
         // SAFETY: CoreAudio provides valid AudioBufferList for the callback duration
         let (buffer, mut data) =
             unsafe { extract_audio_buffer(&args, bytes_per_channel, sample_format, false) };
+
+        if !buffer.mData.is_null() {
+            let bytes = unsafe {
+                std::slice::from_raw_parts_mut(
+                    buffer.mData as *mut u8,
+                    buffer.mDataByteSize as usize,
+                )
+            };
+            fill_equilibrium(bytes, sample_format);
+        }
+
+        if draining.load(Ordering::Relaxed) {
+            return Ok(());
+        }
 
         let callback = match host_time_to_stream_instant(args.time_stamp.mHostTime) {
             Err(err) => {

--- a/src/host/coreaudio/macos/device.rs
+++ b/src/host/coreaudio/macos/device.rs
@@ -4,7 +4,7 @@ use std::{
     ptr::{NonNull, null},
     sync::{
         Arc, Mutex,
-        atomic::{AtomicUsize, Ordering},
+        atomic::{AtomicBool, AtomicUsize, Ordering},
         mpsc::{RecvTimeoutError, channel},
     },
     time::{Duration, Instant},
@@ -52,6 +52,7 @@ use crate::{
     host::{
         ErrorCallbackArc,
         coreaudio::macos::{StreamInner, loopback::LoopbackDevice},
+        equilibrium::fill_equilibrium,
         frames_to_duration, try_emit_error,
     },
     traits::DeviceTrait,
@@ -759,6 +760,9 @@ impl Device {
         let (bytes_per_channel, sample_rate, device_buffer_frames, extra_latency_frames) =
             setup_callback_vars(&audio_unit, config, sample_format, Scope::Input);
 
+        let draining = Arc::new(AtomicBool::new(false));
+        let draining_input = draining.clone();
+
         type Args = render_callback::Args<data::Raw>;
         audio_unit.set_input_callback(move |args: Args| unsafe {
             // SAFETY: We configure the stream format as interleaved (via asbd_from_config which
@@ -774,22 +778,22 @@ impl Device {
             let len = data_byte_size as usize / bytes_per_channel;
             let data = Data::from_parts(data, len, sample_format);
 
-            let callback = match host_time_to_stream_instant(args.time_stamp.mHostTime) {
-                Err(err) => {
-                    let _ = try_emit_error(&error_callback, err);
-                    return Err(());
-                }
-                Ok(cb) => cb,
-            };
-            let buffer_frames = len / channels as usize;
-            let latency_frames =
-                device_buffer_frames.unwrap_or(buffer_frames) + extra_latency_frames;
-            let delay = frames_to_duration(latency_frames as FrameCount, sample_rate);
-            let capture = callback.checked_sub(delay).unwrap_or(StreamInstant::ZERO);
-            let timestamp = InputStreamTimestamp { callback, capture };
-
-            let info = InputCallbackInfo { timestamp };
-            data_callback(&data, &info);
+            if !draining_input.load(Ordering::Relaxed) {
+                let callback = match host_time_to_stream_instant(args.time_stamp.mHostTime) {
+                    Err(err) => {
+                        let _ = try_emit_error(&error_callback, err);
+                        return Err(());
+                    }
+                    Ok(cb) => cb,
+                };
+                let buffer_frames = len / channels as usize;
+                let latency_frames =
+                    device_buffer_frames.unwrap_or(buffer_frames) + extra_latency_frames;
+                let delay = frames_to_duration(latency_frames as FrameCount, sample_rate);
+                let capture = callback.checked_sub(delay).unwrap_or(StreamInstant::ZERO);
+                let timestamp = InputStreamTimestamp { callback, capture };
+                data_callback(&data, &InputCallbackInfo { timestamp });
+            }
             Ok(())
         })?;
 
@@ -809,7 +813,7 @@ impl Device {
             weak_inner,
             error_callback_disconnect,
         )?);
-        let stream = Stream::new(inner_arc, monitor);
+        let stream = Stream::new(inner_arc, monitor, draining, Duration::ZERO);
         stream.signal_ready();
         Ok(stream)
     }
@@ -881,6 +885,12 @@ impl Device {
             device_buffer_frames.map_or(0, |frames| frames + extra_latency_frames),
         ));
         let callback_latency_frames = latency_frames.clone();
+        let draining = Arc::new(AtomicBool::new(false));
+        let draining_render = draining.clone();
+        let drain_window = frames_to_duration(
+            (device_buffer_frames.unwrap_or(0) + extra_latency_frames) as FrameCount,
+            sample_rate,
+        );
 
         type Args = render_callback::Args<data::Raw>;
         audio_unit.set_render_callback(move |args: Args| unsafe {
@@ -895,6 +905,14 @@ impl Device {
 
             let data = data as *mut ();
             let len = data_byte_size as usize / bytes_per_channel;
+
+            let bytes = std::slice::from_raw_parts_mut(data as *mut u8, data_byte_size as usize);
+            fill_equilibrium(bytes, sample_format);
+
+            if draining_render.load(Ordering::Relaxed) {
+                return Ok(());
+            }
+
             let mut data = Data::from_parts(data, len, sample_format);
 
             let callback = match host_time_to_stream_instant(args.time_stamp.mHostTime) {
@@ -944,7 +962,7 @@ impl Device {
                 error_callback,
             )?)
         };
-        let stream = Stream::new(inner_arc, monitor);
+        let stream = Stream::new(inner_arc, monitor, draining, drain_window);
         stream.signal_ready();
         Ok(stream)
     }

--- a/src/host/coreaudio/macos/mod.rs
+++ b/src/host/coreaudio/macos/mod.rs
@@ -1,7 +1,10 @@
-use std::sync::{
-    Arc, Mutex, Weak,
-    atomic::{AtomicUsize, Ordering},
-    mpsc,
+use std::{
+    sync::{
+        Arc, Mutex, Weak,
+        atomic::{AtomicBool, AtomicUsize, Ordering},
+        mpsc,
+    },
+    time::Duration,
 };
 
 use coreaudio::audio_unit::{AudioUnit, Scope};
@@ -326,7 +329,7 @@ struct StreamInner {
 }
 
 impl StreamInner {
-    fn play(&mut self) -> Result<(), Error> {
+    fn start(&mut self) -> Result<(), Error> {
         if !self.playing {
             self.audio_unit
                 .start()
@@ -350,11 +353,23 @@ impl StreamInner {
 pub struct Stream {
     inner: Arc<Mutex<StreamInner>>,
     monitor: Box<dyn Monitor>,
+    draining: Arc<AtomicBool>,
+    drain_window: Duration,
 }
 
 impl Stream {
-    fn new(inner: Arc<Mutex<StreamInner>>, monitor: Box<dyn Monitor>) -> Self {
-        Self { inner, monitor }
+    fn new(
+        inner: Arc<Mutex<StreamInner>>,
+        monitor: Box<dyn Monitor>,
+        draining: Arc<AtomicBool>,
+        drain_window: Duration,
+    ) -> Self {
+        Self {
+            inner,
+            monitor,
+            draining,
+            drain_window,
+        }
     }
 
     fn signal_ready(&self) {
@@ -370,14 +385,31 @@ impl Drop for Stream {
 }
 
 impl StreamTrait for Stream {
-    fn play(&self) -> Result<(), Error> {
+    fn start(&self) -> Result<(), Error> {
+        self.draining.store(false, Ordering::Relaxed);
         self.inner
             .lock()
             .map_err(|_| Error::with_message(ErrorKind::StreamInvalidated, "Stream lock poisoned"))?
-            .play()
+            .start()
     }
 
     fn pause(&self) -> Result<(), Error> {
+        self.inner
+            .lock()
+            .map_err(|_| Error::with_message(ErrorKind::StreamInvalidated, "Stream lock poisoned"))?
+            .pause()
+    }
+
+    fn stop(&self, timeout: Option<Duration>) -> Result<(), Error> {
+        self.draining.store(true, Ordering::Relaxed);
+
+        if timeout != Some(Duration::ZERO) {
+            let wait = timeout.map_or(self.drain_window, |t| self.drain_window.min(t));
+            if !wait.is_zero() {
+                std::thread::sleep(wait);
+            }
+        }
+
         self.inner
             .lock()
             .map_err(|_| Error::with_message(ErrorKind::StreamInvalidated, "Stream lock poisoned"))?
@@ -426,7 +458,7 @@ mod test {
                 None, // None=blocking, Some(Duration)=timeout
             )
             .unwrap();
-        stream.play().unwrap();
+        stream.start().unwrap();
         std::thread::sleep(std::time::Duration::from_secs(1));
     }
 
@@ -458,7 +490,7 @@ mod test {
                 None, // None=blocking, Some(Duration)=timeout
             )
             .unwrap();
-        stream.play().unwrap();
+        stream.start().unwrap();
         std::thread::sleep(std::time::Duration::from_secs(1));
     }
 
@@ -491,7 +523,7 @@ mod test {
                 None, // None=blocking, Some(Duration)=timeout
             )
             .unwrap();
-        stream.play().unwrap();
+        stream.start().unwrap();
         std::thread::sleep(std::time::Duration::from_secs(1));
     }
 

--- a/src/host/custom/mod.rs
+++ b/src/host/custom/mod.rs
@@ -202,8 +202,9 @@ trait DeviceErased: Send + Sync {
 }
 
 trait StreamErased: Send + Sync {
-    fn play(&self) -> Result<(), Error>;
+    fn start(&self) -> Result<(), Error>;
     fn pause(&self) -> Result<(), Error>;
+    fn stop(&self, timeout: Option<Duration>) -> Result<(), Error>;
     fn now(&self) -> StreamInstant;
     fn buffer_size(&self) -> Result<FrameCount, Error>;
 }
@@ -329,12 +330,16 @@ impl<T> StreamErased for T
 where
     T: StreamTrait,
 {
-    fn play(&self) -> Result<(), Error> {
-        <T as StreamTrait>::play(self)
+    fn start(&self) -> Result<(), Error> {
+        <T as StreamTrait>::start(self)
     }
 
     fn pause(&self) -> Result<(), Error> {
         <T as StreamTrait>::pause(self)
+    }
+
+    fn stop(&self, timeout: Option<Duration>) -> Result<(), Error> {
+        <T as StreamTrait>::stop(self, timeout)
     }
 
     fn now(&self) -> StreamInstant {
@@ -452,12 +457,16 @@ impl DeviceTrait for Device {
 }
 
 impl StreamTrait for Stream {
-    fn play(&self) -> Result<(), Error> {
-        self.0.play()
+    fn start(&self) -> Result<(), Error> {
+        self.0.start()
     }
 
     fn pause(&self) -> Result<(), Error> {
         self.0.pause()
+    }
+
+    fn stop(&self, timeout: Option<Duration>) -> Result<(), Error> {
+        self.0.stop(timeout)
     }
 
     fn now(&self) -> StreamInstant {

--- a/src/host/jack/stream.rs
+++ b/src/host/jack/stream.rs
@@ -89,7 +89,7 @@ impl Stream {
             .activate_async(notification_handler, input_process_handler)
             .context("Failed to activate client")?;
 
-        StreamState::Paused.store(&state, Ordering::Release);
+        StreamState::Paused.store(&state, Ordering::Relaxed);
         Ok(Self {
             state,
             async_client,
@@ -145,7 +145,7 @@ impl Stream {
             .activate_async(notification_handler, output_process_handler)
             .context("Failed to activate client")?;
 
-        StreamState::Paused.store(&state, Ordering::Release);
+        StreamState::Paused.store(&state, Ordering::Relaxed);
         Ok(Self {
             state,
             async_client,
@@ -574,7 +574,7 @@ impl JackNotificationHandler {
 
 impl jack::NotificationHandler for JackNotificationHandler {
     unsafe fn shutdown(&mut self, _status: jack::ClientStatus, reason: &str) {
-        if StreamState::load(&self.state, Ordering::Acquire) == StreamState::Starting {
+        if StreamState::load(&self.state, Ordering::Relaxed) == StreamState::Starting {
             return;
         }
         emit_error(
@@ -591,7 +591,7 @@ impl jack::NotificationHandler for JackNotificationHandler {
             // One of these notifications is sent every time a client is started.
             return jack::Control::Continue;
         }
-        if StreamState::load(&self.state, Ordering::Acquire) != StreamState::Starting {
+        if StreamState::load(&self.state, Ordering::Relaxed) != StreamState::Starting {
             emit_error(
                 &self.error_callback_ptr,
                 Error::with_message(
@@ -604,7 +604,7 @@ impl jack::NotificationHandler for JackNotificationHandler {
     }
 
     fn xrun(&mut self, _: &jack::Client) -> jack::Control {
-        if StreamState::load(&self.state, Ordering::Acquire) != StreamState::Starting {
+        if StreamState::load(&self.state, Ordering::Relaxed) != StreamState::Starting {
             let _ = try_emit_error(&self.error_callback_ptr, ErrorKind::Xrun.into());
         }
         jack::Control::Continue

--- a/src/host/jack/stream.rs
+++ b/src/host/jack/stream.rs
@@ -248,13 +248,35 @@ impl Stream {
 }
 
 impl StreamTrait for Stream {
-    fn play(&self) -> Result<(), Error> {
+    fn start(&self) -> Result<(), Error> {
         StreamState::Playing.store(&self.state, Ordering::Relaxed);
         Ok(())
     }
 
     fn pause(&self) -> Result<(), Error> {
         StreamState::Paused.store(&self.state, Ordering::Relaxed);
+        Ok(())
+    }
+
+    fn stop(&self, timeout: Option<std::time::Duration>) -> Result<(), Error> {
+        StreamState::Paused.store(&self.state, Ordering::Relaxed);
+
+        let is_output = !self.output_port_names.is_empty();
+        if is_output && timeout != Some(std::time::Duration::ZERO) {
+            let client = self.async_client.as_client();
+            let ports: Vec<_> = self
+                .output_port_names
+                .iter()
+                .filter_map(|name| client.port_by_name(name))
+                .collect();
+            let latency_frames = hardware_latency_frames(&ports, jack::LatencyType::Playback)
+                .unwrap_or(client.buffer_size() as FrameCount);
+            let buffered = frames_to_duration(latency_frames, client.sample_rate() as SampleRate);
+            let wait = timeout.map_or(buffered, |t| buffered.min(t));
+            if !wait.is_zero() {
+                std::thread::sleep(wait);
+            }
+        }
         Ok(())
     }
 

--- a/src/host/mod.rs
+++ b/src/host/mod.rs
@@ -4,6 +4,7 @@
     target_os = "freebsd",
     target_os = "netbsd",
     target_os = "windows",
+    target_vendor = "apple",
 ))]
 pub(crate) mod equilibrium;
 

--- a/src/host/mod.rs
+++ b/src/host/mod.rs
@@ -121,6 +121,17 @@ pub(crate) mod null;
 ))]
 pub(crate) mod latch;
 
+/// Mutex-guarded bool with Condvar for cross-thread signaling.
+///
+/// The bool tracks whether the notified side has acknowledged the signal.
+#[cfg(any(
+    target_os = "linux",
+    target_os = "dragonfly",
+    target_os = "freebsd",
+    target_os = "netbsd",
+))]
+pub(crate) type Notify = (std::sync::Mutex<bool>, std::sync::Condvar);
+
 /// Shared error-callback type that hands the callback across thread boundaries.
 #[allow(dead_code)]
 pub(crate) type ErrorCallbackArc = std::sync::Arc<std::sync::Mutex<dyn FnMut(crate::Error) + Send>>;

--- a/src/host/null/mod.rs
+++ b/src/host/null/mod.rs
@@ -124,11 +124,15 @@ impl HostTrait for Host {
 }
 
 impl StreamTrait for Stream {
-    fn play(&self) -> Result<(), Error> {
+    fn start(&self) -> Result<(), Error> {
         unimplemented!()
     }
 
     fn pause(&self) -> Result<(), Error> {
+        unimplemented!()
+    }
+
+    fn stop(&self, _timeout: Option<std::time::Duration>) -> Result<(), Error> {
         unimplemented!()
     }
 

--- a/src/host/pipewire/device.rs
+++ b/src/host/pipewire/device.rs
@@ -32,7 +32,7 @@ use crate::{
     OutputCallbackInfo, SampleFormat, SampleRate, StreamConfig, SupportedBufferSize,
     SupportedStreamConfig, SupportedStreamConfigRange,
     host::{
-        emit_error,
+        Notify, emit_error,
         latch::Latch,
         pipewire::{
             stream::{
@@ -382,6 +382,8 @@ impl DeviceTrait for Device {
         };
         let last_quantum = Arc::new(AtomicU64::new(initial_quantum));
         let last_quantum_clone = last_quantum.clone();
+        let draining = Arc::new(AtomicBool::new(false));
+        let draining_clone = draining.clone();
         // Keep `capture` monotonic: pw_time delay() grows when another client joins
         // needing a larger buffer, which can pull `capture` backward.
         let data_callback = crate::host::monotonic_input_callback(data_callback);
@@ -400,6 +402,8 @@ impl DeviceTrait for Device {
                         last_quantum: last_quantum_clone,
                         start,
                         connect_automatically: device.connect_automatically.load(Ordering::Relaxed),
+                        draining: draining_clone,
+                        drained: None,
                     },
                     data_callback,
                     error_callback,
@@ -439,7 +443,7 @@ impl DeviceTrait for Device {
                         Err(e) => {
                             let _ = init_tx.send(Err(Error::with_message(
                                 ErrorKind::BackendError,
-                                format!("PipeWire: could not acquire registry: {e}"),
+                                format!("Could not acquire registry: {e}"),
                             )));
                             return;
                         }
@@ -458,18 +462,19 @@ impl DeviceTrait for Device {
                                 &error_callback_cmd,
                                 Error::with_message(
                                     ErrorKind::StreamInvalidated,
-                                    format!("PipeWire: set_active({state}) failed: {e}"),
+                                    format!("Failed to set stream active ({state}): {e}"),
                                 ),
                             );
                         }
                     }
+                    StreamCommand::Drain => {}
                     StreamCommand::Stop => {
                         if let Err(e) = stream_clone.disconnect() {
                             emit_error(
                                 &error_callback_cmd,
                                 Error::with_message(
                                     ErrorKind::StreamInvalidated,
-                                    format!("PipeWire: stream disconnect failed: {e}"),
+                                    format!("Stream disconnect failed: {e}"),
                                 ),
                             );
                         }
@@ -514,7 +519,16 @@ impl DeviceTrait for Device {
         }
 
         latch.add_thread(handle.thread().clone());
-        let stream = Stream::new(handle, pw_play_tx, last_quantum, start, latch);
+        let stream = Stream::new(
+            handle,
+            pw_play_tx,
+            last_quantum,
+            start,
+            latch,
+            false,
+            draining,
+            None,
+        );
         stream.signal_ready();
         Ok(stream)
     }
@@ -558,6 +572,11 @@ impl DeviceTrait for Device {
         };
         let last_quantum = Arc::new(AtomicU64::new(initial_quantum));
         let last_quantum_clone = last_quantum.clone();
+        let draining = Arc::new(AtomicBool::new(false));
+        let draining_clone = draining.clone();
+        let drained: Arc<Notify> = Arc::new(Notify::default());
+        let drained_clone = drained.clone();
+        let drained_cmd = drained.clone();
         // Keep `playback` monotonic: pw_time delay() shrinks when other clients that needed
         // a larger buffer leave the graph, which can pull `playback` backward.
         let data_callback = crate::host::monotonic_output_callback(data_callback);
@@ -576,6 +595,8 @@ impl DeviceTrait for Device {
                         last_quantum: last_quantum_clone,
                         start,
                         connect_automatically: device.connect_automatically.load(Ordering::Relaxed),
+                        draining: draining_clone,
+                        drained: Some(drained_clone),
                     },
                     data_callback,
                     error_callback,
@@ -615,7 +636,7 @@ impl DeviceTrait for Device {
                         Err(e) => {
                             let _ = init_tx.send(Err(Error::with_message(
                                 ErrorKind::BackendError,
-                                format!("PipeWire: could not acquire registry: {e}"),
+                                format!("Could not acquire registry: {e}"),
                             )));
                             return;
                         }
@@ -634,9 +655,23 @@ impl DeviceTrait for Device {
                                 &error_callback_cmd,
                                 Error::with_message(
                                     ErrorKind::StreamInvalidated,
-                                    format!("PipeWire: set_active({state}) failed: {e}"),
+                                    format!("Failed to set stream active ({state}): {e}"),
                                 ),
                             );
+                        }
+                    }
+                    StreamCommand::Drain => {
+                        if let Err(e) = stream_clone.flush(true) {
+                            emit_error(
+                                &error_callback_cmd,
+                                Error::with_message(
+                                    ErrorKind::StreamInvalidated,
+                                    format!("Stream flush failed: {e}"),
+                                ),
+                            );
+                            let (mutex, cvar) = drained_cmd.as_ref();
+                            *mutex.lock().unwrap_or_else(|g| g.into_inner()) = true;
+                            cvar.notify_one();
                         }
                     }
                     StreamCommand::Stop => {
@@ -645,7 +680,7 @@ impl DeviceTrait for Device {
                                 &error_callback_cmd,
                                 Error::with_message(
                                     ErrorKind::StreamInvalidated,
-                                    format!("PipeWire: stream disconnect failed: {e}"),
+                                    format!("Stream disconnect failed: {e}"),
                                 ),
                             );
                         }
@@ -689,7 +724,16 @@ impl DeviceTrait for Device {
         }
 
         latch.add_thread(handle.thread().clone());
-        let stream = Stream::new(handle, pw_play_tx, last_quantum, start, latch);
+        let stream = Stream::new(
+            handle,
+            pw_play_tx,
+            last_quantum,
+            start,
+            latch,
+            true,
+            draining,
+            Some(drained),
+        );
         stream.signal_ready();
         Ok(stream)
     }

--- a/src/host/pipewire/stream.rs
+++ b/src/host/pipewire/stream.rs
@@ -35,7 +35,7 @@ use crate::{
     Data, Error, ErrorKind, FrameCount, InputCallbackInfo, InputStreamTimestamp,
     OutputCallbackInfo, OutputStreamTimestamp, SampleFormat, StreamConfig, StreamInstant,
     host::{
-        ErrorCallbackArc, emit_error, equilibrium::fill_equilibrium, frames_to_duration,
+        ErrorCallbackArc, Notify, emit_error, equilibrium::fill_equilibrium, frames_to_duration,
         latch::Latch, try_emit_error,
     },
     traits::StreamTrait,
@@ -75,6 +75,7 @@ impl Drop for PwInitGuard {
 
 pub(super) enum StreamCommand {
     Toggle(bool),
+    Drain,
     Stop,
 }
 
@@ -84,15 +85,22 @@ pub struct Stream {
     last_quantum: Arc<AtomicU64>,
     start: Instant,
     latch: Latch,
+    is_output: bool,
+    draining: Arc<AtomicBool>,
+    drained: Option<Arc<Notify>>,
 }
 
 impl Stream {
+    #[allow(clippy::too_many_arguments)]
     pub(super) fn new(
         handle: JoinHandle<()>,
         controller: pw::channel::Sender<StreamCommand>,
         last_quantum: Arc<AtomicU64>,
         start: Instant,
         latch: Latch,
+        is_output: bool,
+        draining: Arc<AtomicBool>,
+        drained: Option<Arc<Notify>>,
     ) -> Self {
         Self {
             handle: Some(handle),
@@ -100,6 +108,9 @@ impl Stream {
             last_quantum,
             start,
             latch,
+            is_output,
+            draining,
+            drained,
         }
     }
 
@@ -125,7 +136,8 @@ impl Drop for Stream {
 }
 
 impl StreamTrait for Stream {
-    fn play(&self) -> Result<(), Error> {
+    fn start(&self) -> Result<(), Error> {
+        self.draining.store(false, Ordering::Relaxed);
         self.controller
             .send(StreamCommand::Toggle(true))
             .map_err(|_| {
@@ -137,6 +149,56 @@ impl StreamTrait for Stream {
         Ok(())
     }
     fn pause(&self) -> Result<(), Error> {
+        self.controller
+            .send(StreamCommand::Toggle(false))
+            .map_err(|_| {
+                Error::with_message(
+                    ErrorKind::StreamInvalidated,
+                    "stream command channel closed",
+                )
+            })?;
+        Ok(())
+    }
+
+    fn stop(&self, timeout: Option<std::time::Duration>) -> Result<(), Error> {
+        self.draining.store(true, Ordering::Relaxed);
+        let do_drain = self.is_output && timeout != Some(std::time::Duration::ZERO);
+        if do_drain {
+            if let Some(drained) = &self.drained {
+                let (mutex, _) = drained.as_ref();
+                *mutex.lock().unwrap_or_else(|e| e.into_inner()) = false;
+            }
+            self.controller.send(StreamCommand::Drain).map_err(|_| {
+                Error::with_message(
+                    ErrorKind::StreamInvalidated,
+                    "stream command channel closed",
+                )
+            })?;
+            if let Some(drained) = &self.drained {
+                let (mutex, cvar) = drained.as_ref();
+                let guard = mutex.lock().unwrap_or_else(|e| e.into_inner());
+                match timeout {
+                    None => {
+                        let _guard = cvar.wait_while(guard, |done| !*done).map_err(|_| {
+                            Error::with_message(
+                                ErrorKind::StreamInvalidated,
+                                "Drain condvar poisoned",
+                            )
+                        })?;
+                    }
+                    Some(t) => {
+                        let _guard =
+                            cvar.wait_timeout_while(guard, t, |done| !*done)
+                                .map_err(|_| {
+                                    Error::with_message(
+                                        ErrorKind::StreamInvalidated,
+                                        "Drain condvar poisoned",
+                                    )
+                                })?;
+                    }
+                }
+            }
+        }
         self.controller
             .send(StreamCommand::Toggle(false))
             .map_err(|_| {
@@ -226,6 +288,7 @@ pub struct UserData<D> {
     format: AudioInfoRaw,
     last_quantum: Arc<AtomicU64>,
     start: Instant,
+    draining: Arc<AtomicBool>,
     is_default_device: Arc<AtomicBool>,
     has_connected: bool,
     invalidated: Arc<AtomicBool>,
@@ -303,28 +366,30 @@ where
         #[cfg(not(feature = "realtime"))]
         self.last_quantum.store(frames as u64, Ordering::Relaxed);
 
-        let (callback, capture) = match pw_stream_time(stream) {
-            Some(t) => {
-                // `pw_stream_time` guarantees `now > 0` and `denom != 0`.
-                let now = t.now() as u64;
-                let delay_ns = (t.delay() * 1_000_000_000i64 / t.rate().denom as i64).max(0) as u64;
-                (
-                    StreamInstant::from_nanos(now),
-                    StreamInstant::from_nanos(now.saturating_sub(delay_ns)),
-                )
-            }
-            None => {
-                let cb = monotonic_stream_instant()
-                    .unwrap_or_else(|| stream_instant_from_start(self.start));
-                let capture = cb
-                    .checked_sub(frames_to_duration(frames as FrameCount, self.format.rate()))
-                    .unwrap_or(StreamInstant::ZERO);
-                (cb, capture)
-            }
-        };
-        let timestamp = InputStreamTimestamp { callback, capture };
-        let info = InputCallbackInfo { timestamp };
-        (self.data_callback)(data, &info);
+        if !self.draining.load(Ordering::Relaxed) {
+            let (callback, capture) = match pw_stream_time(stream) {
+                Some(t) => {
+                    // `pw_stream_time` guarantees `now > 0` and `denom != 0`.
+                    let now = t.now() as u64;
+                    let delay_ns =
+                        (t.delay() * 1_000_000_000 / t.rate().denom as i64).max(0) as u64;
+                    (
+                        StreamInstant::from_nanos(now),
+                        StreamInstant::from_nanos(now.saturating_sub(delay_ns)),
+                    )
+                }
+                None => {
+                    let cb = monotonic_stream_instant()
+                        .unwrap_or_else(|| stream_instant_from_start(self.start));
+                    let capture = cb
+                        .checked_sub(frames_to_duration(frames as FrameCount, self.format.rate()))
+                        .unwrap_or(StreamInstant::ZERO);
+                    (cb, capture)
+                }
+            };
+            let timestamp = InputStreamTimestamp { callback, capture };
+            (self.data_callback)(data, &InputCallbackInfo { timestamp });
+        }
     }
 }
 
@@ -344,26 +409,28 @@ where
         #[cfg(not(feature = "realtime"))]
         self.last_quantum.store(frames as u64, Ordering::Relaxed);
 
-        let (callback, playback) = match pw_stream_time(stream) {
-            Some(t) => {
-                // `pw_stream_time` guarantees `now > 0` and `denom != 0`.
-                let now = t.now() as u64;
-                let delay_ns = (t.delay() * 1_000_000_000i64 / t.rate().denom as i64).max(0) as u64;
-                (
-                    StreamInstant::from_nanos(now),
-                    StreamInstant::from_nanos(now.saturating_add(delay_ns)),
-                )
-            }
-            None => {
-                let cb = monotonic_stream_instant()
-                    .unwrap_or_else(|| stream_instant_from_start(self.start));
-                let pl = cb + frames_to_duration(frames as FrameCount, self.format.rate());
-                (cb, pl)
-            }
-        };
-        let timestamp = OutputStreamTimestamp { callback, playback };
-        let info = OutputCallbackInfo { timestamp };
-        (self.data_callback)(data, &info);
+        if !self.draining.load(Ordering::Relaxed) {
+            let (callback, playback) = match pw_stream_time(stream) {
+                Some(t) => {
+                    // `pw_stream_time` guarantees `now > 0` and `denom != 0`.
+                    let now = t.now() as u64;
+                    let delay_ns =
+                        (t.delay() * 1_000_000_000 / t.rate().denom as i64).max(0) as u64;
+                    (
+                        StreamInstant::from_nanos(now),
+                        StreamInstant::from_nanos(now.saturating_add(delay_ns)),
+                    )
+                }
+                None => {
+                    let cb = monotonic_stream_instant()
+                        .unwrap_or_else(|| stream_instant_from_start(self.start));
+                    let pl = cb + frames_to_duration(frames as FrameCount, self.format.rate());
+                    (cb, pl)
+                }
+            };
+            let timestamp = OutputStreamTimestamp { callback, playback };
+            (self.data_callback)(data, &OutputCallbackInfo { timestamp });
+        }
     }
 }
 
@@ -458,7 +525,7 @@ impl DefaultDeviceMonitor {
                             &error_callback,
                             Error::with_message(
                                 ErrorKind::BackendError,
-                                format!("PipeWire: failed to bind metadata object; device change notifications may be incomplete: {e}"),
+                                format!("Failed to bind metadata object; device change notifications may be incomplete: {e}"),
                             ),
                         );
                         return;
@@ -526,6 +593,8 @@ pub struct ConnectParams {
     pub last_quantum: Arc<AtomicU64>,
     pub start: Instant,
     pub connect_automatically: bool,
+    pub draining: Arc<AtomicBool>,
+    pub drained: Option<Arc<Notify>>,
 }
 
 pub fn connect_output<D, E>(
@@ -544,6 +613,8 @@ where
         last_quantum,
         start,
         connect_automatically,
+        draining,
+        drained,
     } = params;
 
     let mainloop = MainLoopRc::new(None)?;
@@ -582,6 +653,7 @@ where
         format: Default::default(),
         last_quantum,
         start,
+        draining,
         invalidated: invalidated.clone(),
         is_default_device: is_default_device.clone(),
         has_connected: false,
@@ -647,7 +719,7 @@ where
                                 &user_data.error_callback,
                                 Error::with_message(
                                     ErrorKind::StreamInvalidated,
-                                    format!("PipeWire: failed to stop stream: {e}"),
+                                    format!("Failed to stop stream: {e}"),
                                 ),
                             );
                         }
@@ -659,7 +731,7 @@ where
                             &user_data.error_callback,
                             Error::with_message(
                                 ErrorKind::StreamInvalidated,
-                                format!("PipeWire: failed to parse negotiated audio format: {e}"),
+                                format!("Failed to parse negotiated audio format: {e}"),
                             ),
                         );
                         if let Err(e) = stream.set_active(false) {
@@ -667,7 +739,7 @@ where
                                 &user_data.error_callback,
                                 Error::with_message(
                                     ErrorKind::StreamInvalidated,
-                                    format!("PipeWire: failed to stop stream: {e}"),
+                                    format!("Failed to stop stream: {e}"),
                                 ),
                             );
                         }
@@ -730,6 +802,13 @@ where
                 *chunk.size_mut() = (frames * stride) as u32;
             }
         })
+        .drained(move |_stream, _user_data| {
+            if let Some(drained) = &drained {
+                let (mutex, cvar) = drained.as_ref();
+                *mutex.lock().unwrap_or_else(|e| e.into_inner()) = true;
+                cvar.notify_one();
+            }
+        })
         .register()?;
     let mut audio_info = AudioInfoRaw::new();
     audio_info.set_format(sample_format.into());
@@ -790,6 +869,8 @@ where
         last_quantum,
         start,
         connect_automatically,
+        draining,
+        drained: _,
     } = params;
 
     let mainloop = MainLoopRc::new(None)?;
@@ -828,6 +909,7 @@ where
         format: Default::default(),
         last_quantum,
         start,
+        draining,
         invalidated: invalidated.clone(),
         is_default_device: is_default_device.clone(),
         has_connected: false,
@@ -894,7 +976,7 @@ where
                                 &user_data.error_callback,
                                 Error::with_message(
                                     ErrorKind::StreamInvalidated,
-                                    format!("PipeWire: failed to stop stream: {e}"),
+                                    format!("Failed to stop stream: {e}"),
                                 ),
                             );
                         }
@@ -906,7 +988,7 @@ where
                             &user_data.error_callback,
                             Error::with_message(
                                 ErrorKind::StreamInvalidated,
-                                format!("PipeWire: failed to parse negotiated audio format: {e}"),
+                                format!("Failed to parse negotiated audio format: {e}"),
                             ),
                         );
                         if let Err(e) = stream.set_active(false) {
@@ -914,7 +996,7 @@ where
                                 &user_data.error_callback,
                                 Error::with_message(
                                     ErrorKind::StreamInvalidated,
-                                    format!("PipeWire: failed to stop stream: {e}"),
+                                    format!("Failed to stop stream: {e}"),
                                 ),
                             );
                         }

--- a/src/host/pipewire/stream.rs
+++ b/src/host/pipewire/stream.rs
@@ -832,7 +832,7 @@ where
     // runs on this mainloop thread, not the separate data-loop thread RT_PROCESS creates.
     // That thread promotes itself to RT from the process callback, once when the negotiated
     // quantum is known and again whenever PipeWire renegotiates it.
-    let mut flags = StreamFlags::MAP_BUFFERS;
+    let mut flags = StreamFlags::MAP_BUFFERS | StreamFlags::INACTIVE;
     if connect_automatically {
         flags |= StreamFlags::AUTOCONNECT;
     }
@@ -1064,7 +1064,7 @@ where
     // runs on this mainloop thread, not the separate data-loop thread RT_PROCESS creates.
     // That thread promotes itself to RT from the process callback, once when the negotiated
     // quantum is known and again whenever PipeWire renegotiates it.
-    let mut flags = StreamFlags::MAP_BUFFERS;
+    let mut flags = StreamFlags::MAP_BUFFERS | StreamFlags::INACTIVE;
     if connect_automatically {
         flags |= StreamFlags::AUTOCONNECT;
     }

--- a/src/host/pulseaudio/stream.rs
+++ b/src/host/pulseaudio/stream.rs
@@ -50,8 +50,18 @@ impl LatencyHandle {
 }
 
 enum StreamInner {
-    Playback(pulseaudio::PlaybackStream, Instant, LatencyHandle),
-    Record(pulseaudio::RecordStream, Instant, LatencyHandle),
+    Playback {
+        stream: pulseaudio::PlaybackStream,
+        start: Instant,
+        handle: LatencyHandle,
+        draining: Arc<AtomicBool>,
+        fill_usec: Arc<AtomicU64>,
+    },
+    Record {
+        stream: pulseaudio::RecordStream,
+        start: Instant,
+        handle: LatencyHandle,
+    },
 }
 
 pub struct Stream {
@@ -63,7 +73,7 @@ pub struct Stream {
 impl Drop for Stream {
     fn drop(&mut self) {
         match &mut self.inner {
-            StreamInner::Playback(stream, _, handle) => {
+            StreamInner::Playback { stream, handle, .. } => {
                 handle.cancel();
                 // Help the play_all driver thread terminate by
                 // queueing a delete, which causes the reactor to drop
@@ -71,7 +81,7 @@ impl Drop for Stream {
                 // poll_read always reports a non-empty buffer.
                 let _ = stream.clone().delete().now_or_never();
             }
-            StreamInner::Record(_, _, handle) => {
+            StreamInner::Record { handle, .. } => {
                 handle.cancel();
             }
         }
@@ -91,13 +101,20 @@ impl Drop for Stream {
 }
 
 impl StreamTrait for Stream {
-    fn play(&self) -> Result<(), Error> {
+    fn start(&self) -> Result<(), Error> {
         match &self.inner {
-            StreamInner::Playback(stream, _, handle) => {
+            StreamInner::Playback {
+                stream,
+                handle,
+                draining,
+                ..
+            } => {
+                // Clear any pending drain so the write callback resumes pulling real audio.
+                draining.store(false, Ordering::Relaxed);
                 block_on(stream.uncork()).map_err(Error::from)?;
                 handle.notify();
             }
-            StreamInner::Record(stream, _, handle) => {
+            StreamInner::Record { stream, handle, .. } => {
                 block_on(stream.uncork()).map_err(Error::from)?;
                 block_on(stream.started()).map_err(Error::from)?;
                 handle.notify();
@@ -108,13 +125,44 @@ impl StreamTrait for Stream {
 
     fn pause(&self) -> Result<(), Error> {
         let res = match &self.inner {
-            StreamInner::Playback(stream, _, _) => block_on(stream.cork()),
-            StreamInner::Record(stream, _, _) => block_on(stream.cork()),
+            StreamInner::Playback { stream, .. } => block_on(stream.cork()),
+            StreamInner::Record { stream, .. } => block_on(stream.cork()),
         };
         res.map_err(Error::from)?;
         match &self.inner {
-            StreamInner::Playback(_, _, handle) | StreamInner::Record(_, _, handle) => {
-                handle.notify()
+            StreamInner::Playback { handle, .. } | StreamInner::Record { handle, .. } => {
+                handle.notify();
+            }
+        }
+        Ok(())
+    }
+
+    fn stop(&self, timeout: Option<Duration>) -> Result<(), Error> {
+        match &self.inner {
+            StreamInner::Playback {
+                stream,
+                handle,
+                draining,
+                fill_usec,
+                ..
+            } => {
+                // TODO: use PulseAudio's drain() when https://github.com/colinmarc/pulseaudio-rs/pull/9 is merged.
+                draining.store(true, Ordering::Relaxed);
+                if timeout != Some(Duration::ZERO) {
+                    let buffered = Duration::from_micros(fill_usec.load(Ordering::Relaxed));
+                    let wait = timeout.map_or(buffered, |t| buffered.min(t));
+                    if !wait.is_zero() {
+                        std::thread::sleep(wait);
+                    }
+                }
+                block_on(stream.cork()).map_err(Error::from)?;
+                block_on(stream.flush()).map_err(Error::from)?;
+                handle.notify();
+            }
+            StreamInner::Record { stream, handle, .. } => {
+                block_on(stream.cork()).map_err(Error::from)?;
+                block_on(stream.flush()).map_err(Error::from)?;
+                handle.notify();
             }
         }
         Ok(())
@@ -122,7 +170,7 @@ impl StreamTrait for Stream {
 
     fn now(&self) -> StreamInstant {
         let start = match &self.inner {
-            StreamInner::Playback(_, start, _) | StreamInner::Record(_, start, _) => *start,
+            StreamInner::Playback { start, .. } | StreamInner::Record { start, .. } => *start,
         };
         let elapsed = start.elapsed();
         StreamInstant::new(elapsed.as_secs(), elapsed.subsec_nanos())
@@ -130,13 +178,14 @@ impl StreamTrait for Stream {
 
     fn buffer_size(&self) -> Result<FrameCount, Error> {
         let (spec, bytes) = match &self.inner {
-            StreamInner::Playback(s, _, _) => (
-                s.sample_spec(),
-                s.buffer_attr().minimum_request_length as usize,
+            StreamInner::Playback { stream, .. } => (
+                stream.sample_spec(),
+                stream.buffer_attr().minimum_request_length as usize,
             ),
-            StreamInner::Record(s, _, _) => {
-                (s.sample_spec(), s.buffer_attr().fragment_size as usize)
-            }
+            StreamInner::Record { stream, .. } => (
+                stream.sample_spec(),
+                stream.buffer_attr().fragment_size as usize,
+            ),
         };
         let frame_size = spec.channels as usize * spec.format.bytes_per_sample();
         Ok((bytes / frame_size) as _)
@@ -185,50 +234,65 @@ impl Stream {
         let handle = LatencyHandle::new();
         let update_callback = handle.update.clone();
 
+        let draining = Arc::new(AtomicBool::new(false));
+        let draining_callback = draining.clone();
+
+        let fill_usec = Arc::new(AtomicU64::new(0));
+        let fill_usec_clone = fill_usec.clone();
+
         // Wrap the write callback to match the pulseaudio signature.
         let callback = move |buf: &mut [u8]| {
-            let elapsed = Instant::now().saturating_duration_since(start);
-            let elapsed_usec = elapsed.as_micros() as u64;
-
-            // Interpolate the latency based on elapsed time since the last
-            // poll: as audio plays, the DAC drains the buffer at a constant
-            // rate, so the latency decreases linearly between polls.
-            let stored_latency = latency_clone.load(Ordering::Relaxed);
-            let poll_usec = poll_clone.load(Ordering::Relaxed);
-            // Cap to LATENCY_MAX_INTERVAL: the linear-drain assumption is only valid for that
-            // window, and a stale poll_usec (e.g. after cork/uncork where timing_info blocks)
-            // would otherwise saturate latency to zero.
-            let elapsed_since_poll = elapsed_usec
-                .saturating_sub(poll_usec)
-                .min(LATENCY_MAX_INTERVAL.as_micros() as u64);
-            let latency = stored_latency.saturating_sub(elapsed_since_poll);
-
-            let playback_time = elapsed + Duration::from_micros(latency);
-
-            let timestamp = OutputStreamTimestamp {
-                callback: StreamInstant::new(elapsed.as_secs(), elapsed.subsec_nanos()),
-                playback: StreamInstant::new(playback_time.as_secs(), playback_time.subsec_nanos()),
-            };
-
             // Preemptively fill the buffer with silence in case the user
             // callback doesn't fill it completely (cpal's API doesn't allow
             // short writes).
             buf.fill(silence_byte);
 
-            let bps = sample_spec.format.bytes_per_sample();
-            let n_samples = buf.len() / bps;
+            // While draining (set by stop()), leave the buffer at the silence fill above and skip
+            // the user callback, so previously queued audio plays out and new output is silence
+            // until start() clears the flag. Still report the buffer as fully written (never 0,
+            // which the reactor treats as source EOF) so the stream keeps being serviced normally.
+            if !draining_callback.load(Ordering::Relaxed) {
+                let elapsed = Instant::now().saturating_duration_since(start);
+                let elapsed_usec = elapsed.as_micros() as u64;
 
-            // SAFETY: we calculated the number of samples based on
-            // `sample_spec.format`, and `format` is directly derived from (and
-            // equivalent to) `sample_spec.format`.
-            let mut data = unsafe { Data::from_parts(buf.as_mut_ptr().cast(), n_samples, format) };
+                // Interpolate the latency based on elapsed time since the last
+                // poll: as audio plays, the DAC drains the buffer at a constant
+                // rate, so the latency decreases linearly between polls.
+                let stored_latency = latency_clone.load(Ordering::Relaxed);
+                let poll_usec = poll_clone.load(Ordering::Relaxed);
+                // Cap to LATENCY_MAX_INTERVAL: the linear-drain assumption is only valid for that
+                // window, and a stale poll_usec (e.g. after cork/uncork where timing_info blocks)
+                // would otherwise saturate latency to zero.
+                let elapsed_since_poll = elapsed_usec
+                    .saturating_sub(poll_usec)
+                    .min(LATENCY_MAX_INTERVAL.as_micros() as u64);
+                let latency = stored_latency.saturating_sub(elapsed_since_poll);
 
-            data_callback(&mut data, &OutputCallbackInfo { timestamp });
+                let playback_time = elapsed + Duration::from_micros(latency);
+                let timestamp = OutputStreamTimestamp {
+                    callback: StreamInstant::new(elapsed.as_secs(), elapsed.subsec_nanos()),
+                    playback: StreamInstant::new(
+                        playback_time.as_secs(),
+                        playback_time.subsec_nanos(),
+                    ),
+                };
 
-            // Notify the latency thread that audio was written, so it updates timing info.
-            let (lock, cvar) = &*update_callback;
-            *lock.lock().unwrap_or_else(|e| e.into_inner()) = true;
-            cvar.notify_one();
+                let bps = sample_spec.format.bytes_per_sample();
+                let n_samples = buf.len() / bps;
+
+                // SAFETY: we calculated the number of samples based on
+                // `sample_spec.format`, and `format` is directly derived from (and
+                // equivalent to) `sample_spec.format`.
+                let mut data =
+                    unsafe { Data::from_parts(buf.as_mut_ptr().cast(), n_samples, format) };
+
+                data_callback(&mut data, &OutputCallbackInfo { timestamp });
+
+                // Notify the latency thread that audio was written, so it updates timing info.
+                let (lock, cvar) = &*update_callback;
+                *lock.lock().unwrap_or_else(|e| e.into_inner()) = true;
+                cvar.notify_one();
+            }
 
             // We always consider the full buffer filled, because cpal's
             // user-facing API doesn't allow short writes.
@@ -293,6 +357,7 @@ impl Stream {
 
                 store_latency(
                     &latency_clone,
+                    Some(&fill_usec_clone),
                     sample_spec,
                     timing_info.sink_usec,
                     timing_info.write_offset,
@@ -312,7 +377,13 @@ impl Stream {
         latch.add_thread(driver_handle.thread().clone());
         latch.add_thread(latency_handle.thread().clone());
         Ok(Self {
-            inner: StreamInner::Playback(stream, start, handle),
+            inner: StreamInner::Playback {
+                stream,
+                start,
+                handle,
+                draining,
+                fill_usec,
+            },
             workers: vec![driver_handle, latency_handle],
             latch,
         })
@@ -429,6 +500,7 @@ impl Stream {
 
                 store_latency(
                     &latency_clone,
+                    None,
                     sample_spec,
                     timing_info.source_usec,
                     timing_info.write_offset,
@@ -447,7 +519,11 @@ impl Stream {
 
         latch.add_thread(latency_handle.thread().clone());
         Ok(Self {
-            inner: StreamInner::Record(stream, start, handle),
+            inner: StreamInner::Record {
+                stream,
+                start,
+                handle,
+            },
             workers: vec![latency_handle],
             latch,
         })
@@ -461,18 +537,27 @@ impl Stream {
 
 fn store_latency(
     latency_micros: &AtomicU64,
+    fill_usec: Option<&AtomicU64>,
     sample_spec: protocol::SampleSpec,
     device_latency_usec: u64,
     write_offset: i64,
     read_offset: i64,
 ) {
     let offset = (write_offset - read_offset).max(0) as u64;
+    let buffer_usec: u64 = sample_spec
+        .bytes_to_duration(offset as usize)
+        .as_micros()
+        .try_into()
+        .unwrap_or(u64::MAX);
 
-    let latency =
-        Duration::from_micros(device_latency_usec) + sample_spec.bytes_to_duration(offset as usize);
-
+    if let Some(fill) = fill_usec {
+        fill.store(
+            device_latency_usec.saturating_add(buffer_usec),
+            Ordering::Relaxed,
+        );
+    }
     latency_micros.store(
-        latency.as_micros().try_into().unwrap_or(u64::MAX),
+        device_latency_usec.saturating_add(buffer_usec),
         Ordering::Relaxed,
     );
 }

--- a/src/host/wasapi/device.rs
+++ b/src/host/wasapi/device.rs
@@ -5,7 +5,10 @@ use std::{
     mem,
     os::windows::ffi::OsStringExt,
     ptr, slice,
-    sync::{Arc, Mutex, MutexGuard, OnceLock},
+    sync::{
+        Arc, Mutex, MutexGuard, OnceLock,
+        atomic::{AtomicBool, AtomicU64},
+    },
     time::Duration,
 };
 
@@ -946,6 +949,8 @@ impl Device {
                 config,
                 sample_format,
                 stream_latency,
+                draining: Arc::new(AtomicBool::new(false)),
+                fill_usec: Arc::new(AtomicU64::new(0)),
             })
         }
     }
@@ -1061,6 +1066,8 @@ impl Device {
                 config,
                 sample_format,
                 stream_latency,
+                draining: Arc::new(AtomicBool::new(false)),
+                fill_usec: Arc::new(AtomicU64::new(0)),
             })
         }
     }

--- a/src/host/wasapi/stream.rs
+++ b/src/host/wasapi/stream.rs
@@ -4,7 +4,7 @@ use std::{
     ptr,
     sync::{
         Arc,
-        atomic::{AtomicBool, Ordering},
+        atomic::{AtomicBool, AtomicU64, Ordering},
         mpsc::{Receiver, SendError, Sender, channel},
     },
     thread::{self, JoinHandle},
@@ -215,25 +215,27 @@ pub struct Stream {
 
     // Latch that ensures no callbacks fire before the caller receives the `Stream` handle.
     latch: Latch,
+
+    // Raised by `stop()` so the audio loop emits silence while buffered audio drains.
+    draining: Arc<AtomicBool>,
+
+    // Latency + buffer fill in microseconds, updated each output callback; zero for input.
+    fill_usec: Arc<AtomicU64>,
 }
 
-// SAFETY: Windows Event HANDLEs are safe to send between threads - they are designed for
-// synchronization. All fields of Stream are Send:
-// - JoinHandle<()> is Send
-// - Sender<Command> is Send
-// - Foundation::HANDLE is Send (Windows synchronization primitive)
-// - Latch is Send
-// See: https://learn.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-createeventa
+// SAFETY: All fields of Stream are Send:
+// - Option<JoinHandle<()>>, Sender<Command>, u32, u64, Latch,
+//   Arc<AtomicBool>, Arc<AtomicU64>: all trivially Send
+// - Foundation::HANDLE: Windows event HANDLEs are safe to send between threads
+//   (see https://learn.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-createeventa)
+// - Option<DefaultDeviceMonitor>: has its own unsafe impl Send
 unsafe impl Send for Stream {}
 
-// SAFETY: Windows Event HANDLEs are safe to access from multiple threads simultaneously.
-// All synchronization operations (SetEvent, WaitForSingleObject) are thread-safe.
-// All fields of Stream are Sync:
-// - JoinHandle<()> is Sync
-// - Sender<Command> is Sync (uses internal synchronization)
-// - Foundation::HANDLE for event objects supports concurrent access
-// - Latch is Sync
-// The audio thread owns all COM objects, so no cross-thread COM access occurs.
+// SAFETY: All fields of Stream are Sync:
+// - Option<JoinHandle<()>>, Sender<Command>, u32, u64, Latch,
+//   Arc<AtomicBool>, Arc<AtomicU64>: all trivially Sync
+// - Foundation::HANDLE: SetEvent/WaitForSingleObject are thread-safe
+// - Option<DefaultDeviceMonitor>: has its own unsafe impl Sync
 unsafe impl Sync for Stream {}
 
 struct RunContext {
@@ -268,6 +270,7 @@ unsafe impl Send for RunContext {}
 pub enum Command {
     PlayStream,
     PauseStream,
+    StopStream,
     Terminate,
 }
 
@@ -300,6 +303,10 @@ pub struct StreamInner {
     pub sample_format: SampleFormat,
     // Hardware pipeline latency.
     pub stream_latency: Duration,
+    // Raised by `stop()` so the audio loop writes silence or skips delivering.
+    pub draining: Arc<AtomicBool>,
+    // Updated each output callback: latency + current buffer fill in microseconds.
+    pub fill_usec: Arc<AtomicU64>,
 }
 
 impl Stream {
@@ -319,6 +326,8 @@ impl Stream {
         let (tx, rx) = channel();
 
         let period_frames = stream_inner.period_frames;
+        let draining = stream_inner.draining.clone();
+        let fill_usec = stream_inner.fill_usec.clone();
         let mut qpc_frequency: i64 = 0;
         unsafe {
             Performance::QueryPerformanceFrequency(&mut qpc_frequency)
@@ -369,6 +378,8 @@ impl Stream {
             qpc_frequency: qpc_frequency as u64,
             _default_device_monitor: default_device_monitor,
             latch,
+            draining,
+            fill_usec,
         };
         Ok(stream)
     }
@@ -389,6 +400,8 @@ impl Stream {
         let (tx, rx) = channel();
 
         let period_frames = stream_inner.period_frames;
+        let draining = stream_inner.draining.clone();
+        let fill_usec = stream_inner.fill_usec.clone();
         let mut qpc_frequency: i64 = 0;
         unsafe {
             Performance::QueryPerformanceFrequency(&mut qpc_frequency)
@@ -439,6 +452,8 @@ impl Stream {
             qpc_frequency: qpc_frequency as u64,
             _default_device_monitor: default_device_monitor,
             latch,
+            draining,
+            fill_usec,
         };
         Ok(stream)
     }
@@ -476,7 +491,9 @@ impl Drop for Stream {
 }
 
 impl StreamTrait for Stream {
-    fn play(&self) -> Result<(), Error> {
+    fn start(&self) -> Result<(), Error> {
+        // Clear any pending drain so the audio loop resumes calling the user callback.
+        self.draining.store(false, Ordering::Relaxed);
         self.push_command(Command::PlayStream).map_err(|_| {
             Error::with_message(
                 ErrorKind::StreamInvalidated,
@@ -488,6 +505,26 @@ impl StreamTrait for Stream {
 
     fn pause(&self) -> Result<(), Error> {
         self.push_command(Command::PauseStream).map_err(|_| {
+            Error::with_message(
+                ErrorKind::StreamInvalidated,
+                "Stream command channel closed",
+            )
+        })?;
+        Ok(())
+    }
+
+    fn stop(&self, timeout: Option<Duration>) -> Result<(), Error> {
+        self.draining.store(true, Ordering::Relaxed);
+
+        if timeout != Some(Duration::ZERO) {
+            let fill = Duration::from_micros(self.fill_usec.load(Ordering::Relaxed));
+            let wait = timeout.map_or(fill, |t| fill.min(t));
+            if !wait.is_zero() {
+                std::thread::sleep(wait);
+            }
+        }
+
+        self.push_command(Command::StopStream).map_err(|_| {
             Error::with_message(
                 ErrorKind::StreamInvalidated,
                 "Stream command channel closed",
@@ -542,7 +579,7 @@ fn process_commands(run_context: &mut RunContext) -> Result<bool, Error> {
                     run_context.stream.playing = true;
                 }
             },
-            Command::PauseStream => unsafe {
+            Command::PauseStream | Command::StopStream => unsafe {
                 if run_context.stream.playing {
                     run_context
                         .stream
@@ -550,6 +587,14 @@ fn process_commands(run_context: &mut RunContext) -> Result<bool, Error> {
                         .Stop()
                         .context("Failed to stop audio client")?;
                     run_context.stream.playing = false;
+                }
+                if matches!(command, Command::StopStream) {
+                    // Reset discards the render buffer so a future Start() plays no stale frames.
+                    run_context
+                        .stream
+                        .audio_client
+                        .Reset()
+                        .context("Failed to reset audio client")?;
                 }
             },
             Command::Terminate => {
@@ -790,10 +835,11 @@ fn process_input(
                 / stream.sample_format.sample_size();
             let data = Data::from_parts(data, len, stream.sample_format);
 
-            // The `qpc_position` is in 100 nanosecond units. Convert it to nanoseconds.
-            let timestamp = input_timestamp(stream, qpc_position)?;
-            let info = InputCallbackInfo { timestamp };
-            data_callback(&data, &info);
+            if !stream.draining.load(Ordering::Relaxed) {
+                // The `qpc_position` is in 100 nanosecond units. Convert it to nanoseconds.
+                let timestamp = input_timestamp(stream, qpc_position)?;
+                data_callback(&data, &InputCallbackInfo { timestamp });
+            }
 
             // Release the buffer.
             capture_client
@@ -817,6 +863,19 @@ fn process_output(
         n => n,
     };
 
+    let padding = stream.max_frames_in_buffer - frames_available;
+    let fill_usec = (padding as u64)
+        .saturating_mul(1_000_000)
+        .saturating_div(stream.config.sample_rate as u64)
+        .saturating_add(
+            stream
+                .stream_latency
+                .as_micros()
+                .try_into()
+                .unwrap_or(u64::MAX),
+        );
+    stream.fill_usec.store(fill_usec, Ordering::Relaxed);
+
     unsafe {
         let buffer = render_client.GetBuffer(frames_available)?;
 
@@ -829,10 +888,12 @@ fn process_output(
         let data = buffer as *mut ();
         let len = byte_count / stream.sample_format.sample_size();
         let mut data = Data::from_parts(data, len, stream.sample_format);
-        let sample_rate = stream.config.sample_rate;
-        let timestamp = output_timestamp(stream, sample_rate, clock_frequency, *frames_written)?;
-        let info = OutputCallbackInfo { timestamp };
-        data_callback(&mut data, &info);
+        if !stream.draining.load(Ordering::Relaxed) {
+            let sample_rate = stream.config.sample_rate;
+            let timestamp =
+                output_timestamp(stream, sample_rate, clock_frequency, *frames_written)?;
+            data_callback(&mut data, &OutputCallbackInfo { timestamp });
+        }
 
         render_client.ReleaseBuffer(frames_available, 0)?;
 

--- a/src/host/webaudio/mod.rs
+++ b/src/host/webaudio/mod.rs
@@ -689,7 +689,7 @@ impl Stream {
 }
 
 impl StreamTrait for Stream {
-    fn play(&self) -> Result<(), Error> {
+    fn start(&self) -> Result<(), Error> {
         #[cfg(not(target_feature = "atomics"))]
         {
             let window = web_sys::window().unwrap();
@@ -744,6 +744,10 @@ impl StreamTrait for Stream {
                 "WebAudio context task stopped unexpectedly",
             )
         })
+    }
+
+    fn stop(&self, _timeout: Option<std::time::Duration>) -> Result<(), Error> {
+        self.pause()
     }
 
     fn now(&self) -> StreamInstant {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,8 +83,8 @@
 //! );
 //! ```
 //!
-//! Streams are returned in a paused state. Once the stream has been started with
-//! [`Stream::play`](traits::StreamTrait::play), the selected audio device will periodically call
+//! Streams are not running when returned. Once started with
+//! [`Stream::start`](traits::StreamTrait::start), the selected audio device will periodically call
 //! the data callback that was passed to the function. For input streams, the callback receives
 //! `&`[`Data`] containing captured audio samples. For output streams, the callback receives
 //! `&mut`[`Data`] to be filled with audio samples for playback.
@@ -123,8 +123,8 @@
 //! }
 //! ```
 //!
-//! Streams are always returned in a paused state, so we must call
-//! [`Stream::play`](traits::StreamTrait::play) to start running the data callback.
+//! Streams are not running when returned; call
+//! [`Stream::start`](traits::StreamTrait::start) to begin.
 //!
 //! ```no_run
 //! # use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
@@ -136,11 +136,18 @@
 //! # let data_fn = move |_data: &mut cpal::Data, _: &cpal::OutputCallbackInfo| {};
 //! # let err_fn = move |_err| {};
 //! # let stream = device.build_output_stream_raw(config, sample_format, data_fn, err_fn, None).unwrap();
-//! stream.play().unwrap();
+//! stream.start().unwrap();
 //! ```
 //!
-//! Some devices support pausing the audio stream. This can be useful for saving energy in moments
-//! of silence.
+//! A running stream can be halted in two ways:
+//!
+//! 1. [`pause`](traits::StreamTrait::pause) stops the data callback as soon as possible without
+//!    waiting for any buffered audio to finish.
+//! 2. [`stop`](traits::StreamTrait::stop) drains: it lets audio that has already been buffered
+//!    finish playing, blocking up to the given timeout, before halting.
+//!
+//! Both leave the stream resumable with [`start`](traits::StreamTrait::start); dropping the stream
+//! halts it immediately without draining.
 //!
 //! ```no_run
 //! # use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
@@ -152,7 +159,25 @@
 //! # let data_fn = move |_data: &mut cpal::Data, _: &cpal::OutputCallbackInfo| {};
 //! # let err_fn = move |_err| {};
 //! # let stream = device.build_output_stream_raw(config, sample_format, data_fn, err_fn, None).unwrap();
+//! stream.start().unwrap();
+//! // Halt immediately without waiting for buffered audio to drain.
 //! stream.pause().unwrap();
+//! ```
+//!
+//! ```no_run
+//! # use std::time::Duration;
+//! # use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
+//! # let host = cpal::default_host();
+//! # let device = host.default_output_device().unwrap();
+//! # let supported_config = device.default_output_config().unwrap();
+//! # let sample_format = supported_config.sample_format();
+//! # let config = supported_config.into();
+//! # let data_fn = move |_data: &mut cpal::Data, _: &cpal::OutputCallbackInfo| {};
+//! # let err_fn = move |_err| {};
+//! # let stream = device.build_output_stream_raw(config, sample_format, data_fn, err_fn, None).unwrap();
+//! stream.start().unwrap();
+//! // End gracefully, letting buffered audio play out (up to 1 second).
+//! stream.stop(Some(Duration::from_secs(1))).unwrap();
 //! ```
 //!
 //! [`default_input_device()`]: traits::HostTrait::default_input_device

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -627,12 +627,12 @@ macro_rules! impl_platform_host {
         }
 
         impl crate::traits::StreamTrait for Stream {
-            fn play(&self) -> Result<(), crate::Error> {
+            fn start(&self) -> Result<(), crate::Error> {
                 match self.0 {
                     $(
                         $(#[cfg($feat)])?
                         StreamInner::$HostVariant(ref s) => {
-                            s.play()
+                            s.start()
                         }
                     )*
                 }
@@ -644,6 +644,17 @@ macro_rules! impl_platform_host {
                         $(#[cfg($feat)])?
                         StreamInner::$HostVariant(ref s) => {
                             s.pause()
+                        }
+                    )*
+                }
+            }
+
+            fn stop(&self, timeout: Option<std::time::Duration>) -> Result<(), crate::Error> {
+                match self.0 {
+                    $(
+                        $(#[cfg($feat)])?
+                        StreamInner::$HostVariant(ref s) => {
+                            s.stop(timeout)
                         }
                     )*
                 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -525,10 +525,14 @@ pub trait DeviceTrait: PartialEq + Eq + Hash + Debug + Display + Send + Sync {
 
 /// A stream created from [`Device`](DeviceTrait), with methods to control it.
 pub trait StreamTrait: Send + Sync {
-    /// Start the stream.
+    /// Start (or resume) the stream.
     ///
-    /// Streams returned by `build_*_stream` are always stopped, so `play` must be called before the
-    /// data callback will fire. Despite the name, this applies equally to input (capture) streams.
+    /// Streams returned by `build_*_stream` are always stopped, so `start` must be called before
+    /// the data callback will fire.
+    ///
+    /// `start` also resumes a stream that was halted with [`pause`](Self::pause) or
+    /// [`stop`](Self::stop): after a [`stop`](Self::stop) the backend re-prepares the device as
+    /// needed, so the same stream can be cycled through start/stop without being rebuilt.
     ///
     /// # Errors
     ///
@@ -538,17 +542,31 @@ pub trait StreamTrait: Send + Sync {
     ///
     /// [`ErrorKind::DeviceNotAvailable`]: crate::ErrorKind::DeviceNotAvailable
     /// [`ErrorKind::StreamInvalidated`]: crate::ErrorKind::StreamInvalidated
-    fn play(&self) -> Result<(), Error>;
+    fn start(&self) -> Result<(), Error> {
+        #[allow(deprecated)]
+        self.play()
+    }
 
-    /// Pause the stream. Some devices support suspending at the hardware level (saving energy);
-    /// others stop only the data callback while the hardware keeps running.
+    /// Deprecated alias for [`start`](Self::start).
+    #[deprecated(since = "0.19.0", note = "renamed to `start`")]
+    fn play(&self) -> Result<(), Error> {
+        self.start()
+    }
+
+    /// Pause the stream, halting the data callback as soon as possible.
     ///
-    /// Note: Not all devices support suspending the stream at the hardware level. This method may
-    /// fail in these cases.
+    /// Pausing halts audio immediately without waiting for buffered output to finish. On backends
+    /// that support hardware-level suspend, frames already queued in the device are preserved and
+    /// resume playing after the next [`start`](Self::start); on other backends the buffer may be
+    /// flushed. To let buffered audio play out before halting, use [`stop`](Self::stop) instead. A
+    /// paused stream is resumed with [`start`](Self::start).
+    ///
+    /// Some devices support suspending at the hardware level (saving energy); others stop only the
+    /// data callback while the hardware keeps running.
     ///
     /// # Errors
     ///
-    /// - [`ErrorKind::UnsupportedOperation`] if the backend does not support pausing streams.
+    /// - [`ErrorKind::UnsupportedOperation`] if the backend does not support pausing this stream.
     /// - [`ErrorKind::DeviceNotAvailable`] if the device has been disconnected.
     /// - [`ErrorKind::StreamInvalidated`] if the stream configuration has changed and the stream
     ///   must be rebuilt.
@@ -557,6 +575,41 @@ pub trait StreamTrait: Send + Sync {
     /// [`ErrorKind::DeviceNotAvailable`]: crate::ErrorKind::DeviceNotAvailable
     /// [`ErrorKind::StreamInvalidated`]: crate::ErrorKind::StreamInvalidated
     fn pause(&self) -> Result<(), Error>;
+
+    /// Stop the stream gracefully, draining buffered audio before halting.
+    ///
+    /// Unlike [`pause`](Self::pause), `stop` lets audio that has already been buffered finish:
+    /// on an output stream it blocks the calling thread until the device has played out its queued
+    /// frames (or `timeout` elapses), then halts.
+    ///
+    /// The stream remains valid after `stop`; calling [`start`](Self::start) again resumes it,
+    /// re-preparing the device if the backend requires it.
+    ///
+    /// # Parameters
+    ///
+    /// * `timeout` - How long to wait for buffered audio to drain. `None` waits until the drain
+    ///   completes; `Some(duration)` halts after the duration even if frames remain;
+    ///   `Some(Duration::ZERO)` halts immediately. Independent of the timeout passed to
+    ///   `build_*_stream`.
+    ///
+    /// # Backend support
+    ///
+    /// Draining is only meaningful for output streams. Backends may drain natively or approximate
+    /// it by sleeping for an estimated buffer depth; if a backend has no drain support at all,
+    /// `stop` halts immediately like `pause`. On input (capture) streams, `stop` always halts
+    /// immediately and `timeout` is ignored.
+    ///
+    /// Dropping a stream without calling `stop` halts it immediately, without draining.
+    ///
+    /// # Errors
+    ///
+    /// - [`ErrorKind::DeviceNotAvailable`] if the device has been disconnected.
+    /// - [`ErrorKind::StreamInvalidated`] if the stream configuration has changed and the stream
+    ///   must be rebuilt.
+    ///
+    /// [`ErrorKind::DeviceNotAvailable`]: crate::ErrorKind::DeviceNotAvailable
+    /// [`ErrorKind::StreamInvalidated`]: crate::ErrorKind::StreamInvalidated
+    fn stop(&self, timeout: Option<Duration>) -> Result<(), Error>;
 
     /// Returns the backend's best available estimate of the number of frames per callback.
     ///

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -542,10 +542,7 @@ pub trait StreamTrait: Send + Sync {
     ///
     /// [`ErrorKind::DeviceNotAvailable`]: crate::ErrorKind::DeviceNotAvailable
     /// [`ErrorKind::StreamInvalidated`]: crate::ErrorKind::StreamInvalidated
-    fn start(&self) -> Result<(), Error> {
-        #[allow(deprecated)]
-        self.play()
-    }
+    fn start(&self) -> Result<(), Error>;
 
     /// Deprecated alias for [`start`](Self::start).
     #[deprecated(since = "0.19.0", note = "renamed to `start`")]


### PR DESCRIPTION
This PR introduces `start`/`pause`/`stop` semantics on `StreamTrait` with draining `stop`.

# Playback

On **playback** streams, the difference between pausing and stopping is that:
- `pause` halts as soon as possible, if necessary discarding buffered audio
- `stop(timeout)` drains, letting buffered output finish before halting.

`stop`  thus blocks until the buffer empties or `timeout` elapses.

# Capture

**Capture** streams have nothing to drain and halt immediately on `stop`.

# Behavior details

- `play` is now deprecated and forwards to `start`.
- A `timeout` of `None` waits indefinitely; `Some(Duration::ZERO)` halts without draining.
- Stopped and paused streams are resumable with `start`.
- Dropping a stream halts immediately without draining.

# Backend support

- All backends support draining `stop`, except WebAudio and AudioWorklet where the calling thread can't block.
- On ALSA, `pause` now implements a soft-pause fallback when there is no hardware support.
- While there:
  - relaxed `StreamState` atomics in ASIO and JACK from `Acquire`/`Release` to `Relaxed` (no associated data payload).
  - fixed PipeWire to no longer auto-start streams.

# Related

Fixes:
- #284
- #603
- #785
- #1190 