### PR TITLE
Declare the AVAudioSession dependencies on visionOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **visionOS**: The CoreAudio backend now builds. Its AVAudioSession dependencies were only
-  declared for iOS and tvOS.
 - Timestamps now stay monotonic across device and graph changes.
 - **ALSA**: A nonzero but sub-millisecond stream timeout is no longer treated as a non-blocking poll.
+- **visionOS**: The CoreAudio backend now builds.
 - **WASAPI**: Reported buffer sizes are no longer off by one frame.
 
 ## [0.18.1] - 2026-06-07

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **visionOS**: The CoreAudio backend now builds. Its AVAudioSession dependencies were only
+  declared for iOS and tvOS.
 - Timestamps now stay monotonic across device and graph changes.
 - **ALSA**: A nonzero but sub-millisecond stream timeout is no longer treated as a non-blocking poll.
 - **WASAPI**: Reported buffer sizes are no longer off by one frame.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -157,7 +157,7 @@ objc2 = { version = "0.6" }
 [target.'cfg(target_os = "macos")'.dependencies]
 jack = { version = "0.13.5", optional = true }
 
-[target.'cfg(any(target_os = "ios", target_os = "tvos"))'.dependencies]
+[target.'cfg(any(target_os = "ios", target_os = "tvos", target_os = "visionos"))'.dependencies]
 block2 = "0.6"
 objc2-foundation = { version = "0.3", features = [
     "block2",

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ For higher-level audio playback and capture, consider [Rodio](https://github.com
 | Linux | ALSA | JACK, PipeWire, PulseAudio |
 | macOS | CoreAudio | JACK |
 | tvOS | CoreAudio | - |
+| visionOS | CoreAudio | - |
 | WebAssembly | Web Audio API | Audio Worklet |
 | Windows | WASAPI | ASIO, JACK |
 
@@ -46,6 +47,7 @@ The minimum Rust version (MSRV) and minimum operating system / runtime version b
 | CoreAudio | macOS | 1.85 | macOS 14.2 (loopback recording requires 14.6+) |
 | CoreAudio | iOS | 1.85 | — |
 | CoreAudio | tvOS | nightly | — |
+| CoreAudio | visionOS | 1.85 | — |
 | JACK | Linux, BSD, macOS, Windows | 1.85 | — |
 | PipeWire | Linux, BSD | 1.85 | PipeWire 0.3.53 |
 | PulseAudio | Linux, BSD | 1.88 | — |


### PR DESCRIPTION
The CoreAudio backend gates its AVAudioSession code path on every non-macOS Apple platform:

```rust
#[cfg(all(target_vendor = "apple", not(target_os = "macos")))]
```

but `block2`, `objc2-foundation` and `objc2-avf-audio` are declared only for `ios` and `tvos`.
On visionOS the code is compiled while the crates are absent, so the build stops at:

```
error[E0432]: unresolved import `objc2_avf_audio`
error[E0432]: unresolved import `block2`
error[E0432]: unresolved imports `objc2_foundation::NSNotification`, `objc2_foundation::NSNotificationCenter`
```

This looks like an oversight in #1155, which added `tvos` to that list. Everything below is already
in place: coreaudio-rs gained visionOS support in RustAudio/coreaudio-rs#148, and mach2 0.6, the
version cpal requires, builds for every Apple vendor.

Builds, on master with rustc 1.97 and Xcode 26.6:

| target | before | after |
| --- | --- | --- |
| aarch64-apple-darwin | ok | ok |
| aarch64-apple-ios | ok | ok |
| aarch64-apple-tvos | ok | ok |
| aarch64-apple-visionos | fails to build | ok |

Runtime, on the visionOS 26.2 simulator (`xcrun simctl spawn`), built for
`aarch64-apple-visionos-sim`:

- `examples/enumerate` reports the CoreAudio host and the default device, 48 kHz, F32, 2 channels out.
- `examples/beep` opens an output stream and the sine is audible.
- rodio at master, which already requires cpal 0.18, plays a `SineWave` through
  `DeviceSinkBuilder::open_default_sink` and exits cleanly.

I have not run this on Vision Pro hardware, only on the simulator.

I did not widen the cfg to `all(target_vendor = "apple", not(target_os = "macos"))`, which is what
the code gate says. watchOS still fails further down inside coreaudio-rs
(`cannot find value buffer_frame_size`), so claiming it in the manifest would only move the error.
Adding `visionos` alone keeps the manifest honest about what builds today.
