### PR TITLE
Fix clippy::question_mark on Rust 1.97 (ALSA and ASIO)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **ALSA**, **ASIO**: Two `match` expressions are replaced with `?`, which `clippy::question_mark`
-  started flagging in Rust 1.97.
 - Timestamps now stay monotonic across device and graph changes.
 - **ALSA**: A nonzero but sub-millisecond stream timeout is no longer treated as a non-blocking poll.
 - **visionOS**: The CoreAudio backend now builds.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **ALSA**, **ASIO**: Two `match` expressions are replaced with `?`, which `clippy::question_mark`
+  started flagging in Rust 1.97.
 - Timestamps now stay monotonic across device and graph changes.
 - **ALSA**: A nonzero but sub-millisecond stream timeout is no longer treated as a non-blocking poll.
 - **WASAPI**: Reported buffer sizes are no longer off by one frame.

--- a/src/host/alsa/mod.rs
+++ b/src/host/alsa/mod.rs
@@ -607,10 +607,7 @@ impl Device {
     // ALSA does not offer default stream formats, so instead we compare all supported formats by
     // the `SupportedStreamConfigRange::cmp_default_heuristics` order and select the greatest.
     fn default_config(&self, stream_t: alsa::Direction) -> Result<SupportedStreamConfig, Error> {
-        let mut formats: Vec<_> = match self.supported_configs(stream_t) {
-            Err(err) => return Err(err),
-            Ok(fmts) => fmts.collect(),
-        };
+        let mut formats: Vec<_> = self.supported_configs(stream_t)?.collect();
 
         formats.sort_by(|a, b| a.cmp_default_heuristics(b));
 

--- a/src/host/asio/device.rs
+++ b/src/host/asio/device.rs
@@ -180,68 +180,66 @@ impl Iterator for Devices {
         self.current_driver = None;
 
         loop {
-            match self.drivers.next() {
-                Some(name) => match self.asio.load_driver(&name) {
-                    Ok(driver) => {
-                        let Ok(channels) = driver.channels() else {
-                            continue;
-                        };
-                        if channels.ins == 0 && channels.outs == 0 {
-                            continue;
-                        }
-
-                        // Some drivers (e.g. Realtek ASIO) return 0 for sample_rate() until a
-                        // stream is active. Treat 0 as "not yet known" rather than skipping.
-                        let sample_rate = driver.sample_rate().unwrap_or(0.0);
-
-                        let Ok(buffer_size_range) = driver.buffersize_range() else {
-                            continue;
-                        };
-
-                        let input_sample_format = driver
-                            .input_data_type()
-                            .ok()
-                            .and_then(|t| convert_data_type(&t));
-                        let output_sample_format = driver
-                            .output_data_type()
-                            .ok()
-                            .and_then(|t| convert_data_type(&t));
-
-                        let supported_sample_rates: Box<[SampleRate]> = crate::COMMON_SAMPLE_RATES
-                            .iter()
-                            .copied()
-                            .filter(|&r| driver.can_sample_rate(r.into()).unwrap_or(false))
-                            .collect();
-
-                        self.current_driver = Some(driver);
-
-                        let asio_streams = Arc::new(Mutex::new(sys::AsioStreams {
-                            input: None,
-                            output: None,
-                        }));
-
-                        return Some(Device {
-                            name,
-                            channels_in: channels.ins as ChannelCount,
-                            channels_out: channels.outs as ChannelCount,
-                            sample_rate: sample_rate as SampleRate,
-                            buffer_size_min: buffer_size_range.min as FrameCount,
-                            buffer_size_max: buffer_size_range.max as FrameCount,
-                            input_sample_format,
-                            output_sample_format,
-                            supported_sample_rates,
-                            asio_streams,
-                            // Initialize with sentinel value so it never matches global flag state (0 or 1).
-                            current_callback_flag: Arc::new(AtomicU32::new(u32::MAX)),
-                        });
+            let name = self.drivers.next()?;
+            match self.asio.load_driver(&name) {
+                Ok(driver) => {
+                    let Ok(channels) = driver.channels() else {
+                        continue;
+                    };
+                    if channels.ins == 0 && channels.outs == 0 {
+                        continue;
                     }
-                    // A different driver is already loaded (e.g. an active Stream holds it). Stop
-                    // cleanly rather than spinning through the rest of the list.
-                    Err(sys::LoadDriverError::DriverAlreadyExists) => return None,
-                    // Driver failed to load for its own reasons; skip and try the next.
-                    Err(_) => continue,
-                },
-                None => return None,
+
+                    // Some drivers (e.g. Realtek ASIO) return 0 for sample_rate() until a
+                    // stream is active. Treat 0 as "not yet known" rather than skipping.
+                    let sample_rate = driver.sample_rate().unwrap_or(0.0);
+
+                    let Ok(buffer_size_range) = driver.buffersize_range() else {
+                        continue;
+                    };
+
+                    let input_sample_format = driver
+                        .input_data_type()
+                        .ok()
+                        .and_then(|t| convert_data_type(&t));
+                    let output_sample_format = driver
+                        .output_data_type()
+                        .ok()
+                        .and_then(|t| convert_data_type(&t));
+
+                    let supported_sample_rates: Box<[SampleRate]> = crate::COMMON_SAMPLE_RATES
+                        .iter()
+                        .copied()
+                        .filter(|&r| driver.can_sample_rate(r.into()).unwrap_or(false))
+                        .collect();
+
+                    self.current_driver = Some(driver);
+
+                    let asio_streams = Arc::new(Mutex::new(sys::AsioStreams {
+                        input: None,
+                        output: None,
+                    }));
+
+                    return Some(Device {
+                        name,
+                        channels_in: channels.ins as ChannelCount,
+                        channels_out: channels.outs as ChannelCount,
+                        sample_rate: sample_rate as SampleRate,
+                        buffer_size_min: buffer_size_range.min as FrameCount,
+                        buffer_size_max: buffer_size_range.max as FrameCount,
+                        input_sample_format,
+                        output_sample_format,
+                        supported_sample_rates,
+                        asio_streams,
+                        // Initialize with sentinel value so it never matches global flag state (0 or 1).
+                        current_callback_flag: Arc::new(AtomicU32::new(u32::MAX)),
+                    });
+                }
+                // A different driver is already loaded (e.g. an active Stream holds it). Stop
+                // cleanly rather than spinning through the rest of the list.
+                Err(sys::LoadDriverError::DriverAlreadyExists) => return None,
+                // Driver failed to load for its own reasons; skip and try the next.
+                Err(_) => continue,
             }
         }
     }


### PR DESCRIPTION
Rust 1.97, released on July 9, extends `clippy::question_mark` to `match` expressions whose arms
map cleanly onto `?`. CI runs clippy with `-D warnings`, so `clippy-Linux` and `clippy-Windows`
now fail on master and on every open pull request:

```
error: this `match` expression can be replaced with `?`
   --> src/host/alsa/mod.rs:610:35
error: this `match` expression can be replaced with `?`
   --> src\host\asio\device.rs:183:13
```

Both are mechanical. In the ASIO iterator the `match` on `self.drivers.next()` becomes
`let name = self.drivers.next()?;`, which returns `None` from `next` exactly as the old
`None => return None` arm did. The rest of that hunk is reindentation, and the diff is empty once
whitespace is ignored.

Verified for ALSA by running the Linux job's own command, `cargo clippy --all --all-features
-- -D warnings`, on rust:1.97: it fails on master and passes with this change. The ASIO backend
only builds on Windows with the ASIO SDK, so I could not run clippy against it locally and I am
relying on this PR's own `clippy-Windows` job. `cargo fmt --all --check` is clean.
