### PR TITLE
chore(alsa): bump to 0.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Migrated to Rust 2024.
 - `DeviceTrait` and `StreamTrait` now require `Send + Sync` as supertrait bounds.
+- **ALSA**: Update `alsa` dependency to 0.12.
 - **WASAPI**: The `windows` and `windows-core` dependencies are now both pinned to 0.62.
 
 ### Deprecated

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,8 +118,8 @@ num-traits = { version = "0.2", optional = true }
 jack = { version = "0.13.5", optional = true }
 
 [target.'cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "netbsd"))'.dependencies]
-alsa = "0.11"
-alsa-sys = { version = "0.4", optional = true }
+alsa = "0.12"
+alsa-sys = { version = "0.6", optional = true }
 libc = "0.2"
 audio_thread_priority = { version = "0.35", optional = true, default-features = false }
 jack = { version = "0.13.5", optional = true }


### PR DESCRIPTION
alsa 0.12 includes fixes for compiling on time64 enabled libc: https://github.com/diwic/alsa-rs/pull/157

CC @Gelbpunkt

Edit: The clippy-Windows failure looks unrelated since this MR does not change anything for windows.