### PR TITLE
feat: report xrun via CallbackInfo instead of ErrorKind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,45 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [Unreleased] (v0.19)
 
 ### Added
 
 - `StreamTrait::stop` ends a stream gracefully, draining buffered audio before halting (blocking up to a caller-supplied timeout). Dropping a stream still halts immediately without draining.
+- `CallbackInfo::xrun()` reports buffer over/underruns via the data callback.
+
+### Changed
+
+- Migrated to Rust 2024.
+- `DeviceTrait` and `StreamTrait` now require `Send + Sync` as supertrait bounds.
+- `StreamTrait::play` is renamed to `start`.
+- `InputCallbackInfo`/`OutputCallbackInfo` merged into `CallbackInfo`.
+- `InputStreamTimestamp`/`OutputStreamTimestamp` merged into `StreamTimestamp`; `capture`/`playback` renamed `device`.
+- **ALSA**: Update `alsa` dependency to 0.12.
+
+### Deprecated
+
+- `StreamTrait::play` is deprecated in favor of `start`.
+- `assert_stream_send!` and `assert_stream_sync!` are deprecated; `StreamTrait: Send + Sync` makes them redundant.
+
+### Removed
+
+- Breaking: `ErrorKind::Xrun` (see UPGRADING.md).
+
+### Fixed
+
+- **AudioWorklet**: Fix `Stream` operations to work when called from any thread.
+- **CoreAudio**: Default-output streams now report xrun status.
+- **CoreAudio**: Fix stale audio output when a data callback wrote a partial buffer.
+- **PipeWire**: Fix streams starting audio before `start()` is called.
+- **PulseAudio**: `NoData` errors are no longer misreported as buffer xruns.
+- **WebAudio**: Fix unsound `Send + Sync` on `Stream` when compiled with `+atomics`.
+- **WebAudio**: Fix `Host::is_available()` always returning `true`, even in non-window contexts.
+
+## [Unreleased] (v0.18.2)
+
+### Added
+
 - **AAudio**: Xruns are now reported as `ErrorKind::Xrun`.
 - **CoreAudio**: Xruns are now reported as `ErrorKind::Xrun`.
 - **PipeWire**: Xruns are now reported as `ErrorKind::Xrun`.
@@ -17,36 +51,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Migrated to Rust 2024.
-- `DeviceTrait` and `StreamTrait` now require `Send + Sync` as supertrait bounds.
-- `StreamTrait::play` is renamed to `start`.
-- **ALSA**: Update `alsa` dependency to 0.12.
+- **CoreAudio**: Bump `objc2-core-foundation` dependency lower bound to 0.3.1.
+- **iOS**: Timestamps now include hardware latency and update when the audio route changes.
+- **JACK**: Timestamps now include port latency.
 - **WASAPI**: The `windows` and `windows-core` dependencies are now both pinned to 0.62.
-
-### Deprecated
-
-- `StreamTrait::play` is deprecated in favor of `start`.
-- `assert_stream_send!` and `assert_stream_sync!` are deprecated; `StreamTrait: Send + Sync` makes them redundant.
 
 ### Fixed
 
 - Timestamps now stay monotonic across device and graph changes.
 - **ALSA**: A nonzero but sub-millisecond stream timeout is no longer treated as a non-blocking poll.
-- **AudioWorklet**: Fix `Stream` operations to work when called from any thread.
-- **CoreAudio**: Bump `objc2-core-foundation` dependency lower bound to 0.3.1.
-- **CoreAudio**: Fix stale audio output when a data callback wrote a partial buffer.
-- **iOS**: Timestamps now include hardware latency and update when the audio route changes.
-- **JACK**: Timestamps now include port latency.
 - **JACK**: Streams with more channels than physical system ports no longer fail to build.
 - **JACK**: Channel enumeration is no longer capped at the physical system port count.
-- **PipeWire**: Fix streams starting audio before `start()` is called.
 - **PipeWire**: Streams for a specific device no longer auto-reroute if it disappears.
 - **visionOS**: The CoreAudio backend now builds.
 - **WASAPI**: Default device changes no longer report `DeviceChanged`, which wrongly implied the stream had rerouted automatically.
 - **WASAPI**: Reported buffer sizes are no longer off by one frame.
 - **WASAPI**: `Stream::drop`, `play`, and `pause` no longer panic when the device is lost.
-- **WebAudio**: Fix unsound `Send + Sync` on `Stream` when compiled with `+atomics`.
-- **WebAudio**: Fix `Host::is_available()` always returning `true`, even in non-window contexts.
 
 ## [0.18.1] - 2026-06-07
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -224,6 +224,10 @@ name = "record_wav"
 [[example]]
 name = "synth_tones"
 
+[[example]]
+name = "custom"
+required-features = ["custom"]
+
 [package.metadata.docs.rs]
 # The docs.rs build environment does not have all the dependencies for all features
 features = [

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -8,6 +8,9 @@ This guide covers breaking changes requiring code updates. See [CHANGELOG.md](CH
 - [ ] Remove any calls to the deprecated `assert_stream_send!` and `assert_stream_sync!` macros.
 - [ ] Rename `StreamTrait::play` calls to `start` (the old name still works but is deprecated).
 - [ ] If you implement a custom host, add a `StreamTrait::stop` implementation.
+- [ ] Replace `InputCallbackInfo`/`OutputCallbackInfo` with `CallbackInfo`.
+- [ ] Replace `InputStreamTimestamp`/`OutputStreamTimestamp` with `StreamTimestamp`; `capture`/`playback` is now `device`.
+- [ ] Remove `ErrorKind::Xrun` match arms; read `CallbackInfo::xrun()` instead.
 
 ## 1. `DeviceTrait` and `StreamTrait` require `Send + Sync`
 
@@ -35,6 +38,59 @@ Draining is best-effort and varies by backend: most built-in output backends res
 
 [`start`]: https://docs.rs/cpal/latest/cpal/traits/trait.StreamTrait.html#tymethod.start
 [`stop`]: https://docs.rs/cpal/latest/cpal/traits/trait.StreamTrait.html#tymethod.stop
+
+## 3. `InputCallbackInfo`/`OutputCallbackInfo` and timestamp types merged
+
+**What changed:** `InputCallbackInfo` and `OutputCallbackInfo` are replaced by a single [`CallbackInfo`]. `InputStreamTimestamp` and `OutputStreamTimestamp` are replaced by a single [`StreamTimestamp`]; its `capture`/`playback` field is renamed `device`.
+
+```rust
+// Before (v0.18)
+let data_fn = move |data: &mut [f32], info: &OutputCallbackInfo| {
+    let playback = info.timestamp().playback;
+    // ...
+};
+
+// After (v0.19)
+let data_fn = move |data: &mut [f32], info: &CallbackInfo| {
+    let playback = info.timestamp().device;
+    // ...
+};
+```
+
+**Impact:** Update data callback signatures to `&CallbackInfo`, and `.playback`/`.capture` reads to `.device`. The type system still stops you from wiring an output closure to an input stream: `build_output_stream` requires `&mut Data`, `build_input_stream` requires `&Data`.
+
+**Why:** The two structs were identical in shape, distinguished only by name.
+
+[`CallbackInfo`]: https://docs.rs/cpal/latest/cpal/struct.CallbackInfo.html
+[`StreamTimestamp`]: https://docs.rs/cpal/latest/cpal/struct.StreamTimestamp.html
+
+## 4. Buffer over/underrun reported via `CallbackInfo::xrun()`, not `ErrorKind::Xrun`
+
+**What changed:** `ErrorKind::Xrun` is removed. Buffer overruns and underruns are now reported through the data callback's info struct instead of `error_callback`, via [`CallbackInfo::xrun()`].
+
+```rust
+// Before (v0.18): delivered asynchronously through error_callback
+let err_fn = |err: Error| match err.kind() {
+    ErrorKind::Xrun => eprintln!("xrun"),
+    _ => eprintln!("Stream error: {err}"),
+};
+
+// After (v0.19): delivered with the data callback, tied to the affected block of samples
+let data_fn = move |data: &mut [f32], info: &CallbackInfo| {
+    if info.xrun() {
+        eprintln!("underrun");
+    }
+    // ...
+};
+```
+
+**Impact:** Remove `ErrorKind::Xrun` from `error_callback` match arms. Read `info.xrun()` in the data callback instead.
+
+**Why:** `error_callback` has no ordering guarantee relative to the data callback. On several hosts the xrun notification arrives through a separate system-level callback entirely. An engine that needs to know exactly which block of samples was affected by a glitch, e.g. to skip forward and stay in sync with something else running in real time, needs that information delivered alongside the data itself.
+
+Ordering of `xrun()` relative to the glitch it reports varies by host; see [`CallbackInfo`]'s docs for the per-host table. WASAPI render and iOS have no xrun signal at all, so `xrun()` is always `false` there.
+
+[`CallbackInfo::xrun()`]: https://docs.rs/cpal/latest/cpal/struct.CallbackInfo.html#method.xrun
 
 ---
 

--- a/examples/android/src/lib.rs
+++ b/examples/android/src/lib.rs
@@ -4,9 +4,9 @@ extern crate anyhow;
 extern crate cpal;
 
 use cpal::{
+    CallbackInfo, Device, Error, ErrorKind, FromSample, I24, Sample, SampleFormat, SizedSample,
+    StreamConfig,
     traits::{DeviceTrait, HostTrait, StreamTrait},
-    Device, Error, ErrorKind, FromSample, OutputCallbackInfo, Sample, SampleFormat, SizedSample,
-    StreamConfig, I24,
 };
 
 #[cfg_attr(target_os = "android", ndk_glue::main(backtrace = "full"))]
@@ -53,15 +53,15 @@ where
     };
 
     let err_fn = |err: Error| match err.kind() {
-        ErrorKind::DeviceChanged | ErrorKind::Xrun | ErrorKind::RealtimeDenied => eprintln!("{err}"),
+        ErrorKind::DeviceChanged | ErrorKind::Xrun | ErrorKind::RealtimeDenied => {
+            eprintln!("{err}")
+        }
         _ => eprintln!("Stream error: {err}"),
     };
 
     let stream = device.build_output_stream(
         config,
-        move |data: &mut [T], _: &OutputCallbackInfo| {
-            write_data(data, channels, &mut next_value)
-        },
+        move |data: &mut [T], _: &CallbackInfo| write_data(data, channels, &mut next_value),
         err_fn,
         None,
     )?;

--- a/examples/android/src/lib.rs
+++ b/examples/android/src/lib.rs
@@ -53,9 +53,7 @@ where
     };
 
     let err_fn = |err: Error| match err.kind() {
-        ErrorKind::DeviceChanged | ErrorKind::Xrun | ErrorKind::RealtimeDenied => {
-            eprintln!("{err}")
-        }
+        ErrorKind::DeviceChanged | ErrorKind::RealtimeDenied => eprintln!("{err}"),
         _ => eprintln!("Stream error: {err}"),
     };
 

--- a/examples/audioworklet-beep/src/lib.rs
+++ b/examples/audioworklet-beep/src/lib.rs
@@ -80,7 +80,7 @@ where
     };
 
     let err_fn = |err: Error| match err.kind() {
-        ErrorKind::DeviceChanged | ErrorKind::Xrun | ErrorKind::RealtimeDenied => {
+        ErrorKind::DeviceChanged | ErrorKind::RealtimeDenied => {
             console::log_1(&format!("{err}").into())
         }
         _ => console::error_1(&format!("Stream error: {err}").into()),

--- a/examples/beep.rs
+++ b/examples/beep.rs
@@ -13,7 +13,7 @@
 
 use clap::Parser;
 use cpal::{
-    Device, Error, ErrorKind, FromSample, HostId, I24, OutputCallbackInfo, Sample, SampleFormat,
+    CallbackInfo, Device, Error, ErrorKind, FromSample, HostId, I24, Sample, SampleFormat,
     SizedSample, StreamConfig,
     traits::{DeviceTrait, HostTrait, StreamTrait},
 };
@@ -143,7 +143,7 @@ where
 
     let stream = device.build_output_stream(
         config,
-        move |data: &mut [T], _: &OutputCallbackInfo| write_data(data, channels, &mut next_value),
+        move |data: &mut [T], _: &CallbackInfo| write_data(data, channels, &mut next_value),
         err_fn,
         None,
     )?;

--- a/examples/beep.rs
+++ b/examples/beep.rs
@@ -143,7 +143,12 @@ where
 
     let stream = device.build_output_stream(
         config,
-        move |data: &mut [T], _: &CallbackInfo| write_data(data, channels, &mut next_value),
+        move |data: &mut [T], info: &CallbackInfo| {
+            if info.xrun() {
+                eprintln!("output underrun");
+            }
+            write_data(data, channels, &mut next_value)
+        },
         err_fn,
         None,
     )?;

--- a/examples/beep.rs
+++ b/examples/beep.rs
@@ -135,7 +135,7 @@ where
     };
 
     let err_fn = |err: Error| match err.kind() {
-        ErrorKind::DeviceChanged | ErrorKind::Xrun | ErrorKind::RealtimeDenied => {
+        ErrorKind::DeviceChanged | ErrorKind::RealtimeDenied => {
             eprintln!("{err}")
         }
         _ => eprintln!("Stream error: {err}"),

--- a/examples/custom.rs
+++ b/examples/custom.rs
@@ -8,14 +8,13 @@ use std::{
 };
 
 use cpal::{
-    ChannelCount, Data, Device, DeviceDescription, DeviceDescriptionBuilder, DeviceId, Error,
-    ErrorKind, FrameCount, FromSample, InputCallbackInfo, OutputCallbackInfo,
-    OutputStreamTimestamp, Sample, SampleFormat, Stream, StreamConfig, StreamInstant,
-    SupportedBufferSize, SupportedStreamConfig, SupportedStreamConfigRange,
+    CallbackInfo, ChannelCount, Data, Device, DeviceDescription, DeviceDescriptionBuilder,
+    DeviceId, Error, ErrorKind, FrameCount, FromSample, Sample, SampleFormat, Stream, StreamConfig,
+    StreamInstant, StreamTimestamp, SupportedBufferSize, SupportedStreamConfig,
+    SupportedStreamConfigRange,
     traits::{DeviceTrait, HostTrait, StreamTrait},
 };
 
-#[allow(dead_code)]
 #[derive(Clone)] // Clone, Send+Sync are required
 struct MyHost;
 
@@ -117,7 +116,7 @@ impl DeviceTrait for MyDevice {
         _: Option<Duration>,
     ) -> Result<Self::Stream, Error>
     where
-        D: FnMut(&Data, &InputCallbackInfo) + Send + 'static,
+        D: FnMut(&Data, &CallbackInfo) + Send + 'static,
         E: FnMut(Error) + Send + 'static,
     {
         Err(Error::new(ErrorKind::UnsupportedConfig))
@@ -136,7 +135,7 @@ impl DeviceTrait for MyDevice {
         _: Option<Duration>,
     ) -> Result<Self::Stream, Error>
     where
-        D: FnMut(&mut Data, &OutputCallbackInfo) + Send + 'static,
+        D: FnMut(&mut Data, &CallbackInfo) + Send + 'static,
         E: FnMut(Error) + Send + 'static,
     {
         let controls = Arc::new(StreamControls {
@@ -167,11 +166,11 @@ impl DeviceTrait for MyDevice {
                 let secs = duration.as_nanos() / 1_000_000_000;
                 let subsec_nanos = duration.as_nanos() - secs * 1_000_000_000;
                 let stream_instant = StreamInstant::new(secs as _, subsec_nanos as _);
-                let timestamp = OutputStreamTimestamp {
+                let timestamp = StreamTimestamp {
                     callback: stream_instant,
-                    playback: stream_instant,
+                    device: stream_instant,
                 };
-                data_callback(&mut data, &OutputCallbackInfo::new(timestamp));
+                data_callback(&mut data, &CallbackInfo::new(timestamp, false));
 
                 let avg = buffer.iter().sum::<f32>() / buffer.len() as f32;
                 println!("avg: {avg}");
@@ -228,7 +227,6 @@ impl Drop for MyStream {
     }
 }
 
-#[cfg(feature = "custom")]
 fn main() {
     let custom_host = cpal::platform::CustomHost::from_host(MyHost);
     // alternatively, use cpal::platform::CustomDevice and skip enumerating devices
@@ -240,11 +238,6 @@ fn main() {
     let stream = make_stream(&device, config.into()).unwrap();
     stream.start().unwrap();
     std::thread::sleep(std::time::Duration::from_millis(4000));
-}
-
-#[cfg(not(feature = "custom"))]
-fn main() {
-    panic!("please run with -F custom to try this example")
 }
 
 // rest of this example is mostly based off of synth_tones.rs
@@ -329,7 +322,7 @@ pub fn make_stream(device: &Device, config: StreamConfig) -> Result<Stream, anyh
         frequency_hz: 440.0,
     };
     let err_fn = |err: Error| match err.kind() {
-        ErrorKind::DeviceChanged | ErrorKind::Xrun | ErrorKind::RealtimeDenied => {
+        ErrorKind::DeviceChanged | ErrorKind::RealtimeDenied => {
             eprintln!("{err}")
         }
         _ => eprintln!("Stream error: {err}"),
@@ -340,7 +333,7 @@ pub fn make_stream(device: &Device, config: StreamConfig) -> Result<Stream, anyh
 
     let stream = device.build_output_stream(
         config,
-        move |output: &mut [f32], _: &OutputCallbackInfo| {
+        move |output: &mut [f32], _: &CallbackInfo| {
             // for 0-1s play sine, 1-2s play square, 2-3s play saw, 3-4s play triangle_wave
             let time_since_start = Instant::now().duration_since(time_at_start).as_secs_f32();
             if time_since_start < 1.0 {

--- a/examples/feedback.rs
+++ b/examples/feedback.rs
@@ -159,7 +159,7 @@ fn main() -> anyhow::Result<()> {
 
 fn err_fn(err: Error) {
     match err.kind() {
-        ErrorKind::DeviceChanged | ErrorKind::Xrun | ErrorKind::RealtimeDenied => {
+        ErrorKind::DeviceChanged | ErrorKind::RealtimeDenied => {
             eprintln!("{err}")
         }
         _ => eprintln!("Stream error: {err}"),

--- a/examples/feedback.rs
+++ b/examples/feedback.rs
@@ -8,7 +8,7 @@
 
 use clap::Parser;
 use cpal::{
-    Error, ErrorKind, HostId, InputCallbackInfo, OutputCallbackInfo, Sample, StreamConfig,
+    CallbackInfo, Error, ErrorKind, HostId, Sample, StreamConfig,
     traits::{DeviceTrait, HostTrait, StreamTrait},
 };
 use ringbuf::{
@@ -120,13 +120,13 @@ fn main() -> anyhow::Result<()> {
         producer.try_push(f32::EQUILIBRIUM).unwrap();
     }
 
-    let input_data_fn = move |data: &[f32], _: &InputCallbackInfo| {
+    let input_data_fn = move |data: &[f32], _: &CallbackInfo| {
         if producer.push_slice(data) < data.len() {
             eprintln!("output stream fell behind: try increasing latency");
         }
     };
 
-    let output_data_fn = move |data: &mut [f32], _: &OutputCallbackInfo| {
+    let output_data_fn = move |data: &mut [f32], _: &CallbackInfo| {
         let read = consumer.pop_slice(data);
         if read < data.len() {
             data[read..].fill(f32::EQUILIBRIUM);

--- a/examples/ios-feedback/src/feedback.rs
+++ b/examples/ios-feedback/src/feedback.rs
@@ -11,12 +11,12 @@ extern crate cpal;
 extern crate ringbuf;
 
 use cpal::{
+    CallbackInfo, Error, ErrorKind, Sample, StreamConfig,
     traits::{DeviceTrait, HostTrait, StreamTrait},
-    Error, ErrorKind, InputCallbackInfo, OutputCallbackInfo, Sample, StreamConfig,
 };
 use ringbuf::{
-    traits::{Consumer, Producer, Split},
     HeapRb,
+    traits::{Consumer, Producer, Split},
 };
 
 const LATENCY_MS: f32 = 1000.0;
@@ -31,8 +31,14 @@ pub fn run_example() -> Result<(), anyhow::Error> {
     let output_device = host
         .default_output_device()
         .expect("failed to get default output device");
-    println!("Using default input device: \"{}\"", input_device.description()?.name());
-    println!("Using default output device: \"{}\"", output_device.description()?.name());
+    println!(
+        "Using default input device: \"{}\"",
+        input_device.description()?.name()
+    );
+    println!(
+        "Using default output device: \"{}\"",
+        output_device.description()?.name()
+    );
 
     // We'll try and use the same configuration between streams to keep it simple.
     let config: StreamConfig = input_device.default_input_config()?.into();
@@ -52,13 +58,13 @@ pub fn run_example() -> Result<(), anyhow::Error> {
         producer.try_push(f32::EQUILIBRIUM).unwrap();
     }
 
-    let input_data_fn = move |data: &[f32], _: &InputCallbackInfo| {
+    let input_data_fn = move |data: &[f32], _: &CallbackInfo| {
         if producer.push_slice(data) < data.len() {
             eprintln!("output stream fell behind: try increasing latency");
         }
     };
 
-    let output_data_fn = move |data: &mut [f32], _: &OutputCallbackInfo| {
+    let output_data_fn = move |data: &mut [f32], _: &CallbackInfo| {
         let read = consumer.pop_slice(data);
         if read < data.len() {
             data[read..].fill(f32::EQUILIBRIUM);
@@ -88,7 +94,9 @@ pub fn run_example() -> Result<(), anyhow::Error> {
 
 fn err_fn(err: Error) {
     match err.kind() {
-        ErrorKind::DeviceChanged | ErrorKind::Xrun | ErrorKind::RealtimeDenied => eprintln!("{err}"),
+        ErrorKind::DeviceChanged | ErrorKind::Xrun | ErrorKind::RealtimeDenied => {
+            eprintln!("{err}")
+        }
         _ => eprintln!("Stream error: {err}"),
     }
 }

--- a/examples/ios-feedback/src/feedback.rs
+++ b/examples/ios-feedback/src/feedback.rs
@@ -94,9 +94,7 @@ pub fn run_example() -> Result<(), anyhow::Error> {
 
 fn err_fn(err: Error) {
     match err.kind() {
-        ErrorKind::DeviceChanged | ErrorKind::Xrun | ErrorKind::RealtimeDenied => {
-            eprintln!("{err}")
-        }
+        ErrorKind::DeviceChanged | ErrorKind::RealtimeDenied => eprintln!("{err}"),
         _ => eprintln!("Stream error: {err}"),
     }
 }

--- a/examples/record_wav.rs
+++ b/examples/record_wav.rs
@@ -121,7 +121,7 @@ fn main() -> Result<(), anyhow::Error> {
     let writer_2 = writer.clone();
 
     let err_fn = move |err: Error| match err.kind() {
-        ErrorKind::DeviceChanged | ErrorKind::Xrun | ErrorKind::RealtimeDenied => {
+        ErrorKind::DeviceChanged | ErrorKind::RealtimeDenied => {
             eprintln!("{err}")
         }
         _ => eprintln!("Stream error: {err}"),

--- a/examples/record_wav.rs
+++ b/examples/record_wav.rs
@@ -10,7 +10,8 @@ use std::{
 
 use clap::Parser;
 use cpal::{
-    Error, ErrorKind, FromSample, HostId, Sample, SampleFormat, SupportedStreamConfig,
+    CallbackInfo, Error, ErrorKind, FromSample, HostId, Sample, SampleFormat,
+    SupportedStreamConfig,
     traits::{DeviceTrait, HostTrait, StreamTrait},
 };
 
@@ -130,25 +131,37 @@ fn main() -> Result<(), anyhow::Error> {
     let stream = match config.sample_format() {
         SampleFormat::I8 => device.build_input_stream(
             config.into(),
-            move |data, _: &_| write_input_data::<i8, i8>(data, &writer_2),
+            move |data, info: &CallbackInfo| {
+                warn_on_xrun(info);
+                write_input_data::<i8, i8>(data, &writer_2)
+            },
             err_fn,
             None,
         )?,
         SampleFormat::I16 => device.build_input_stream(
             config.into(),
-            move |data, _: &_| write_input_data::<i16, i16>(data, &writer_2),
+            move |data, info: &CallbackInfo| {
+                warn_on_xrun(info);
+                write_input_data::<i16, i16>(data, &writer_2)
+            },
             err_fn,
             None,
         )?,
         SampleFormat::I32 => device.build_input_stream(
             config.into(),
-            move |data, _: &_| write_input_data::<i32, i32>(data, &writer_2),
+            move |data, info: &CallbackInfo| {
+                warn_on_xrun(info);
+                write_input_data::<i32, i32>(data, &writer_2)
+            },
             err_fn,
             None,
         )?,
         SampleFormat::F32 => device.build_input_stream(
             config.into(),
-            move |data, _: &_| write_input_data::<f32, f32>(data, &writer_2),
+            move |data, info: &CallbackInfo| {
+                warn_on_xrun(info);
+                write_input_data::<f32, f32>(data, &writer_2)
+            },
             err_fn,
             None,
         )?,
@@ -189,6 +202,12 @@ fn wav_spec_from_config(config: &SupportedStreamConfig) -> hound::WavSpec {
 }
 
 type WavWriterHandle = Arc<Mutex<Option<hound::WavWriter<BufWriter<File>>>>>;
+
+fn warn_on_xrun(info: &CallbackInfo) {
+    if info.xrun() {
+        eprintln!("input overrun: recording has a gap");
+    }
+}
 
 fn write_input_data<T, U>(input: &[T], writer: &WavWriterHandle)
 where

--- a/examples/synth_tones.rs
+++ b/examples/synth_tones.rs
@@ -7,7 +7,7 @@ extern crate clap;
 extern crate cpal;
 
 use cpal::{
-    Device, Error, ErrorKind, FromSample, Host, I24, OutputCallbackInfo, Sample, SampleFormat,
+    CallbackInfo, Device, Error, ErrorKind, FromSample, Host, I24, Sample, SampleFormat,
     SizedSample, Stream, StreamConfig, SupportedStreamConfig, U24,
     traits::{DeviceTrait, HostTrait, StreamTrait},
 };
@@ -151,7 +151,7 @@ where
 
     let stream = device.build_output_stream(
         config,
-        move |output: &mut [T], _: &OutputCallbackInfo| {
+        move |output: &mut [T], _: &CallbackInfo| {
             // for 0-1s play sine, 1-2s play square, 2-3s play saw, 3-4s play triangle_wave
             let time_since_start = std::time::Instant::now()
                 .duration_since(time_at_start)

--- a/examples/synth_tones.rs
+++ b/examples/synth_tones.rs
@@ -140,7 +140,7 @@ where
         frequency_hz: 440.0,
     };
     let err_fn = |err: Error| match err.kind() {
-        ErrorKind::DeviceChanged | ErrorKind::Xrun | ErrorKind::RealtimeDenied => {
+        ErrorKind::DeviceChanged | ErrorKind::RealtimeDenied => {
             eprintln!("{err}")
         }
         _ => eprintln!("Stream error: {err}"),

--- a/examples/wasm-beep/src/lib.rs
+++ b/examples/wasm-beep/src/lib.rs
@@ -77,7 +77,7 @@ where
     };
 
     let err_fn = |err: Error| match err.kind() {
-        ErrorKind::DeviceChanged | ErrorKind::Xrun | ErrorKind::RealtimeDenied => {
+        ErrorKind::DeviceChanged | ErrorKind::RealtimeDenied => {
             console::log_1(&format!("{err}").into())
         }
         _ => console::error_1(&format!("Stream error: {err}").into()),

--- a/src/duplex.rs
+++ b/src/duplex.rs
@@ -1,35 +1,31 @@
-use crate::{BufferSize, ChannelCount, InputStreamTimestamp, OutputStreamTimestamp, SampleRate};
+use crate::{BufferSize, CallbackInfo, ChannelCount, SampleRate};
 
 /// Information relevant to a single call to the user's duplex stream data callback.
 ///
-/// Combines the input and output timestamps for the callback. Because a duplex stream's input and
-/// output share a single clock, both timestamps are drawn from the same time source.
+/// Because a duplex stream's input and output share a single clock, `input.timestamp()` and
+/// `output.timestamp()` are drawn from the same time source. The two directions have independent
+/// buffers, so `input.xrun()` and `output.xrun()` can each report a glitch independently for the
+/// same invocation.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct DuplexCallbackInfo {
-    input_timestamp: InputStreamTimestamp,
-    output_timestamp: OutputStreamTimestamp,
+    input: CallbackInfo,
+    output: CallbackInfo,
 }
 
 impl DuplexCallbackInfo {
-    /// Construct a `DuplexCallbackInfo` from its input and output timestamps.
-    pub fn new(
-        input_timestamp: InputStreamTimestamp,
-        output_timestamp: OutputStreamTimestamp,
-    ) -> Self {
-        Self {
-            input_timestamp,
-            output_timestamp,
-        }
+    /// Construct a `DuplexCallbackInfo` from its input and output callback info.
+    pub fn new(input: CallbackInfo, output: CallbackInfo) -> Self {
+        Self { input, output }
     }
 
-    /// The timestamp for the captured input data passed to the callback.
-    pub fn input_timestamp(&self) -> InputStreamTimestamp {
-        self.input_timestamp
+    /// The timestamp and xrun status for the captured input data passed to the callback.
+    pub fn input(&self) -> CallbackInfo {
+        self.input
     }
 
-    /// The timestamp for the output data written by the callback.
-    pub fn output_timestamp(&self) -> OutputStreamTimestamp {
-        self.output_timestamp
+    /// The timestamp and xrun status for the output data written by the callback.
+    pub fn output(&self) -> CallbackInfo {
+        self.output
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -74,9 +74,6 @@ pub enum ErrorKind {
     /// not implemented by the backend.
     UnsupportedOperation,
 
-    /// A buffer underrun or overrun occurred, causing a potential audio glitch.
-    Xrun,
-
     /// The underlying platform audio API returned an error that CPAL cannot map to a more
     /// specific error kind.
     BackendError,
@@ -124,7 +121,6 @@ impl Display for ErrorKind {
                 "The requested stream configuration is not supported by the device.",
             ),
             Self::UnsupportedOperation => f.write_str("The requested operation is not supported."),
-            Self::Xrun => f.write_str("A buffer underrun or overrun occurred."),
             Self::BackendError => f.write_str(
                 "The audio backend returned an unclassified error.",
             ),

--- a/src/host/aaudio/mod.rs
+++ b/src/host/aaudio/mod.rs
@@ -14,11 +14,10 @@ use std::{
 };
 
 use crate::{
-    BufferSize, ChannelCount, Data, DeviceDescription, DeviceDescriptionBuilder, DeviceDirection,
-    DeviceId, DeviceType, Error, ErrorKind, FrameCount, InputCallbackInfo, InputStreamTimestamp,
-    InterfaceType, OutputCallbackInfo, OutputStreamTimestamp, ResultExt, SampleFormat, SampleRate,
-    StreamConfig, StreamInstant, SupportedBufferSize, SupportedStreamConfig,
-    SupportedStreamConfigRange,
+    BufferSize, CallbackInfo, ChannelCount, Data, DeviceDescription, DeviceDescriptionBuilder,
+    DeviceDirection, DeviceId, DeviceType, Error, ErrorKind, FrameCount, InterfaceType, ResultExt,
+    SampleFormat, SampleRate, StreamConfig, StreamInstant, StreamTimestamp, SupportedBufferSize,
+    SupportedStreamConfig, SupportedStreamConfigRange,
     host::{ErrorCallbackArc, emit_error},
     traits::{DeviceTrait, HostTrait, StreamTrait},
 };
@@ -308,7 +307,7 @@ fn build_input_stream<D, E>(
     sample_format: SampleFormat,
 ) -> Result<Stream, Error>
 where
-    D: FnMut(&Data, &InputCallbackInfo) + Send + 'static,
+    D: FnMut(&Data, &CallbackInfo) + Send + 'static,
     E: FnMut(Error) + Send + 'static,
 {
     let builder = configure_for_device(builder, device, config);
@@ -318,7 +317,6 @@ where
     let error_callback: ErrorCallbackArc = Arc::new(Mutex::new(error_callback));
     let error_callback_for_stream = error_callback.clone();
     let error_callback_for_data = error_callback.clone();
-    let error_callback_for_xrun = error_callback.clone();
     let last_xrun_count = Arc::new(AtomicI32::new(0));
 
     let draining = Arc::new(AtomicBool::new(false));
@@ -348,9 +346,7 @@ where
             }
 
             let xrun_count = stream.x_run_count();
-            if last_xrun_count.swap(xrun_count, Ordering::Relaxed) < xrun_count {
-                let _ = try_emit_error(&error_callback_for_xrun, ErrorKind::Xrun.into());
-            }
+            let xrun = last_xrun_count.swap(xrun_count, Ordering::Relaxed) < xrun_count;
 
             let Some(n_samples) = u64::try_from(num_frames)
                 .ok()
@@ -369,11 +365,12 @@ where
                 return ndk::audio::AudioCallbackResult::Stop;
             };
             if !draining_for_data.load(Ordering::Relaxed) {
-                let cb_info = InputCallbackInfo {
-                    timestamp: InputStreamTimestamp {
+                let cb_info = CallbackInfo {
+                    timestamp: StreamTimestamp {
                         callback: now_stream_instant(),
-                        capture: input_stream_instant(stream, sample_rate),
+                        device: input_stream_instant(stream, sample_rate),
                     },
+                    xrun,
                 };
                 (data_callback)(
                     &unsafe { Data::from_parts(data as *mut _, n_samples, sample_format) },
@@ -407,7 +404,7 @@ fn build_output_stream<D, E>(
     sample_format: SampleFormat,
 ) -> Result<Stream, Error>
 where
-    D: FnMut(&mut Data, &OutputCallbackInfo) + Send + 'static,
+    D: FnMut(&mut Data, &CallbackInfo) + Send + 'static,
     E: FnMut(Error) + Send + 'static,
 {
     let builder = configure_for_device(builder, device, config);
@@ -421,7 +418,6 @@ where
     let error_callback: ErrorCallbackArc = Arc::new(Mutex::new(error_callback));
     let error_callback_for_stream = error_callback.clone();
     let error_callback_for_data = error_callback.clone();
-    let error_callback_for_xrun = error_callback.clone();
     let last_xrun_count = Arc::new(AtomicI32::new(0));
 
     let draining = Arc::new(AtomicBool::new(false));
@@ -451,9 +447,7 @@ where
             }
 
             let xrun_count = stream.x_run_count();
-            if last_xrun_count.swap(xrun_count, Ordering::Relaxed) < xrun_count {
-                let _ = try_emit_error(&error_callback_for_xrun, ErrorKind::Xrun.into());
-            }
+            let xrun = last_xrun_count.swap(xrun_count, Ordering::Relaxed) < xrun_count;
 
             let Some(n_samples) = u64::try_from(num_frames)
                 .ok()
@@ -480,11 +474,12 @@ where
             }
 
             if !draining_for_data.load(Ordering::Relaxed) {
-                let cb_info = OutputCallbackInfo {
-                    timestamp: OutputStreamTimestamp {
+                let cb_info = CallbackInfo {
+                    timestamp: StreamTimestamp {
                         callback: now_stream_instant(),
-                        playback: output_stream_instant(stream, sample_rate),
+                        device: output_stream_instant(stream, sample_rate),
                     },
+                    xrun,
                 };
                 (data_callback)(
                     &mut unsafe { Data::from_parts(data as *mut _, n_samples, sample_format) },
@@ -673,7 +668,7 @@ impl DeviceTrait for Device {
         _timeout: Option<Duration>,
     ) -> Result<Self::Stream, Error>
     where
-        D: FnMut(&Data, &InputCallbackInfo) + Send + 'static,
+        D: FnMut(&Data, &CallbackInfo) + Send + 'static,
         E: FnMut(Error) + Send + 'static,
     {
         crate::validate_stream_config(&config)?;
@@ -720,7 +715,7 @@ impl DeviceTrait for Device {
         _timeout: Option<Duration>,
     ) -> Result<Self::Stream, Error>
     where
-        D: FnMut(&mut Data, &OutputCallbackInfo) + Send + 'static,
+        D: FnMut(&mut Data, &CallbackInfo) + Send + 'static,
         E: FnMut(Error) + Send + 'static,
     {
         crate::validate_stream_config(&config)?;

--- a/src/host/alsa/mod.rs
+++ b/src/host/alsa/mod.rs
@@ -22,10 +22,9 @@ use std::{
 use self::alsa::poll::Descriptors;
 pub use self::enumerate::Devices;
 use crate::{
-    BufferSize, COMMON_SAMPLE_RATES, ChannelCount, Data, DeviceDescription,
+    BufferSize, COMMON_SAMPLE_RATES, CallbackInfo, ChannelCount, Data, DeviceDescription,
     DeviceDescriptionBuilder, DeviceDirection, DeviceId, Error, ErrorKind, FrameCount,
-    InputCallbackInfo, InputStreamTimestamp, OutputCallbackInfo, OutputStreamTimestamp,
-    SampleFormat, SampleRate, StreamConfig, StreamInstant, SupportedBufferSize,
+    SampleFormat, SampleRate, StreamConfig, StreamInstant, StreamTimestamp, SupportedBufferSize,
     SupportedStreamConfig, SupportedStreamConfigRange,
     host::{
         Notify,
@@ -266,7 +265,7 @@ impl DeviceTrait for Device {
         timeout: Option<Duration>,
     ) -> Result<Self::Stream, Error>
     where
-        D: FnMut(&Data, &InputCallbackInfo) + Send + 'static,
+        D: FnMut(&Data, &CallbackInfo) + Send + 'static,
         E: FnMut(Error) + Send + 'static,
     {
         // Keep `capture` monotonic: avail_delay() varies between cycles, and a capture overrun
@@ -292,7 +291,7 @@ impl DeviceTrait for Device {
         timeout: Option<Duration>,
     ) -> Result<Self::Stream, Error>
     where
-        D: FnMut(&mut Data, &OutputCallbackInfo) + Send + 'static,
+        D: FnMut(&mut Data, &CallbackInfo) + Send + 'static,
         E: FnMut(Error) + Send + 'static,
     {
         // Keep `playback` monotonic: avail_delay() varies between cycles, and a playback
@@ -976,7 +975,7 @@ impl StreamWorkerContext {
 fn input_stream_worker(
     rx: Arc<TriggerReceiver>,
     stream: &StreamInner,
-    data_callback: &mut (dyn FnMut(&Data, &InputCallbackInfo) + Send + 'static),
+    data_callback: &mut (dyn FnMut(&Data, &CallbackInfo) + Send + 'static),
     error_callback: &mut (dyn FnMut(Error) + Send + 'static),
     timeout: Option<Duration>,
 ) {
@@ -1037,7 +1036,7 @@ fn input_stream_worker(
 fn output_stream_worker(
     rx: Arc<TriggerReceiver>,
     stream: &StreamInner,
-    data_callback: &mut (dyn FnMut(&mut Data, &OutputCallbackInfo) + Send + 'static),
+    data_callback: &mut (dyn FnMut(&mut Data, &CallbackInfo) + Send + 'static),
     error_callback: &mut (dyn FnMut(Error) + Send + 'static),
     timeout: Option<Duration>,
 ) {
@@ -1240,7 +1239,7 @@ fn process_input(
     buffer: &mut [u8],
     status: alsa::pcm::Status,
     delay_frames: usize,
-    data_callback: &mut (dyn FnMut(&Data, &InputCallbackInfo) + Send + 'static),
+    data_callback: &mut (dyn FnMut(&Data, &CallbackInfo) + Send + 'static),
 ) -> Result<(), Error> {
     let mut frames_read = 0;
     while frames_read < stream.period_size {
@@ -1277,11 +1276,17 @@ fn process_input(
         let capture = callback_instant
             .checked_sub(delay_duration)
             .unwrap_or(StreamInstant::ZERO);
-        let timestamp = InputStreamTimestamp {
+        let timestamp = StreamTimestamp {
             callback: callback_instant,
-            capture,
+            device: capture,
         };
-        data_callback(&data, &InputCallbackInfo { timestamp });
+        data_callback(
+            &data,
+            &CallbackInfo {
+                timestamp,
+                xrun: false,
+            },
+        );
     }
 
     Ok(())
@@ -1293,7 +1298,7 @@ fn process_output(
     buffer: &mut [u8],
     status: alsa::pcm::Status,
     delay_frames: usize,
-    data_callback: &mut (dyn FnMut(&mut Data, &OutputCallbackInfo) + Send + 'static),
+    data_callback: &mut (dyn FnMut(&mut Data, &CallbackInfo) + Send + 'static),
 ) -> Result<(), Error> {
     // Pre-fill buffer with equilibrium; user callback overwrites what it wants.
     stream.equilibrium.fill(buffer);
@@ -1305,11 +1310,17 @@ fn process_output(
         let callback_instant = stream.callback_instant(&status);
         let delay_duration = frames_to_duration(delay_frames as FrameCount, stream.sample_rate);
         let playback = callback_instant + delay_duration;
-        let timestamp = OutputStreamTimestamp {
+        let timestamp = StreamTimestamp {
             callback: callback_instant,
-            playback,
+            device: playback,
         };
-        data_callback(&mut data, &OutputCallbackInfo { timestamp });
+        data_callback(
+            &mut data,
+            &CallbackInfo {
+                timestamp,
+                xrun: false,
+            },
+        );
     }
 
     let mut frames_written = 0;
@@ -1383,7 +1394,7 @@ impl Stream {
         timeout: Option<Duration>,
     ) -> Stream
     where
-        D: FnMut(&Data, &InputCallbackInfo) + Send + 'static,
+        D: FnMut(&Data, &CallbackInfo) + Send + 'static,
         E: FnMut(Error) + Send + 'static,
     {
         let (tx, rx) = trigger();
@@ -1426,7 +1437,7 @@ impl Stream {
         timeout: Option<Duration>,
     ) -> Stream
     where
-        D: FnMut(&mut Data, &OutputCallbackInfo) + Send + 'static,
+        D: FnMut(&mut Data, &CallbackInfo) + Send + 'static,
         E: FnMut(Error) + Send + 'static,
     {
         let (tx, rx) = trigger();

--- a/src/host/alsa/mod.rs
+++ b/src/host/alsa/mod.rs
@@ -449,6 +449,7 @@ impl Device {
             timestamp_mode,
             creation_ts,
             creation_instant: std::time::Instant::now(),
+            pending_xrun: AtomicBool::new(false),
             _context: self._context.clone(),
         };
 
@@ -767,6 +768,9 @@ struct StreamInner {
     // mode and last-resort fallback if the status query in now() fails.
     creation_instant: std::time::Instant,
 
+    // Xrun pending delivery to the data callback.
+    pending_xrun: AtomicBool,
+
     // Keep ALSA context alive to prevent premature ALSA config cleanup.
     _context: Arc<AlsaContext>,
 }
@@ -1000,6 +1004,7 @@ fn input_stream_worker(
         }
         let result = match poll_for_period(&rx, stream, &mut ctxt) {
             Ok(Poll::Pending) => continue,
+            Ok(Poll::Recover) => recover_input(stream),
             Ok(Poll::Ready {
                 status,
                 delay_frames,
@@ -1014,14 +1019,6 @@ fn input_stream_worker(
         };
         if let Err(err) = result {
             match err.kind() {
-                ErrorKind::Xrun => {
-                    error_callback(err);
-                    if let Err(err) = stream.handle.prepare() {
-                        error_callback(err.into());
-                    } else if let Err(err) = stream.handle.start() {
-                        error_callback(err.into());
-                    }
-                }
                 ErrorKind::DeviceNotAvailable => {
                     error_callback(err);
                     stream.signal_worker_exit();
@@ -1062,6 +1059,7 @@ fn output_stream_worker(
         }
         let result = match poll_for_period(&rx, stream, &mut ctxt) {
             Ok(Poll::Pending) => continue,
+            Ok(Poll::Recover) => recover_output(stream),
             Ok(Poll::Ready {
                 status,
                 delay_frames,
@@ -1076,15 +1074,6 @@ fn output_stream_worker(
         };
         if let Err(err) = result {
             match err.kind() {
-                ErrorKind::Xrun => {
-                    error_callback(err);
-                    if let Err(err) = stream.handle.prepare() {
-                        error_callback(err.into());
-                    }
-                    // No need to call start() for output streams after prepare();
-                    // ALSA automatically restarts them when the buffer is refilled
-                    // and the stream is triggered again.
-                }
                 ErrorKind::DeviceNotAvailable => {
                     error_callback(err);
                     stream.signal_worker_exit();
@@ -1097,13 +1086,14 @@ fn output_stream_worker(
 }
 
 /// Attempt hardware resume from a suspend event (`ESTRPIPE`).
-fn try_resume(handle: &alsa::PCM) -> Result<Poll, Error> {
+fn try_resume(stream: &StreamInner) -> Result<Poll, Error> {
+    let handle = &stream.handle;
+
     let hw_params = handle.hw_params_current()?;
     if !hw_params.can_resume() {
-        return Err(Error::with_message(
-            ErrorKind::Xrun, // treat as xrun so the worker calls prepare()
-            "Device does not support suspend/resume",
-        ));
+        // Hardware doesn't support suspend/resume: fall back to full recovery.
+        stream.pending_xrun.store(true, Ordering::Relaxed);
+        return Ok(Poll::Recover);
     }
 
     match handle.resume() {
@@ -1126,8 +1116,11 @@ fn try_resume(handle: &alsa::PCM) -> Result<Poll, Error> {
         }
         // device is still resuming; poll again until it is ready.
         Err(e) if e.errno() == libc::EAGAIN => Ok(Poll::Pending),
-        // hardware does not support soft resume; treat as xrun so the worker calls prepare()
-        Err(e) if e.errno() == libc::ENOSYS => Err(ErrorKind::Xrun.into()),
+        // hardware does not support soft resume: fall back to full recovery.
+        Err(e) if e.errno() == libc::ENOSYS => {
+            stream.pending_xrun.store(true, Ordering::Relaxed);
+            Ok(Poll::Recover)
+        }
         Err(e) => Err(e.into()),
     }
 }
@@ -1138,6 +1131,8 @@ enum Poll {
         status: alsa::pcm::Status,
         delay_frames: usize,
     },
+    // An xrun was detected; the worker should call prepare() (+ start() for input) and loop.
+    Recover,
 }
 
 // This block is shared between both input and output stream worker functions.
@@ -1166,10 +1161,11 @@ fn poll_for_period(
             }
             // Xrun with POLLERR missed: recover the same way the POLLERR path does.
             alsa::pcm::State::XRun => {
-                return Err(ErrorKind::Xrun.into());
+                stream.pending_xrun.store(true, Ordering::Relaxed);
+                return Ok(Poll::Recover);
             }
             // Suspend with POLLHUP/POLLERR missed: attempt hardware resume.
-            alsa::pcm::State::Suspended => return try_resume(&stream.handle),
+            alsa::pcm::State::Suspended => return try_resume(stream),
             // No events and no error state: spurious wakeup, poll again.
             _ => {}
         }
@@ -1199,9 +1195,12 @@ fn poll_for_period(
     // POLLIN/POLLOUT: data is ready, fall through to process it.
     let (avail_frames, delay_frames) = match stream.handle.avail_delay() {
         // Xrun: recover via prepare() (+ start() for capture, handled by the worker).
-        Err(err) if err.errno() == libc::EPIPE => return Err(ErrorKind::Xrun.into()),
+        Err(err) if err.errno() == libc::EPIPE => {
+            stream.pending_xrun.store(true, Ordering::Relaxed);
+            return Ok(Poll::Recover);
+        }
         // Suspend: try hardware resume first; fall back to prepare() if unsupported.
-        Err(err) if err.errno() == libc::ESTRPIPE => return try_resume(&stream.handle),
+        Err(err) if err.errno() == libc::ESTRPIPE => return try_resume(stream),
         res => res,
     }?;
     // ALSA can have spurious wakeups where poll returns but avail < avail_min.
@@ -1233,6 +1232,14 @@ fn poll_for_period(
     })
 }
 
+// Full input underrun recovery: mark the xrun, then prepare + start the stream.
+fn recover_input(stream: &StreamInner) -> Result<(), Error> {
+    stream.pending_xrun.store(true, Ordering::Relaxed);
+    stream.handle.prepare()?;
+    stream.handle.start()?;
+    Ok(())
+}
+
 // Read input data from ALSA and deliver it to the user.
 fn process_input(
     stream: &StreamInner,
@@ -1251,19 +1258,18 @@ fn process_input(
             Ok(n) => frames_read += n,
             // EAGAIN = no frames available: skip this cycle if no progress was made,
             // otherwise treat as an underrun (partial period cannot be delivered safely).
-            Err(err) if err.errno() == libc::EAGAIN => {
-                if frames_read == 0 {
-                    return Ok(());
-                } else {
-                    return Err(ErrorKind::Xrun.into());
-                }
+            Err(err) if err.errno() == libc::EAGAIN && frames_read == 0 => return Ok(()),
+            // EAGAIN with partial progress, or EPIPE: full underrun recovery required.
+            Err(err) if err.errno() == libc::EAGAIN || err.errno() == libc::EPIPE => {
+                return recover_input(stream);
             }
-            // EPIPE = xrun: full underrun recovery (prepare + start) required.
-            Err(err) if err.errno() == libc::EPIPE => return Err(ErrorKind::Xrun.into()),
             // ESTRPIPE = hardware suspend: try soft resume first, falling back to underrun
             // recovery if the hardware doesn't support it.
             Err(err) if err.errno() == libc::ESTRPIPE => {
-                return try_resume(&stream.handle).map(|_| ());
+                return match try_resume(stream)? {
+                    Poll::Recover => recover_input(stream),
+                    _ => Ok(()),
+                };
             }
             Err(err) => return Err(err.into()),
         }
@@ -1280,19 +1286,23 @@ fn process_input(
             callback: callback_instant,
             device: capture,
         };
-        data_callback(
-            &data,
-            &CallbackInfo {
-                timestamp,
-                xrun: false,
-            },
-        );
+        let xrun = stream.pending_xrun.swap(false, Ordering::Relaxed);
+        data_callback(&data, &CallbackInfo { timestamp, xrun });
     }
 
     Ok(())
 }
 
 // Request data from the user's function and write it via ALSA.
+// Full output underrun recovery: mark the xrun, then prepare the stream. No need to call
+// start(): ALSA automatically restarts output streams once the buffer is refilled and
+// triggered again.
+fn recover_output(stream: &StreamInner) -> Result<(), Error> {
+    stream.pending_xrun.store(true, Ordering::Relaxed);
+    stream.handle.prepare()?;
+    Ok(())
+}
+
 fn process_output(
     stream: &StreamInner,
     buffer: &mut [u8],
@@ -1314,13 +1324,8 @@ fn process_output(
             callback: callback_instant,
             device: playback,
         };
-        data_callback(
-            &mut data,
-            &CallbackInfo {
-                timestamp,
-                xrun: false,
-            },
-        );
+        let xrun = stream.pending_xrun.swap(false, Ordering::Relaxed);
+        data_callback(&mut data, &CallbackInfo { timestamp, xrun });
     }
 
     let mut frames_written = 0;
@@ -1334,19 +1339,18 @@ fn process_output(
             // EAGAIN = device cannot currently accept more frames: skip this cycle if no
             // progress was made, otherwise treat as an underrun (partial period cannot be
             // completed safely).
-            Err(err) if err.errno() == libc::EAGAIN => {
-                if frames_written == 0 {
-                    return Ok(());
-                } else {
-                    return Err(ErrorKind::Xrun.into());
-                }
+            Err(err) if err.errno() == libc::EAGAIN && frames_written == 0 => return Ok(()),
+            // EAGAIN with partial progress, or EPIPE: full underrun recovery required.
+            Err(err) if err.errno() == libc::EAGAIN || err.errno() == libc::EPIPE => {
+                return recover_output(stream);
             }
-            // EPIPE = xrun: full underrun recovery (prepare) required.
-            Err(err) if err.errno() == libc::EPIPE => return Err(ErrorKind::Xrun.into()),
             // ESTRPIPE = hardware suspend: try soft resume first, falling back to underrun
             // recovery if the hardware doesn't support it.
             Err(err) if err.errno() == libc::ESTRPIPE => {
-                return try_resume(&stream.handle).map(|_| ());
+                return match try_resume(stream)? {
+                    Poll::Recover => recover_output(stream),
+                    _ => Ok(()),
+                };
             }
             Err(err) => return Err(err.into()),
         }
@@ -1940,7 +1944,6 @@ impl From<alsa::Error> for Error {
             libc::EBUSY | libc::EAGAIN => ErrorKind::DeviceBusy.into(),
             libc::EINVAL => ErrorKind::UnsupportedConfig.into(),
             libc::ENOSYS => ErrorKind::UnsupportedOperation.into(),
-            libc::EPIPE => ErrorKind::Xrun.into(),
             _ => Error::with_message(ErrorKind::BackendError, err.to_string()),
         }
     }

--- a/src/host/asio/mod.rs
+++ b/src/host/asio/mod.rs
@@ -15,8 +15,8 @@ pub use self::{
     stream::Stream,
 };
 use crate::{
-    Data, DeviceDescription, DeviceId, Error, FrameCount, InputCallbackInfo, OutputCallbackInfo,
-    SampleFormat, StreamConfig, StreamInstant, SupportedStreamConfig,
+    CallbackInfo, Data, DeviceDescription, DeviceId, Error, FrameCount, SampleFormat, StreamConfig,
+    StreamInstant, SupportedStreamConfig,
     host::com,
     traits::{DeviceTrait, HostTrait, StreamTrait},
 };
@@ -109,7 +109,7 @@ impl DeviceTrait for Device {
         timeout: Option<Duration>,
     ) -> Result<Self::Stream, Error>
     where
-        D: FnMut(&Data, &InputCallbackInfo) + Send + 'static,
+        D: FnMut(&Data, &CallbackInfo) + Send + 'static,
         E: FnMut(Error) + Send + 'static,
     {
         Device::build_input_stream_raw(
@@ -131,7 +131,7 @@ impl DeviceTrait for Device {
         timeout: Option<Duration>,
     ) -> Result<Self::Stream, Error>
     where
-        D: FnMut(&mut Data, &OutputCallbackInfo) + Send + 'static,
+        D: FnMut(&mut Data, &CallbackInfo) + Send + 'static,
         E: FnMut(Error) + Send + 'static,
     {
         Device::build_output_stream_raw(

--- a/src/host/asio/stream.rs
+++ b/src/host/asio/stream.rs
@@ -13,9 +13,8 @@ use std::{
 use self::num_traits::{FromPrimitive, PrimInt};
 use super::Device;
 use crate::{
-    BufferSize, Data, Error, ErrorKind, FrameCount, I24, InputCallbackInfo, InputStreamTimestamp,
-    OutputCallbackInfo, OutputStreamTimestamp, SampleFormat, SampleRate, StreamConfig,
-    StreamInstant,
+    BufferSize, CallbackInfo, Data, Error, ErrorKind, FrameCount, I24, SampleFormat, SampleRate,
+    StreamConfig, StreamInstant, StreamTimestamp,
     host::{
         com,
         error_emit::{emit_error, try_emit_error},
@@ -127,7 +126,7 @@ impl Device {
         _timeout: Option<Duration>,
     ) -> Result<Stream, Error>
     where
-        D: FnMut(&Data, &InputCallbackInfo) + Send + 'static,
+        D: FnMut(&Data, &CallbackInfo) + Send + 'static,
         E: FnMut(Error) + Send + 'static,
     {
         crate::validate_stream_config(&config)?;
@@ -263,7 +262,7 @@ impl Device {
                 callback_instant: StreamInstant,
             ) where
                 A: Copy,
-                D: FnMut(&Data, &InputCallbackInfo) + Send + 'static,
+                D: FnMut(&Data, &CallbackInfo) + Send + 'static,
                 F: Fn(A) -> A,
             {
                 // 1. Write the ASIO channels to the CPAL buffer.
@@ -466,7 +465,7 @@ impl Device {
         _timeout: Option<Duration>,
     ) -> Result<Stream, Error>
     where
-        D: FnMut(&mut Data, &OutputCallbackInfo) + Send + 'static,
+        D: FnMut(&mut Data, &CallbackInfo) + Send + 'static,
         E: FnMut(Error) + Send + 'static,
     {
         crate::validate_stream_config(&config)?;
@@ -615,7 +614,7 @@ impl Device {
                 callback_instant: StreamInstant,
             ) where
                 A: Copy,
-                D: FnMut(&mut Data, &OutputCallbackInfo) + Send + 'static,
+                D: FnMut(&mut Data, &CallbackInfo) + Send + 'static,
                 F: Fn(A, A) -> A,
             {
                 let interleaved: &mut [A] = unsafe { cast_slice_mut(interleaved) };
@@ -1289,7 +1288,7 @@ unsafe fn process_output_callback_i24<D>(
     hardware_latency_frames: usize,
     callback_instant: StreamInstant,
 ) where
-    D: FnMut(&mut Data, &OutputCallbackInfo) + Send + 'static,
+    D: FnMut(&mut Data, &CallbackInfo) + Send + 'static,
 {
     let format = SampleFormat::I24;
     let interleaved: &mut [I24] = unsafe { cast_slice_mut(interleaved) };
@@ -1365,7 +1364,7 @@ unsafe fn process_input_callback_i24<D>(
     hardware_latency_frames: usize,
     callback_instant: StreamInstant,
 ) where
-    D: FnMut(&Data, &InputCallbackInfo) + Send + 'static,
+    D: FnMut(&Data, &CallbackInfo) + Send + 'static,
 {
     let format = SampleFormat::I24;
 
@@ -1421,7 +1420,7 @@ unsafe fn apply_output_callback_to_data<A, D>(
     hardware_latency_frames: usize,
 ) where
     A: Copy,
-    D: FnMut(&mut Data, &OutputCallbackInfo) + Send + 'static,
+    D: FnMut(&mut Data, &CallbackInfo) + Send + 'static,
 {
     let mut data = unsafe {
         Data::from_parts(
@@ -1432,11 +1431,14 @@ unsafe fn apply_output_callback_to_data<A, D>(
     };
     let delay = frames_to_duration(hardware_latency_frames as FrameCount, sample_rate);
     let playback = callback_instant + delay;
-    let timestamp = OutputStreamTimestamp {
+    let timestamp = StreamTimestamp {
         callback: callback_instant,
-        playback,
+        device: playback,
     };
-    let info = OutputCallbackInfo { timestamp };
+    let info = CallbackInfo {
+        timestamp,
+        xrun: false,
+    };
     data_callback(&mut data, &info);
 }
 
@@ -1451,7 +1453,7 @@ unsafe fn apply_input_callback_to_data<A, D>(
     hardware_latency_frames: usize,
 ) where
     A: Copy,
-    D: FnMut(&Data, &InputCallbackInfo) + Send + 'static,
+    D: FnMut(&Data, &CallbackInfo) + Send + 'static,
 {
     let data = unsafe {
         Data::from_parts(
@@ -1464,10 +1466,13 @@ unsafe fn apply_input_callback_to_data<A, D>(
     let capture = callback_instant
         .checked_sub(delay)
         .unwrap_or(StreamInstant::ZERO);
-    let timestamp = InputStreamTimestamp {
+    let timestamp = StreamTimestamp {
         callback: callback_instant,
-        capture,
+        device: capture,
     };
-    let info = InputCallbackInfo { timestamp };
+    let info = CallbackInfo {
+        timestamp,
+        xrun: false,
+    };
     data_callback(&data, &info);
 }

--- a/src/host/asio/stream.rs
+++ b/src/host/asio/stream.rs
@@ -4,7 +4,7 @@ extern crate num_traits;
 use std::{
     sync::{
         Arc, Mutex,
-        atomic::{AtomicU8, AtomicU32, AtomicU64, Ordering},
+        atomic::{AtomicBool, AtomicU8, AtomicU32, AtomicU64, Ordering},
         mpsc,
     },
     time::Duration,
@@ -15,11 +15,7 @@ use super::Device;
 use crate::{
     BufferSize, CallbackInfo, Data, Error, ErrorKind, FrameCount, I24, SampleFormat, SampleRate,
     StreamConfig, StreamInstant, StreamTimestamp,
-    host::{
-        com,
-        error_emit::{emit_error, try_emit_error},
-        frames_to_duration,
-    },
+    host::{com, error_emit::emit_error, frames_to_duration},
 };
 
 /// Shared state for extending the 32-bit `timeGetTime()` millisecond counter into a
@@ -76,7 +72,7 @@ impl StreamState {
 }
 
 pub struct Stream {
-    state: Arc<AtomicU8>,
+    playback_state: Arc<AtomicU8>,
     driver: Arc<sys::Driver>,
     asio_streams: Arc<Mutex<sys::AsioStreams>>,
     callback_id: sys::BufferCallbackId,
@@ -94,12 +90,12 @@ impl Stream {
     }
 
     pub fn start(&self) -> Result<(), Error> {
-        StreamState::Playing.store(&self.state, Ordering::Relaxed);
+        StreamState::Playing.store(&self.playback_state, Ordering::Relaxed);
         Ok(())
     }
 
     pub fn pause(&self) -> Result<(), Error> {
-        StreamState::Paused.store(&self.state, Ordering::Relaxed);
+        StreamState::Paused.store(&self.playback_state, Ordering::Relaxed);
         Ok(())
     }
 
@@ -184,14 +180,16 @@ impl Device {
                 .unwrap_or(0),
         ));
 
-        let state = Arc::new(AtomicU8::new(StreamState::Starting as u8));
+        let playback_state = Arc::new(AtomicU8::new(StreamState::Starting as u8));
+        let pending_xrun = Arc::new(AtomicBool::new(false));
         let driver_event_callback_id = self
             .add_event_callback(
                 &driver,
                 error_callback,
                 Arc::clone(&hardware_input_latency),
                 true,
-                Arc::clone(&state),
+                Arc::clone(&playback_state),
+                Arc::clone(&pending_xrun),
             )
             .inspect_err(|_| {
                 // Roll back the input stream stored by get_or_create_input_stream.
@@ -200,7 +198,8 @@ impl Device {
                 }
             })?;
 
-        let state_cb = Arc::clone(&state);
+        let playback_state_cb = Arc::clone(&playback_state);
+        let pending_xrun_cb = Arc::clone(&pending_xrun);
         let asio_streams = self.asio_streams.clone();
         let mut current_buffer_size = buffer_size as i32;
         let mut last_buffer_index: i32 = -1;
@@ -212,7 +211,7 @@ impl Device {
         // This is most performance critical part of the ASIO bindings.
         let callback_id = driver.add_callback(move |callback_info| unsafe {
             // If not playing, return early.
-            if StreamState::load(&state_cb, Ordering::Relaxed) != StreamState::Playing {
+            if StreamState::load(&playback_state_cb, Ordering::Relaxed) != StreamState::Playing {
                 return;
             }
 
@@ -246,6 +245,7 @@ impl Device {
             let hardware_input_latency = hardware_input_latency.load(Ordering::Relaxed) as usize;
 
             let callback_instant = time_base_cb.to_stream_instant(callback_info.system_time);
+            let xrun = pending_xrun_cb.swap(false, Ordering::Relaxed);
 
             /// 1. Write from the ASIO buffer to the interleaved CPAL buffer.
             /// 2. Deliver the CPAL buffer to the user callback.
@@ -260,6 +260,7 @@ impl Device {
                 from_endianness: F,
                 hardware_latency_frames: usize,
                 callback_instant: StreamInstant,
+                xrun: bool,
             ) where
                 A: Copy,
                 D: FnMut(&Data, &CallbackInfo) + Send + 'static,
@@ -287,6 +288,7 @@ impl Device {
                         sample_rate,
                         format,
                         hardware_latency_frames,
+                        xrun,
                     );
                 }
             }
@@ -303,6 +305,7 @@ impl Device {
                         from_le,
                         hardware_input_latency,
                         callback_instant,
+                        xrun,
                     );
                 }
                 (&sys::AsioSampleType::ASIOSTInt16MSB, SampleFormat::I16) => {
@@ -316,6 +319,7 @@ impl Device {
                         from_be,
                         hardware_input_latency,
                         callback_instant,
+                        xrun,
                     );
                 }
 
@@ -330,6 +334,7 @@ impl Device {
                         from_le,
                         hardware_input_latency,
                         callback_instant,
+                        xrun,
                     );
                 }
                 (&sys::AsioSampleType::ASIOSTFloat32MSB, SampleFormat::F32) => {
@@ -343,6 +348,7 @@ impl Device {
                         from_be,
                         hardware_input_latency,
                         callback_instant,
+                        xrun,
                     );
                 }
 
@@ -357,6 +363,7 @@ impl Device {
                         from_le,
                         hardware_input_latency,
                         callback_instant,
+                        xrun,
                     );
                 }
                 (&sys::AsioSampleType::ASIOSTInt32MSB, SampleFormat::I32) => {
@@ -370,6 +377,7 @@ impl Device {
                         from_be,
                         hardware_input_latency,
                         callback_instant,
+                        xrun,
                     );
                 }
 
@@ -384,6 +392,7 @@ impl Device {
                         from_le,
                         hardware_input_latency,
                         callback_instant,
+                        xrun,
                     );
                 }
                 (&sys::AsioSampleType::ASIOSTFloat64MSB, SampleFormat::F64) => {
@@ -397,6 +406,7 @@ impl Device {
                         from_be,
                         hardware_input_latency,
                         callback_instant,
+                        xrun,
                     );
                 }
 
@@ -410,6 +420,7 @@ impl Device {
                         true,
                         hardware_input_latency,
                         callback_instant,
+                        xrun,
                     );
                 }
                 (&sys::AsioSampleType::ASIOSTInt24MSB, SampleFormat::I24) => {
@@ -422,6 +433,7 @@ impl Device {
                         false,
                         hardware_input_latency,
                         callback_instant,
+                        xrun,
                     );
                 }
 
@@ -445,9 +457,9 @@ impl Device {
             return Err(build_stream_err(e));
         }
 
-        StreamState::Paused.store(&state, Ordering::Relaxed);
+        StreamState::Paused.store(&playback_state, Ordering::Relaxed);
         Ok(Stream {
-            state,
+            playback_state,
             driver,
             asio_streams,
             callback_id,
@@ -524,14 +536,16 @@ impl Device {
                 .unwrap_or(0),
         ));
 
-        let state = Arc::new(AtomicU8::new(StreamState::Starting as u8));
+        let playback_state = Arc::new(AtomicU8::new(StreamState::Starting as u8));
+        let pending_xrun = Arc::new(AtomicBool::new(false));
         let driver_event_callback_id = self
             .add_event_callback(
                 &driver,
                 error_callback,
                 Arc::clone(&hardware_output_latency),
                 false,
-                Arc::clone(&state),
+                Arc::clone(&playback_state),
+                Arc::clone(&pending_xrun),
             )
             .inspect_err(|_| {
                 // Roll back the output stream stored by get_or_create_output_stream.
@@ -540,7 +554,8 @@ impl Device {
                 }
             })?;
 
-        let state_cb = Arc::clone(&state);
+        let playback_state_cb = Arc::clone(&playback_state);
+        let pending_xrun_cb = Arc::clone(&pending_xrun);
         let asio_streams = self.asio_streams.clone();
         let mut current_buffer_size = buffer_size as i32;
         let mut last_buffer_index: i32 = -1;
@@ -550,7 +565,7 @@ impl Device {
 
         let callback_id = driver.add_callback(move |callback_info| unsafe {
             // If not playing, return early.
-            if StreamState::load(&state_cb, Ordering::Relaxed) != StreamState::Playing {
+            if StreamState::load(&playback_state_cb, Ordering::Relaxed) != StreamState::Playing {
                 return;
             }
 
@@ -584,6 +599,7 @@ impl Device {
             let hardware_output_latency = hardware_output_latency.load(Ordering::Relaxed) as usize;
 
             let callback_instant = time_base_cb.to_stream_instant(callback_info.system_time);
+            let xrun = pending_xrun_cb.swap(false, Ordering::Relaxed);
 
             // Silence the ASIO buffer that is about to be used.
             //
@@ -612,6 +628,7 @@ impl Device {
                 mix_samples: F,
                 hardware_latency_frames: usize,
                 callback_instant: StreamInstant,
+                xrun: bool,
             ) where
                 A: Copy,
                 D: FnMut(&mut Data, &CallbackInfo) + Send + 'static,
@@ -626,6 +643,7 @@ impl Device {
                         sample_rate,
                         format,
                         hardware_latency_frames,
+                        xrun,
                     );
                 }
                 let n_channels = interleaved.len() / asio_stream.buffer_size as usize;
@@ -661,6 +679,7 @@ impl Device {
                         },
                         hardware_output_latency,
                         callback_instant,
+                        xrun,
                     );
                 }
                 (SampleFormat::I16, &sys::AsioSampleType::ASIOSTInt16MSB) => {
@@ -677,6 +696,7 @@ impl Device {
                         },
                         hardware_output_latency,
                         callback_instant,
+                        xrun,
                     );
                 }
                 (SampleFormat::F32, &sys::AsioSampleType::ASIOSTFloat32LSB) => {
@@ -695,6 +715,7 @@ impl Device {
                         },
                         hardware_output_latency,
                         callback_instant,
+                        xrun,
                     );
                 }
 
@@ -714,6 +735,7 @@ impl Device {
                         },
                         hardware_output_latency,
                         callback_instant,
+                        xrun,
                     );
                 }
 
@@ -731,6 +753,7 @@ impl Device {
                         },
                         hardware_output_latency,
                         callback_instant,
+                        xrun,
                     );
                 }
                 (SampleFormat::I32, &sys::AsioSampleType::ASIOSTInt32MSB) => {
@@ -747,6 +770,7 @@ impl Device {
                         },
                         hardware_output_latency,
                         callback_instant,
+                        xrun,
                     );
                 }
 
@@ -766,6 +790,7 @@ impl Device {
                         },
                         hardware_output_latency,
                         callback_instant,
+                        xrun,
                     );
                 }
 
@@ -785,6 +810,7 @@ impl Device {
                         },
                         hardware_output_latency,
                         callback_instant,
+                        xrun,
                     );
                 }
 
@@ -799,6 +825,7 @@ impl Device {
                         config.sample_rate,
                         hardware_output_latency,
                         callback_instant,
+                        xrun,
                     );
                 }
 
@@ -813,6 +840,7 @@ impl Device {
                         config.sample_rate,
                         hardware_output_latency,
                         callback_instant,
+                        xrun,
                     );
                 }
 
@@ -835,9 +863,9 @@ impl Device {
             return Err(build_stream_err(e));
         }
 
-        StreamState::Paused.store(&state, Ordering::Relaxed);
+        StreamState::Paused.store(&playback_state, Ordering::Relaxed);
         Ok(Stream {
-            state,
+            playback_state,
             driver,
             asio_streams,
             callback_id,
@@ -938,7 +966,8 @@ impl Device {
         error_callback: E,
         hardware_latency: Arc<AtomicU32>,
         is_input: bool,
-        state: Arc<AtomicU8>,
+        playback_state: Arc<AtomicU8>,
+        pending_xrun: Arc<AtomicBool>,
     ) -> Result<sys::DriverEventCallbackId, Error>
     where
         E: FnMut(Error) + Send + 'static,
@@ -1011,7 +1040,9 @@ impl Device {
                     sys::AsioMessageSelectors::kAsioResetRequest => {
                         // Guard on Starting: some USB ASIO drivers (ASIO4ALL, Focusrite, etc.)
                         // fire spurious reset/resync requests during driver.start().
-                        if StreamState::load(&state, Ordering::Relaxed) != StreamState::Starting {
+                        if StreamState::load(&playback_state, Ordering::Relaxed)
+                            != StreamState::Starting
+                        {
                             let _ = timer_tx.send(Error::with_message(
                                 ErrorKind::StreamInvalidated,
                                 "Stream reset was requested by the ASIO driver",
@@ -1023,7 +1054,9 @@ impl Device {
                         // Per the ASIO spec (and matching JUCE's behavior), kAsioResyncRequest
                         // means the driver needs a full stop/reinit/start. It is *not* a simple
                         // xrun notification.
-                        if StreamState::load(&state, Ordering::Relaxed) != StreamState::Starting {
+                        if StreamState::load(&playback_state, Ordering::Relaxed)
+                            != StreamState::Starting
+                        {
                             let _ = timer_tx.send(Error::with_message(
                                 ErrorKind::StreamInvalidated,
                                 "Stream resynchronization was requested by the ASIO driver",
@@ -1032,9 +1065,10 @@ impl Device {
                         true
                     }
                     sys::AsioMessageSelectors::kAsioOverload => {
-                        if StreamState::load(&state, Ordering::Relaxed) == StreamState::Playing {
-                            let _ =
-                                try_emit_error(&error_callback_shared, Error::new(ErrorKind::Xrun));
+                        if StreamState::load(&playback_state, Ordering::Relaxed)
+                            == StreamState::Playing
+                        {
+                            pending_xrun.store(true, Ordering::Relaxed);
                         }
                         true
                     }
@@ -1076,7 +1110,8 @@ impl Device {
                         }
                     };
                     if should_notify
-                        && StreamState::load(&state, Ordering::Relaxed) != StreamState::Starting
+                        && StreamState::load(&playback_state, Ordering::Relaxed)
+                            != StreamState::Starting
                     {
                         let _ = timer_tx.send(Error::with_message(
                             ErrorKind::StreamInvalidated,
@@ -1287,6 +1322,7 @@ unsafe fn process_output_callback_i24<D>(
     sample_rate: SampleRate,
     hardware_latency_frames: usize,
     callback_instant: StreamInstant,
+    xrun: bool,
 ) where
     D: FnMut(&mut Data, &CallbackInfo) + Send + 'static,
 {
@@ -1300,6 +1336,7 @@ unsafe fn process_output_callback_i24<D>(
             sample_rate,
             format,
             hardware_latency_frames,
+            xrun,
         );
     }
 
@@ -1363,6 +1400,7 @@ unsafe fn process_input_callback_i24<D>(
     little_endian: bool,
     hardware_latency_frames: usize,
     callback_instant: StreamInstant,
+    xrun: bool,
 ) where
     D: FnMut(&Data, &CallbackInfo) + Send + 'static,
 {
@@ -1405,6 +1443,7 @@ unsafe fn process_input_callback_i24<D>(
             sample_rate,
             format,
             hardware_latency_frames,
+            xrun,
         );
     }
 }
@@ -1418,6 +1457,7 @@ unsafe fn apply_output_callback_to_data<A, D>(
     sample_rate: SampleRate,
     sample_format: SampleFormat,
     hardware_latency_frames: usize,
+    xrun: bool,
 ) where
     A: Copy,
     D: FnMut(&mut Data, &CallbackInfo) + Send + 'static,
@@ -1435,10 +1475,7 @@ unsafe fn apply_output_callback_to_data<A, D>(
         callback: callback_instant,
         device: playback,
     };
-    let info = CallbackInfo {
-        timestamp,
-        xrun: false,
-    };
+    let info = CallbackInfo { timestamp, xrun };
     data_callback(&mut data, &info);
 }
 
@@ -1451,6 +1488,7 @@ unsafe fn apply_input_callback_to_data<A, D>(
     sample_rate: SampleRate,
     format: SampleFormat,
     hardware_latency_frames: usize,
+    xrun: bool,
 ) where
     A: Copy,
     D: FnMut(&Data, &CallbackInfo) + Send + 'static,
@@ -1470,9 +1508,6 @@ unsafe fn apply_input_callback_to_data<A, D>(
         callback: callback_instant,
         device: capture,
     };
-    let info = CallbackInfo {
-        timestamp,
-        xrun: false,
-    };
+    let info = CallbackInfo { timestamp, xrun };
     data_callback(&data, &info);
 }

--- a/src/host/audioworklet/mod.rs
+++ b/src/host/audioworklet/mod.rs
@@ -18,10 +18,10 @@ use js_sys::wasm_bindgen;
 use wasm_bindgen::prelude::*;
 
 use crate::{
-    BufferSize, ChannelCount, Data, DeviceDescription, DeviceDescriptionBuilder, DeviceDirection,
-    DeviceId, Error, ErrorKind, FrameCount, InputCallbackInfo, OutputCallbackInfo,
-    OutputStreamTimestamp, SampleFormat, SampleRate, StreamConfig, StreamInstant,
-    SupportedBufferSize, SupportedStreamConfig, SupportedStreamConfigRange,
+    BufferSize, CallbackInfo, ChannelCount, Data, DeviceDescription, DeviceDescriptionBuilder,
+    DeviceDirection, DeviceId, Error, ErrorKind, FrameCount, SampleFormat, SampleRate,
+    StreamConfig, StreamInstant, StreamTimestamp, SupportedBufferSize, SupportedStreamConfig,
+    SupportedStreamConfigRange,
     host::frames_to_duration,
     traits::{DeviceTrait, HostTrait, StreamTrait},
 };
@@ -238,7 +238,7 @@ impl DeviceTrait for Device {
         _timeout: Option<Duration>,
     ) -> Result<Self::Stream, Error>
     where
-        D: FnMut(&Data, &InputCallbackInfo) + Send + 'static,
+        D: FnMut(&Data, &CallbackInfo) + Send + 'static,
         E: FnMut(Error) + Send + 'static,
     {
         Err(Error::with_message(
@@ -280,12 +280,12 @@ impl DeviceTrait for Device {
         _timeout: Option<Duration>,
     ) -> Result<Self::Stream, Error>
     where
-        D: FnMut(&mut Data, &OutputCallbackInfo) + Send + 'static,
+        D: FnMut(&mut Data, &CallbackInfo) + Send + 'static,
         E: FnMut(Error) + Send + 'static,
     {
         crate::validate_stream_config(&config)?;
-        // Keep `playback` monotonic: the polled outputLatency can drop when the
-        // page calls `setSinkId()` to switch output devices, pulling `playback` backward.
+        // Keep `device` monotonic: the polled outputLatency can drop when the
+        // page calls `setSinkId()` to switch output devices, pulling `device` backward.
         let mut data_callback = crate::host::monotonic_output_callback(data_callback);
         if config.channels > MAX_CHANNELS {
             return Err(Error::with_message(
@@ -416,9 +416,12 @@ impl DeviceTrait for Device {
                                 frames_to_duration(frame_size as FrameCount, sample_rate);
                             let latency =
                                 Duration::from_nanos(latency_nanos_cb.load(Ordering::Relaxed));
-                            let playback = callback + (buffer_duration + latency);
-                            let timestamp = OutputStreamTimestamp { callback, playback };
-                            let info = OutputCallbackInfo { timestamp };
+                            let device = callback + (buffer_duration + latency);
+                            let timestamp = StreamTimestamp { callback, device };
+                            let info = CallbackInfo {
+                                timestamp,
+                                xrun: false,
+                            };
                             (data_callback)(&mut data, &info);
                         },
                     ))

--- a/src/host/coreaudio/ios/mod.rs
+++ b/src/host/coreaudio/ios/mod.rs
@@ -24,10 +24,10 @@ use self::enumerate::{
 };
 use super::{asbd_from_config, host_time_to_stream_instant};
 use crate::{
-    BufferSize, ChannelCount, Data, DeviceDescription, DeviceDescriptionBuilder, DeviceId, Error,
-    ErrorKind, FrameCount, InputCallbackInfo, InputStreamTimestamp, OutputCallbackInfo,
-    OutputStreamTimestamp, ResultExt, SampleFormat, SampleRate, StreamConfig, StreamInstant,
-    SupportedBufferSize, SupportedStreamConfig, SupportedStreamConfigRange,
+    BufferSize, CallbackInfo, ChannelCount, Data, DeviceDescription, DeviceDescriptionBuilder,
+    DeviceId, Error, ErrorKind, FrameCount, ResultExt, SampleFormat, SampleRate, StreamConfig,
+    StreamInstant, StreamTimestamp, SupportedBufferSize, SupportedStreamConfig,
+    SupportedStreamConfigRange,
     host::{
         ErrorCallbackArc, equilibrium::fill_equilibrium, frames_to_duration, latch::Latch,
         try_emit_error,
@@ -176,7 +176,7 @@ impl DeviceTrait for Device {
         _timeout: Option<Duration>,
     ) -> Result<Self::Stream, Error>
     where
-        D: FnMut(&Data, &InputCallbackInfo) + Send + 'static,
+        D: FnMut(&Data, &CallbackInfo) + Send + 'static,
         E: FnMut(Error) + Send + 'static,
     {
         crate::validate_stream_config(&config)?;
@@ -235,7 +235,7 @@ impl DeviceTrait for Device {
         _timeout: Option<Duration>,
     ) -> Result<Self::Stream, Error>
     where
-        D: FnMut(&mut Data, &OutputCallbackInfo) + Send + 'static,
+        D: FnMut(&mut Data, &CallbackInfo) + Send + 'static,
         E: FnMut(Error) + Send + 'static,
     {
         crate::validate_stream_config(&config)?;
@@ -613,7 +613,7 @@ fn setup_input_callback<D, E>(
     mut error_callback: E,
 ) -> Result<(), Error>
 where
-    D: FnMut(&Data, &InputCallbackInfo) + Send + 'static,
+    D: FnMut(&Data, &CallbackInfo) + Send + 'static,
     E: FnMut(Error) + Send + 'static,
 {
     let bytes_per_channel = sample_format.sample_size();
@@ -644,8 +644,18 @@ where
             };
             let delay = frames_to_duration(latency_frames as FrameCount, sample_rate);
             let capture = callback.checked_sub(delay).unwrap_or(StreamInstant::ZERO);
-            let timestamp = InputStreamTimestamp { callback, capture };
-            data_callback(&data, &InputCallbackInfo { timestamp });
+            let timestamp = StreamTimestamp {
+                callback,
+                device: capture,
+            };
+            // iOS exposes no xrun signal.
+            data_callback(
+                &data,
+                &CallbackInfo {
+                    timestamp,
+                    xrun: false,
+                },
+            );
         }
         Ok(())
     })?;
@@ -664,7 +674,7 @@ fn setup_output_callback<D, E>(
     mut error_callback: E,
 ) -> Result<(), Error>
 where
-    D: FnMut(&mut Data, &OutputCallbackInfo) + Send + 'static,
+    D: FnMut(&mut Data, &CallbackInfo) + Send + 'static,
     E: FnMut(Error) + Send + 'static,
 {
     let bytes_per_channel = sample_format.sample_size();
@@ -708,9 +718,16 @@ where
         };
         let delay = frames_to_duration(latency_frames as FrameCount, sample_rate);
         let playback = callback + delay;
-        let timestamp = OutputStreamTimestamp { callback, playback };
+        let timestamp = StreamTimestamp {
+            callback,
+            device: playback,
+        };
 
-        let info = OutputCallbackInfo { timestamp };
+        // iOS exposes no xrun signal.
+        let info = CallbackInfo {
+            timestamp,
+            xrun: false,
+        };
         data_callback(&mut data, &info);
         Ok(())
     })?;
@@ -735,7 +752,7 @@ mod tests {
 
         let result = device.build_output_stream(
             &config,
-            |_data: &mut [f32], _info: &OutputCallbackInfo| {},
+            |_data: &mut [f32], _info: &CallbackInfo| {},
             |_err| {},
             None,
         );

--- a/src/host/coreaudio/macos/device.rs
+++ b/src/host/coreaudio/macos/device.rs
@@ -45,10 +45,10 @@ use super::{
     host_time_to_stream_instant,
 };
 use crate::{
-    BufferSize, ChannelCount, Data, DeviceDescription, DeviceDescriptionBuilder, DeviceId, Error,
-    ErrorKind, FrameCount, InputCallbackInfo, InputStreamTimestamp, InterfaceType,
-    OutputCallbackInfo, OutputStreamTimestamp, ResultExt, SampleFormat, SampleRate, StreamConfig,
-    StreamInstant, SupportedBufferSize, SupportedStreamConfig, SupportedStreamConfigRange,
+    BufferSize, CallbackInfo, ChannelCount, Data, DeviceDescription, DeviceDescriptionBuilder,
+    DeviceId, Error, ErrorKind, FrameCount, InterfaceType, ResultExt, SampleFormat, SampleRate,
+    StreamConfig, StreamInstant, StreamTimestamp, SupportedBufferSize, SupportedStreamConfig,
+    SupportedStreamConfigRange,
     host::{
         ErrorCallbackArc,
         coreaudio::macos::{StreamInner, loopback::LoopbackDevice},
@@ -323,7 +323,7 @@ impl DeviceTrait for Device {
         timeout: Option<Duration>,
     ) -> Result<Self::Stream, Error>
     where
-        D: FnMut(&Data, &InputCallbackInfo) + Send + 'static,
+        D: FnMut(&Data, &CallbackInfo) + Send + 'static,
         E: FnMut(Error) + Send + 'static,
     {
         Device::build_input_stream_raw(
@@ -345,7 +345,7 @@ impl DeviceTrait for Device {
         timeout: Option<Duration>,
     ) -> Result<Self::Stream, Error>
     where
-        D: FnMut(&mut Data, &OutputCallbackInfo) + Send + 'static,
+        D: FnMut(&mut Data, &CallbackInfo) + Send + 'static,
         E: FnMut(Error) + Send + 'static,
     {
         Device::build_output_stream_raw(
@@ -702,7 +702,7 @@ impl Device {
         timeout: Option<Duration>,
     ) -> Result<Stream, Error>
     where
-        D: FnMut(&Data, &InputCallbackInfo) + Send + 'static,
+        D: FnMut(&Data, &CallbackInfo) + Send + 'static,
         E: FnMut(Error) + Send + 'static,
     {
         crate::validate_stream_config(&config)?;
@@ -791,8 +791,17 @@ impl Device {
                     device_buffer_frames.unwrap_or(buffer_frames) + extra_latency_frames;
                 let delay = frames_to_duration(latency_frames as FrameCount, sample_rate);
                 let capture = callback.checked_sub(delay).unwrap_or(StreamInstant::ZERO);
-                let timestamp = InputStreamTimestamp { callback, capture };
-                data_callback(&data, &InputCallbackInfo { timestamp });
+                let timestamp = StreamTimestamp {
+                    callback,
+                    device: capture,
+                };
+                data_callback(
+                    &data,
+                    &CallbackInfo {
+                        timestamp,
+                        xrun: false,
+                    },
+                );
             }
             Ok(())
         })?;
@@ -827,7 +836,7 @@ impl Device {
         timeout: Option<Duration>,
     ) -> Result<Stream, Error>
     where
-        D: FnMut(&mut Data, &OutputCallbackInfo) + Send + 'static,
+        D: FnMut(&mut Data, &CallbackInfo) + Send + 'static,
         E: FnMut(Error) + Send + 'static,
     {
         crate::validate_stream_config(&config)?;
@@ -930,9 +939,15 @@ impl Device {
             };
             let delay = frames_to_duration(latency_frames as FrameCount, sample_rate);
             let playback = callback + delay;
-            let timestamp = OutputStreamTimestamp { callback, playback };
+            let timestamp = StreamTimestamp {
+                callback,
+                device: playback,
+            };
 
-            let info = OutputCallbackInfo { timestamp };
+            let info = CallbackInfo {
+                timestamp,
+                xrun: false,
+            };
             data_callback(&mut data, &info);
             Ok(())
         })?;

--- a/src/host/coreaudio/macos/device.rs
+++ b/src/host/coreaudio/macos/device.rs
@@ -754,6 +754,8 @@ impl Device {
 
         let error_callback: ErrorCallbackArc = Arc::new(Mutex::new(error_callback));
         let error_callback_disconnect = error_callback.clone();
+        let pending_xrun = Arc::new(AtomicBool::new(false));
+        let pending_xrun_overload = pending_xrun.clone();
 
         // Register the callback that is being called by coreaudio whenever it needs data to be
         // fed to the audio buffer.
@@ -795,13 +797,8 @@ impl Device {
                     callback,
                     device: capture,
                 };
-                data_callback(
-                    &data,
-                    &CallbackInfo {
-                        timestamp,
-                        xrun: false,
-                    },
-                );
+                let xrun = pending_xrun.swap(false, Ordering::Relaxed);
+                data_callback(&data, &CallbackInfo { timestamp, xrun });
             }
             Ok(())
         })?;
@@ -821,6 +818,7 @@ impl Device {
             self.audio_device_id,
             weak_inner,
             error_callback_disconnect,
+            pending_xrun_overload,
         )?);
         let stream = Stream::new(inner_arc, monitor, draining, Duration::ZERO);
         stream.signal_ready();
@@ -882,6 +880,8 @@ impl Device {
 
         let error_callback: ErrorCallbackArc = Arc::new(Mutex::new(error_callback));
         let error_callback_for_render = error_callback.clone();
+        let pending_xrun = Arc::new(AtomicBool::new(false));
+        let pending_xrun_overload = pending_xrun.clone();
 
         // Register the callback that is being called by coreaudio whenever it needs data to be
         // fed to the audio buffer.
@@ -943,11 +943,9 @@ impl Device {
                 callback,
                 device: playback,
             };
+            let xrun = pending_xrun.swap(false, Ordering::Relaxed);
 
-            let info = CallbackInfo {
-                timestamp,
-                xrun: false,
-            };
+            let info = CallbackInfo { timestamp, xrun };
             data_callback(&mut data, &info);
             Ok(())
         })?;
@@ -969,12 +967,14 @@ impl Device {
                 weak_inner,
                 error_callback,
                 Some((latency_frames, Scope::Output)),
+                pending_xrun_overload,
             )?)
         } else {
             Box::new(DisconnectManager::new(
                 self.audio_device_id,
                 weak_inner,
                 error_callback,
+                pending_xrun_overload,
             )?)
         };
         let stream = Stream::new(inner_arc, monitor, draining, drain_window);

--- a/src/host/coreaudio/macos/mod.rs
+++ b/src/host/coreaudio/macos/mod.rs
@@ -447,7 +447,7 @@ impl StreamTrait for Stream {
 #[cfg(test)]
 mod test {
     use crate::{
-        InputCallbackInfo, OutputCallbackInfo, Sample, default_host,
+        CallbackInfo, Sample, default_host,
         traits::{DeviceTrait, HostTrait, StreamTrait},
     };
 
@@ -495,7 +495,7 @@ mod test {
         let stream = device
             .build_input_stream(
                 config,
-                move |data: &[f32], _: &InputCallbackInfo| {
+                move |data: &[f32], _: &CallbackInfo| {
                     // react to stream events and read or write stream data here.
                     println!("Got data: {:?}", &data[..25]);
                 },
@@ -528,7 +528,7 @@ mod test {
         let stream = device
             .build_input_stream(
                 config,
-                move |data: &[f32], _: &InputCallbackInfo| {
+                move |data: &[f32], _: &CallbackInfo| {
                     // react to stream events and read or write stream data here.
                     println!("Got data: {:?}", &data[..25]);
                 },
@@ -540,7 +540,7 @@ mod test {
         std::thread::sleep(std::time::Duration::from_secs(1));
     }
 
-    fn write_silence<T: Sample>(data: &mut [T], _: &OutputCallbackInfo) {
+    fn write_silence<T: Sample>(data: &mut [T], _: &CallbackInfo) {
         for sample in data.iter_mut() {
             *sample = Sample::EQUILIBRIUM;
         }

--- a/src/host/coreaudio/macos/mod.rs
+++ b/src/host/coreaudio/macos/mod.rs
@@ -20,7 +20,7 @@ pub use self::enumerate::{Devices, default_input_device, default_output_device};
 use super::{OSStatus, asbd_from_config, check_os_status, host_time_to_stream_instant};
 use crate::{
     Error, ErrorKind, FrameCount, ResultExt, StreamInstant,
-    host::{coreaudio::macos::loopback::LoopbackDevice, emit_error, latch::Latch, try_emit_error},
+    host::{coreaudio::macos::loopback::LoopbackDevice, emit_error, latch::Latch},
     traits::{HostTrait, StreamTrait},
 };
 
@@ -65,20 +65,21 @@ impl HostTrait for Host {
 /// Type alias for the error callback to reduce complexity
 type ErrorCallback = dyn FnMut(Error) + Send;
 
-/// Spawns a dedicated thread that registers a single property listener and signals a channel on
-/// each change. The listener is deregistered when the returned `Sender<()>` is dropped.
-fn spawn_property_listener_thread(
+/// Spawns a dedicated thread that registers a single property listener, calling `on_change` on
+/// each firing. The listener is deregistered when the returned `Sender<()>` is dropped.
+fn spawn_property_listener_thread<F>(
     object_id: AudioObjectID,
     address: AudioObjectPropertyAddress,
-) -> Result<(mpsc::Receiver<()>, mpsc::Sender<()>), Error> {
+    on_change: F,
+) -> Result<mpsc::Sender<()>, Error>
+where
+    F: FnMut() + Send + 'static,
+{
     let (shutdown_tx, shutdown_rx) = mpsc::channel::<()>();
-    let (change_tx, change_rx) = mpsc::channel::<()>();
     let (ready_tx, ready_rx) = mpsc::channel();
 
     std::thread::spawn(move || {
-        let listener = AudioObjectPropertyListener::new(object_id, address, move || {
-            let _ = change_tx.send(());
-        });
+        let listener = AudioObjectPropertyListener::new(object_id, address, on_change);
         match listener {
             Ok(_l) => {
                 let _ = ready_tx.send(Ok(()));
@@ -97,7 +98,7 @@ fn spawn_property_listener_thread(
         )
     })??;
 
-    Ok((change_rx, shutdown_tx))
+    Ok(shutdown_tx)
 }
 
 /// A device monitor that can signal when the owning `Stream` handle has been returned to the
@@ -126,6 +127,7 @@ impl DisconnectManager {
         device_id: AudioDeviceID,
         stream_weak: Weak<Mutex<StreamInner>>,
         error_callback: Arc<Mutex<ErrorCallback>>,
+        pending_xrun: Arc<AtomicBool>,
     ) -> Result<Self, Error> {
         let (shutdown_tx, shutdown_rx) = mpsc::channel();
         let (disconnect_tx, disconnect_rx) = mpsc::channel::<Error>();
@@ -135,7 +137,6 @@ impl DisconnectManager {
         // AudioObjectPropertyListeners are added and removed on the same thread.
         let disconnect_tx_alive = disconnect_tx.clone();
         let disconnect_tx_rate = disconnect_tx;
-        let error_callback_overload = error_callback.clone();
         std::thread::spawn(move || {
             let alive_address = AudioObjectPropertyAddress {
                 mSelector: kAudioDevicePropertyDeviceIsAlive,
@@ -171,7 +172,7 @@ impl DisconnectManager {
             };
             let overload_listener =
                 AudioObjectPropertyListener::new(device_id, overload_address, move || {
-                    let _ = try_emit_error(&error_callback_overload, ErrorKind::Xrun.into());
+                    pending_xrun.store(true, Ordering::Relaxed);
                 });
 
             match (alive_listener, rate_listener, overload_listener) {
@@ -250,15 +251,41 @@ impl DefaultOutputMonitor {
         stream_weak: Weak<Mutex<StreamInner>>,
         error_callback: Arc<Mutex<ErrorCallback>>,
         latency_refresh: Option<(Arc<AtomicUsize>, Scope)>,
+        pending_xrun: Arc<AtomicBool>,
     ) -> Result<Self, Error> {
-        let (change_rx, shutdown_tx) = spawn_property_listener_thread(
+        let (change_tx, change_rx) = mpsc::channel::<()>();
+        let shutdown_tx = spawn_property_listener_thread(
             kAudioObjectSystemObject as AudioObjectID,
             AudioObjectPropertyAddress {
                 mSelector: kAudioHardwarePropertyDefaultOutputDevice,
                 mScope: kAudioObjectPropertyScopeGlobal,
                 mElement: kAudioObjectPropertyElementMain,
             },
+            move || {
+                let _ = change_tx.send(());
+            },
         )?;
+
+        // The overload listener targets a specific device, so it must be re-registered against
+        // whatever device is current whenever the default output reroutes.
+        // Held only to shut down the previous listener thread on drop when reassigned below.
+        let mut _overload_shutdown_tx = match default_output_device() {
+            Some(device) => Some(spawn_property_listener_thread(
+                device.audio_device_id,
+                AudioObjectPropertyAddress {
+                    mSelector: kAudioDeviceProcessorOverload,
+                    mScope: kAudioObjectPropertyScopeGlobal,
+                    mElement: kAudioObjectPropertyElementMain,
+                },
+                {
+                    let pending_xrun = pending_xrun.clone();
+                    move || {
+                        pending_xrun.store(true, Ordering::Relaxed);
+                    }
+                },
+            )?),
+            None => None,
+        };
 
         let mut latch = Latch::new();
         let waiter = latch.waiter();
@@ -273,41 +300,61 @@ impl DefaultOutputMonitor {
                     let Some(stream) = stream_weak.upgrade() else {
                         break;
                     };
-                    if default_output_device().is_none() {
-                        if let Ok(mut inner) = stream.try_lock() {
-                            let _ = inner.pause();
-                        }
-                        emit_error(
-                            &error_callback,
-                            Error::with_message(
-                                ErrorKind::DeviceNotAvailable,
-                                "no default output device",
-                            ),
-                        );
-                    } else {
-                        // DefaultOutput AudioUnit rerouted automatically: recompute and notify
-                        // the buffer depth for the new device.
-                        if let Some((frames, scope)) = &latency_refresh {
-                            if let Ok(inner) = stream.lock() {
-                                let depth = device::get_device_buffer_frame_size(&inner.audio_unit)
-                                    .ok()
-                                    .map_or(0, |buffer| {
-                                        buffer
-                                            + device::get_device_extra_latency_frames(
-                                                &inner.audio_unit,
-                                                *scope,
-                                            )
-                                    });
-                                frames.store(depth, Ordering::Relaxed);
+                    match default_output_device() {
+                        None => {
+                            _overload_shutdown_tx = None;
+                            if let Ok(mut inner) = stream.try_lock() {
+                                let _ = inner.pause();
                             }
+                            emit_error(
+                                &error_callback,
+                                Error::with_message(
+                                    ErrorKind::DeviceNotAvailable,
+                                    "no default output device",
+                                ),
+                            );
                         }
-                        emit_error(
-                            &error_callback,
-                            Error::with_message(
-                                ErrorKind::DeviceChanged,
-                                "default output device changed",
-                            ),
-                        );
+                        Some(device) => {
+                            // DefaultOutput AudioUnit rerouted automatically: recompute and notify
+                            // the buffer depth for the new device.
+                            if let Some((frames, scope)) = &latency_refresh {
+                                if let Ok(inner) = stream.lock() {
+                                    let depth =
+                                        device::get_device_buffer_frame_size(&inner.audio_unit)
+                                            .ok()
+                                            .map_or(0, |buffer| {
+                                                buffer
+                                                    + device::get_device_extra_latency_frames(
+                                                        &inner.audio_unit,
+                                                        *scope,
+                                                    )
+                                            });
+                                    frames.store(depth, Ordering::Relaxed);
+                                }
+                            }
+                            _overload_shutdown_tx = spawn_property_listener_thread(
+                                device.audio_device_id,
+                                AudioObjectPropertyAddress {
+                                    mSelector: kAudioDeviceProcessorOverload,
+                                    mScope: kAudioObjectPropertyScopeGlobal,
+                                    mElement: kAudioObjectPropertyElementMain,
+                                },
+                                {
+                                    let pending_xrun = pending_xrun.clone();
+                                    move || {
+                                        pending_xrun.store(true, Ordering::Relaxed);
+                                    }
+                                },
+                            )
+                            .ok();
+                            emit_error(
+                                &error_callback,
+                                Error::with_message(
+                                    ErrorKind::DeviceChanged,
+                                    "default output device changed",
+                                ),
+                            );
+                        }
                     }
                 }
             })

--- a/src/host/custom/mod.rs
+++ b/src/host/custom/mod.rs
@@ -7,9 +7,8 @@ use core::time::Duration;
 use std::fmt;
 
 use crate::{
-    Data, DeviceDescription, DeviceId, Error, ErrorKind, FrameCount, InputCallbackInfo,
-    OutputCallbackInfo, SampleFormat, StreamConfig, StreamInstant, SupportedStreamConfig,
-    SupportedStreamConfigRange,
+    CallbackInfo, Data, DeviceDescription, DeviceId, Error, ErrorKind, FrameCount, SampleFormat,
+    StreamConfig, StreamInstant, SupportedStreamConfig, SupportedStreamConfigRange,
     traits::{DeviceTrait, HostTrait, StreamTrait},
 };
 
@@ -169,8 +168,8 @@ impl Clone for SupportedConfigs {
 }
 
 type ErrorCallback = Box<dyn FnMut(Error) + Send + 'static>;
-type InputCallback = Box<dyn FnMut(&Data, &InputCallbackInfo) + Send + 'static>;
-type OutputCallback = Box<dyn FnMut(&mut Data, &OutputCallbackInfo) + Send + 'static>;
+type InputCallback = Box<dyn FnMut(&Data, &CallbackInfo) + Send + 'static>;
+type OutputCallback = Box<dyn FnMut(&mut Data, &CallbackInfo) + Send + 'static>;
 
 trait DeviceErased: Send + Sync {
     fn description(&self) -> Result<DeviceDescription, Error>;
@@ -422,7 +421,7 @@ impl DeviceTrait for Device {
         timeout: Option<Duration>,
     ) -> Result<Self::Stream, Error>
     where
-        D: FnMut(&Data, &InputCallbackInfo) + Send + 'static,
+        D: FnMut(&Data, &CallbackInfo) + Send + 'static,
         E: FnMut(Error) + Send + 'static,
     {
         self.0.build_input_stream_raw(
@@ -443,7 +442,7 @@ impl DeviceTrait for Device {
         timeout: Option<Duration>,
     ) -> Result<Self::Stream, Error>
     where
-        D: FnMut(&mut Data, &OutputCallbackInfo) + Send + 'static,
+        D: FnMut(&mut Data, &CallbackInfo) + Send + 'static,
         E: FnMut(Error) + Send + 'static,
     {
         self.0.build_output_stream_raw(

--- a/src/host/jack/device.rs
+++ b/src/host/jack/device.rs
@@ -7,10 +7,9 @@ use std::{
 use super::{JACK_SAMPLE_FORMAT, stream::Stream};
 pub use crate::iter::{SupportedInputConfigs, SupportedOutputConfigs};
 use crate::{
-    BufferSize, ChannelCount, Data, DeviceDescription, DeviceDescriptionBuilder, DeviceDirection,
-    DeviceId, Error, ErrorKind, InputCallbackInfo, OutputCallbackInfo, SampleFormat, SampleRate,
-    StreamConfig, SupportedBufferSize, SupportedStreamConfig, SupportedStreamConfigRange,
-    traits::DeviceTrait,
+    BufferSize, CallbackInfo, ChannelCount, Data, DeviceDescription, DeviceDescriptionBuilder,
+    DeviceDirection, DeviceId, Error, ErrorKind, SampleFormat, SampleRate, StreamConfig,
+    SupportedBufferSize, SupportedStreamConfig, SupportedStreamConfigRange, traits::DeviceTrait,
 };
 
 const DEFAULT_NUM_CHANNELS: ChannelCount = 2;
@@ -183,7 +182,7 @@ impl DeviceTrait for Device {
         timeout: Option<Duration>,
     ) -> Result<Self::Stream, Error>
     where
-        D: FnMut(&Data, &InputCallbackInfo) + Send + 'static,
+        D: FnMut(&Data, &CallbackInfo) + Send + 'static,
         E: FnMut(Error) + Send + 'static,
     {
         if self.is_output() {
@@ -267,7 +266,7 @@ impl DeviceTrait for Device {
         timeout: Option<Duration>,
     ) -> Result<Self::Stream, Error>
     where
-        D: FnMut(&mut Data, &OutputCallbackInfo) + Send + 'static,
+        D: FnMut(&mut Data, &CallbackInfo) + Send + 'static,
         E: FnMut(Error) + Send + 'static,
     {
         if self.is_input() {

--- a/src/host/jack/stream.rs
+++ b/src/host/jack/stream.rs
@@ -5,8 +5,8 @@ use std::sync::{
 
 use super::JACK_SAMPLE_FORMAT;
 use crate::{
-    ChannelCount, Data, Error, ErrorKind, FrameCount, InputCallbackInfo, InputStreamTimestamp,
-    OutputCallbackInfo, OutputStreamTimestamp, ResultExt, Sample, SampleRate, StreamInstant,
+    CallbackInfo, ChannelCount, Data, Error, ErrorKind, FrameCount, ResultExt, Sample, SampleRate,
+    StreamInstant, StreamTimestamp,
     host::{ErrorCallbackArc, emit_error, frames_to_duration, try_emit_error},
     traits::StreamTrait,
 };
@@ -49,7 +49,7 @@ impl Stream {
         error_callback: E,
     ) -> Result<Stream, Error>
     where
-        D: FnMut(&Data, &InputCallbackInfo) + Send + 'static,
+        D: FnMut(&Data, &CallbackInfo) + Send + 'static,
         E: FnMut(Error) + Send + 'static,
     {
         let mut ports = vec![];
@@ -105,7 +105,7 @@ impl Stream {
         error_callback: E,
     ) -> Result<Stream, Error>
     where
-        D: FnMut(&mut Data, &OutputCallbackInfo) + Send + 'static,
+        D: FnMut(&mut Data, &CallbackInfo) + Send + 'static,
         E: FnMut(Error) + Send + 'static,
     {
         let mut ports = vec![];
@@ -259,8 +259,8 @@ impl StreamTrait for Stream {
     }
 }
 
-type InputDataCallback = Box<dyn FnMut(&Data, &InputCallbackInfo) + Send + 'static>;
-type OutputDataCallback = Box<dyn FnMut(&mut Data, &OutputCallbackInfo) + Send + 'static>;
+type InputDataCallback = Box<dyn FnMut(&Data, &CallbackInfo) + Send + 'static>;
+type OutputDataCallback = Box<dyn FnMut(&mut Data, &CallbackInfo) + Send + 'static>;
 
 struct LocalProcessHandler {
     /// No new ports are allowed to be created after the creation of the LocalProcessHandler as that would invalidate the buffer sizes
@@ -452,8 +452,14 @@ impl jack::ProcessHandler for LocalProcessHandler {
             let capture = start_cycle_instant
                 .checked_sub(latency)
                 .unwrap_or(StreamInstant::ZERO);
-            let timestamp = InputStreamTimestamp { callback, capture };
-            let info = InputCallbackInfo { timestamp };
+            let timestamp = StreamTimestamp {
+                callback,
+                device: capture,
+            };
+            let info = CallbackInfo {
+                timestamp,
+                xrun: false,
+            };
             input_callback(&data, &info);
         }
 
@@ -488,8 +494,14 @@ impl jack::ProcessHandler for LocalProcessHandler {
                         }
                     },
                 };
-            let timestamp = OutputStreamTimestamp { callback, playback };
-            let info = OutputCallbackInfo { timestamp };
+            let timestamp = StreamTimestamp {
+                callback,
+                device: playback,
+            };
+            let info = CallbackInfo {
+                timestamp,
+                xrun: false,
+            };
             output_callback(&mut data, &info);
 
             // Deinterlace

--- a/src/host/jack/stream.rs
+++ b/src/host/jack/stream.rs
@@ -1,13 +1,15 @@
 use std::sync::{
     Arc, Mutex,
-    atomic::{AtomicU8, Ordering},
+    atomic::{AtomicBool, AtomicU8, Ordering},
 };
 
 use super::JACK_SAMPLE_FORMAT;
+#[cfg(feature = "realtime")]
+use crate::host::try_emit_error;
 use crate::{
     CallbackInfo, ChannelCount, Data, Error, ErrorKind, FrameCount, ResultExt, Sample, SampleRate,
     StreamInstant, StreamTimestamp,
-    host::{ErrorCallbackArc, emit_error, frames_to_duration, try_emit_error},
+    host::{ErrorCallbackArc, emit_error, frames_to_duration},
     traits::StreamTrait,
 };
 
@@ -34,7 +36,7 @@ impl StreamState {
 }
 
 pub struct Stream {
-    state: Arc<AtomicU8>,
+    playback_state: Arc<AtomicU8>,
     async_client: jack::AsyncClient<JackNotificationHandler, LocalProcessHandler>,
     // Port names are stored in order to connect them to other ports in jack automatically
     input_port_names: Box<[String]>,
@@ -64,7 +66,8 @@ impl Stream {
             ports.push(port);
         }
 
-        let state = Arc::new(AtomicU8::new(StreamState::Starting as u8));
+        let playback_state = Arc::new(AtomicU8::new(StreamState::Starting as u8));
+        let pending_xrun = Arc::new(AtomicBool::new(false));
         let error_callback_ptr: ErrorCallbackArc = Arc::new(Mutex::new(error_callback));
 
         let input_process_handler = LocalProcessHandler::new(
@@ -74,24 +77,26 @@ impl Stream {
             client.buffer_size() as usize,
             Some(Box::new(data_callback)),
             None,
-            state.clone(),
+            playback_state.clone(),
+            pending_xrun.clone(),
             #[cfg(feature = "realtime")]
             error_callback_ptr.clone(),
         );
 
         let notification_handler = JackNotificationHandler::new(
             error_callback_ptr,
-            state.clone(),
+            playback_state.clone(),
             client.sample_rate() as jack::Frames,
+            pending_xrun,
         );
 
         let async_client = client
             .activate_async(notification_handler, input_process_handler)
             .context("Failed to activate client")?;
 
-        StreamState::Paused.store(&state, Ordering::Relaxed);
+        StreamState::Paused.store(&playback_state, Ordering::Relaxed);
         Ok(Self {
-            state,
+            playback_state,
             async_client,
             input_port_names: port_names.into_boxed_slice(),
             output_port_names: Default::default(),
@@ -120,7 +125,8 @@ impl Stream {
             ports.push(port);
         }
 
-        let state = Arc::new(AtomicU8::new(StreamState::Starting as u8));
+        let playback_state = Arc::new(AtomicU8::new(StreamState::Starting as u8));
+        let pending_xrun = Arc::new(AtomicBool::new(false));
         let error_callback_ptr: ErrorCallbackArc = Arc::new(Mutex::new(error_callback));
 
         let output_process_handler = LocalProcessHandler::new(
@@ -130,24 +136,26 @@ impl Stream {
             client.buffer_size() as usize,
             None,
             Some(Box::new(data_callback)),
-            state.clone(),
+            playback_state.clone(),
+            pending_xrun.clone(),
             #[cfg(feature = "realtime")]
             error_callback_ptr.clone(),
         );
 
         let notification_handler = JackNotificationHandler::new(
             error_callback_ptr,
-            state.clone(),
+            playback_state.clone(),
             client.sample_rate() as jack::Frames,
+            pending_xrun,
         );
 
         let async_client = client
             .activate_async(notification_handler, output_process_handler)
             .context("Failed to activate client")?;
 
-        StreamState::Paused.store(&state, Ordering::Relaxed);
+        StreamState::Paused.store(&playback_state, Ordering::Relaxed);
         Ok(Self {
-            state,
+            playback_state,
             async_client,
             input_port_names: Box::default(),
             output_port_names: port_names.into_boxed_slice(),
@@ -219,17 +227,17 @@ impl Stream {
 
 impl StreamTrait for Stream {
     fn start(&self) -> Result<(), Error> {
-        StreamState::Playing.store(&self.state, Ordering::Relaxed);
+        StreamState::Playing.store(&self.playback_state, Ordering::Relaxed);
         Ok(())
     }
 
     fn pause(&self) -> Result<(), Error> {
-        StreamState::Paused.store(&self.state, Ordering::Relaxed);
+        StreamState::Paused.store(&self.playback_state, Ordering::Relaxed);
         Ok(())
     }
 
     fn stop(&self, timeout: Option<std::time::Duration>) -> Result<(), Error> {
-        StreamState::Paused.store(&self.state, Ordering::Relaxed);
+        StreamState::Paused.store(&self.playback_state, Ordering::Relaxed);
 
         let is_output = !self.output_port_names.is_empty();
         if is_output && timeout != Some(std::time::Duration::ZERO) {
@@ -275,7 +283,8 @@ struct LocalProcessHandler {
     // JACK audio samples are 32-bit float (unless you do some custom dark magic)
     temp_input_buffer: Vec<f32>,
     temp_output_buffer: Vec<f32>,
-    state: Arc<AtomicU8>,
+    playback_state: Arc<AtomicU8>,
+    pending_xrun: Arc<AtomicBool>,
     #[cfg(feature = "realtime")]
     error_callback: ErrorCallbackArc,
     #[cfg(feature = "realtime")]
@@ -283,7 +292,7 @@ struct LocalProcessHandler {
 }
 
 impl LocalProcessHandler {
-    #[cfg_attr(feature = "realtime", expect(clippy::too_many_arguments))]
+    #[expect(clippy::too_many_arguments)]
     fn new(
         out_ports: Vec<jack::Port<jack::AudioOut>>,
         in_ports: Vec<jack::Port<jack::AudioIn>>,
@@ -291,7 +300,8 @@ impl LocalProcessHandler {
         buffer_size: usize,
         input_data_callback: Option<InputDataCallback>,
         output_data_callback: Option<OutputDataCallback>,
-        state: Arc<AtomicU8>,
+        playback_state: Arc<AtomicU8>,
+        pending_xrun: Arc<AtomicBool>,
         #[cfg(feature = "realtime")] error_callback: ErrorCallbackArc,
     ) -> Self {
         let temp_input_buffer = vec![0.0; in_ports.len() * buffer_size];
@@ -306,7 +316,8 @@ impl LocalProcessHandler {
             output_data_callback,
             temp_input_buffer,
             temp_output_buffer,
-            state,
+            playback_state,
+            pending_xrun,
             #[cfg(feature = "realtime")]
             error_callback,
             #[cfg(feature = "realtime")]
@@ -328,7 +339,7 @@ impl jack::ProcessHandler for LocalProcessHandler {
         client: &jack::Client,
         process_scope: &jack::ProcessScope,
     ) -> jack::Control {
-        if StreamState::load(&self.state, Ordering::Relaxed) != StreamState::Playing {
+        if StreamState::load(&self.playback_state, Ordering::Relaxed) != StreamState::Playing {
             // JACK does not zero-fill output port buffers before calling the process handler
             for port in &mut self.out_ports {
                 port.as_mut_slice(process_scope).fill(f32::EQUILIBRIUM);
@@ -424,6 +435,8 @@ impl jack::ProcessHandler for LocalProcessHandler {
                 self.sample_rate,
             );
 
+        let xrun = self.pending_xrun.swap(false, Ordering::Relaxed);
+
         if let Some(input_callback) = &mut self.input_data_callback {
             // Let's get the data from the input ports and run the callback
 
@@ -456,10 +469,7 @@ impl jack::ProcessHandler for LocalProcessHandler {
                 callback,
                 device: capture,
             };
-            let info = CallbackInfo {
-                timestamp,
-                xrun: false,
-            };
+            let info = CallbackInfo { timestamp, xrun };
             input_callback(&data, &info);
         }
 
@@ -498,10 +508,7 @@ impl jack::ProcessHandler for LocalProcessHandler {
                 callback,
                 device: playback,
             };
-            let info = CallbackInfo {
-                timestamp,
-                xrun: false,
-            };
+            let info = CallbackInfo { timestamp, xrun };
             output_callback(&mut data, &info);
 
             // Deinterlace
@@ -558,27 +565,30 @@ fn hardware_latency_frames<PS>(
 /// Receives notifications from the JACK server on JACK's notification thread (single-threaded).
 struct JackNotificationHandler {
     error_callback_ptr: ErrorCallbackArc,
-    state: Arc<AtomicU8>,
+    playback_state: Arc<AtomicU8>,
     configured_sample_rate: jack::Frames,
+    pending_xrun: Arc<AtomicBool>,
 }
 
 impl JackNotificationHandler {
     pub fn new(
         error_callback_ptr: ErrorCallbackArc,
-        state: Arc<AtomicU8>,
+        playback_state: Arc<AtomicU8>,
         configured_sample_rate: jack::Frames,
+        pending_xrun: Arc<AtomicBool>,
     ) -> Self {
         JackNotificationHandler {
             error_callback_ptr,
-            state,
+            playback_state,
             configured_sample_rate,
+            pending_xrun,
         }
     }
 }
 
 impl jack::NotificationHandler for JackNotificationHandler {
     unsafe fn shutdown(&mut self, _status: jack::ClientStatus, reason: &str) {
-        if StreamState::load(&self.state, Ordering::Relaxed) == StreamState::Starting {
+        if StreamState::load(&self.playback_state, Ordering::Relaxed) == StreamState::Starting {
             return;
         }
         emit_error(
@@ -595,7 +605,7 @@ impl jack::NotificationHandler for JackNotificationHandler {
             // One of these notifications is sent every time a client is started.
             return jack::Control::Continue;
         }
-        if StreamState::load(&self.state, Ordering::Relaxed) != StreamState::Starting {
+        if StreamState::load(&self.playback_state, Ordering::Relaxed) != StreamState::Starting {
             emit_error(
                 &self.error_callback_ptr,
                 Error::with_message(
@@ -608,8 +618,8 @@ impl jack::NotificationHandler for JackNotificationHandler {
     }
 
     fn xrun(&mut self, _: &jack::Client) -> jack::Control {
-        if StreamState::load(&self.state, Ordering::Relaxed) != StreamState::Starting {
-            let _ = try_emit_error(&self.error_callback_ptr, ErrorKind::Xrun.into());
+        if StreamState::load(&self.playback_state, Ordering::Relaxed) != StreamState::Starting {
+            self.pending_xrun.store(true, Ordering::Relaxed);
         }
         jack::Control::Continue
     }

--- a/src/host/mod.rs
+++ b/src/host/mod.rs
@@ -208,7 +208,35 @@ pub(crate) mod error_emit;
         )
     ),
 ))]
-pub(crate) use error_emit::{emit_error, try_emit_error};
+pub(crate) use error_emit::emit_error;
+
+#[cfg(any(
+    target_vendor = "apple",
+    target_os = "android",
+    all(target_os = "windows", feature = "asio"),
+    all(
+        feature = "jack",
+        feature = "realtime",
+        any(
+            target_os = "linux",
+            target_os = "dragonfly",
+            target_os = "freebsd",
+            target_os = "netbsd",
+            target_os = "macos",
+            target_os = "windows",
+        )
+    ),
+    all(
+        feature = "pipewire",
+        any(
+            target_os = "linux",
+            target_os = "dragonfly",
+            target_os = "freebsd",
+            target_os = "netbsd",
+        )
+    ),
+))]
+pub(crate) use error_emit::try_emit_error;
 
 /// Convert a frame count at a given sample rate to a [`std::time::Duration`].
 #[cfg(any(

--- a/src/host/mod.rs
+++ b/src/host/mod.rs
@@ -258,15 +258,15 @@ fn non_decreasing(floor: &mut u64, instant: crate::StreamInstant) -> crate::Stre
 #[allow(dead_code)]
 pub(crate) fn monotonic_input_callback<D>(
     mut data_callback: D,
-) -> impl FnMut(&crate::Data, &crate::InputCallbackInfo) + Send + 'static
+) -> impl FnMut(&crate::Data, &crate::CallbackInfo) + Send + 'static
 where
-    D: FnMut(&crate::Data, &crate::InputCallbackInfo) + Send + 'static,
+    D: FnMut(&crate::Data, &crate::CallbackInfo) + Send + 'static,
 {
     // FnMut runs on one thread at a time, so the floor needs no synchronization.
     let mut floor = 0u64;
     move |data, info| {
         let mut info = *info;
-        info.timestamp.capture = non_decreasing(&mut floor, info.timestamp.capture);
+        info.timestamp.device = non_decreasing(&mut floor, info.timestamp.device);
         data_callback(data, &info);
     }
 }
@@ -275,14 +275,14 @@ where
 #[allow(dead_code)]
 pub(crate) fn monotonic_output_callback<D>(
     mut data_callback: D,
-) -> impl FnMut(&mut crate::Data, &crate::OutputCallbackInfo) + Send + 'static
+) -> impl FnMut(&mut crate::Data, &crate::CallbackInfo) + Send + 'static
 where
-    D: FnMut(&mut crate::Data, &crate::OutputCallbackInfo) + Send + 'static,
+    D: FnMut(&mut crate::Data, &crate::CallbackInfo) + Send + 'static,
 {
     let mut floor = 0u64;
     move |data, info| {
         let mut info = *info;
-        info.timestamp.playback = non_decreasing(&mut floor, info.timestamp.playback);
+        info.timestamp.device = non_decreasing(&mut floor, info.timestamp.device);
         data_callback(data, &info);
     }
 }

--- a/src/host/mod.rs
+++ b/src/host/mod.rs
@@ -213,7 +213,6 @@ pub(crate) use error_emit::emit_error;
 #[cfg(any(
     target_vendor = "apple",
     target_os = "android",
-    all(target_os = "windows", feature = "asio"),
     all(
         feature = "jack",
         feature = "realtime",

--- a/src/host/null/mod.rs
+++ b/src/host/null/mod.rs
@@ -6,9 +6,8 @@ use std::fmt;
 use std::time::Duration;
 
 use crate::{
-    Data, DeviceDescription, DeviceDescriptionBuilder, DeviceId, Error, FrameCount,
-    InputCallbackInfo, OutputCallbackInfo, SampleFormat, StreamConfig, StreamInstant,
-    SupportedStreamConfig, SupportedStreamConfigRange,
+    CallbackInfo, Data, DeviceDescription, DeviceDescriptionBuilder, DeviceId, Error, FrameCount,
+    SampleFormat, StreamConfig, StreamInstant, SupportedStreamConfig, SupportedStreamConfigRange,
     traits::{DeviceTrait, HostTrait, StreamTrait},
 };
 
@@ -79,7 +78,7 @@ impl DeviceTrait for Device {
         _timeout: Option<Duration>,
     ) -> Result<Self::Stream, Error>
     where
-        D: FnMut(&Data, &InputCallbackInfo) + Send + 'static,
+        D: FnMut(&Data, &CallbackInfo) + Send + 'static,
         E: FnMut(Error) + Send + 'static,
     {
         unimplemented!()
@@ -95,7 +94,7 @@ impl DeviceTrait for Device {
         _timeout: Option<Duration>,
     ) -> Result<Self::Stream, Error>
     where
-        D: FnMut(&mut Data, &OutputCallbackInfo) + Send + 'static,
+        D: FnMut(&mut Data, &CallbackInfo) + Send + 'static,
         E: FnMut(Error) + Send + 'static,
     {
         unimplemented!()

--- a/src/host/pipewire/device.rs
+++ b/src/host/pipewire/device.rs
@@ -27,10 +27,10 @@ use pipewire::{
 
 use super::stream::Stream;
 use crate::{
-    BufferSize, ChannelCount, Data, DeviceDescription, DeviceDescriptionBuilder, DeviceDirection,
-    DeviceId, DeviceType, Error, ErrorKind, FrameCount, HostId, InputCallbackInfo, InterfaceType,
-    OutputCallbackInfo, SampleFormat, SampleRate, StreamConfig, SupportedBufferSize,
-    SupportedStreamConfig, SupportedStreamConfigRange,
+    BufferSize, CallbackInfo, ChannelCount, Data, DeviceDescription, DeviceDescriptionBuilder,
+    DeviceDirection, DeviceId, DeviceType, Error, ErrorKind, FrameCount, HostId, InterfaceType,
+    SampleFormat, SampleRate, StreamConfig, SupportedBufferSize, SupportedStreamConfig,
+    SupportedStreamConfigRange,
     host::{
         Notify, emit_error,
         latch::Latch,
@@ -352,7 +352,7 @@ impl DeviceTrait for Device {
         timeout: Option<std::time::Duration>,
     ) -> Result<Self::Stream, Error>
     where
-        D: FnMut(&Data, &InputCallbackInfo) + Send + 'static,
+        D: FnMut(&Data, &CallbackInfo) + Send + 'static,
         E: FnMut(Error) + Send + 'static,
     {
         crate::validate_stream_config(&config)?;
@@ -544,7 +544,7 @@ impl DeviceTrait for Device {
         timeout: Option<std::time::Duration>,
     ) -> Result<Self::Stream, Error>
     where
-        D: FnMut(&mut Data, &OutputCallbackInfo) + Send + 'static,
+        D: FnMut(&mut Data, &CallbackInfo) + Send + 'static,
         E: FnMut(Error) + Send + 'static,
     {
         crate::validate_stream_config(&config)?;

--- a/src/host/pipewire/stream.rs
+++ b/src/host/pipewire/stream.rs
@@ -33,8 +33,8 @@ use pipewire::{
 };
 
 use crate::{
-    Data, Error, ErrorKind, FrameCount, InputCallbackInfo, InputStreamTimestamp,
-    OutputCallbackInfo, OutputStreamTimestamp, SampleFormat, StreamConfig, StreamInstant,
+    CallbackInfo, Data, Error, ErrorKind, FrameCount, SampleFormat, StreamConfig, StreamInstant,
+    StreamTimestamp,
     host::{
         ErrorCallbackArc, Notify, emit_error, equilibrium::fill_equilibrium, frames_to_duration,
         latch::Latch, try_emit_error,
@@ -341,19 +341,18 @@ impl<D> UserData<D> {
         }
     }
 
-    fn check_xrun(&mut self) {
+    fn check_xrun(&mut self) -> bool {
         if self.spa_io_clock.is_null() {
-            return;
+            return false;
         }
         // spa/node/io.h; not present in bindgen output on all libspa versions.
         const SPA_IO_CLOCK_FLAG_XRUN_RECOVER: u32 = 1 << 1;
         // io_changed and process run on the same thread.
         let flags = unsafe { (*self.spa_io_clock).flags };
         let recovering = flags & SPA_IO_CLOCK_FLAG_XRUN_RECOVER != 0;
-        if recovering && !self.xrun_recovering {
-            let _ = try_emit_error(&self.error_callback, ErrorKind::Xrun.into());
-        }
+        let xrun = recovering && !self.xrun_recovering;
         self.xrun_recovering = recovering;
+        xrun
     }
 }
 
@@ -370,9 +369,15 @@ fn pw_stream_time(stream: &pw::stream::Stream) -> Option<Time> {
 
 impl<D> UserData<D>
 where
-    D: FnMut(&Data, &InputCallbackInfo) + Send + 'static,
+    D: FnMut(&Data, &CallbackInfo) + Send + 'static,
 {
-    fn publish_data_in(&mut self, stream: &pw::stream::Stream, frames: usize, data: &Data) {
+    fn publish_data_in(
+        &mut self,
+        stream: &pw::stream::Stream,
+        frames: usize,
+        data: &Data,
+        xrun: bool,
+    ) {
         #[cfg(feature = "realtime")]
         {
             let prev = self.last_quantum.swap(frames as u64, Ordering::Relaxed);
@@ -405,17 +410,26 @@ where
                     (cb, capture)
                 }
             };
-            let timestamp = InputStreamTimestamp { callback, capture };
-            (self.data_callback)(data, &InputCallbackInfo { timestamp });
+            let timestamp = StreamTimestamp {
+                callback,
+                device: capture,
+            };
+            (self.data_callback)(data, &CallbackInfo { timestamp, xrun });
         }
     }
 }
 
 impl<D> UserData<D>
 where
-    D: FnMut(&mut Data, &OutputCallbackInfo) + Send + 'static,
+    D: FnMut(&mut Data, &CallbackInfo) + Send + 'static,
 {
-    fn publish_data_out(&mut self, stream: &pw::stream::Stream, frames: usize, data: &mut Data) {
+    fn publish_data_out(
+        &mut self,
+        stream: &pw::stream::Stream,
+        frames: usize,
+        data: &mut Data,
+        xrun: bool,
+    ) {
         #[cfg(feature = "realtime")]
         {
             let prev = self.last_quantum.swap(frames as u64, Ordering::Relaxed);
@@ -446,8 +460,11 @@ where
                     (cb, pl)
                 }
             };
-            let timestamp = OutputStreamTimestamp { callback, playback };
-            (self.data_callback)(data, &OutputCallbackInfo { timestamp });
+            let timestamp = StreamTimestamp {
+                callback,
+                device: playback,
+            };
+            (self.data_callback)(data, &CallbackInfo { timestamp, xrun });
         }
     }
 }
@@ -621,7 +638,7 @@ pub fn connect_output<D, E>(
     error_callback: E,
 ) -> Result<StreamData<D>, pw::Error>
 where
-    D: FnMut(&mut Data, &OutputCallbackInfo) + Send + 'static,
+    D: FnMut(&mut Data, &CallbackInfo) + Send + 'static,
     E: FnMut(Error) + Send + 'static,
 {
     let ConnectParams {
@@ -785,7 +802,7 @@ where
             {
                 user_data.pending_device_changed.store(false, Ordering::Relaxed);
             }
-            user_data.check_xrun();
+            let xrun = user_data.check_xrun();
 
             let n_channels = user_data.format.channels();
             if n_channels == 0 {
@@ -821,7 +838,7 @@ where
                 let data = active.as_mut_ptr() as *mut ();
                 let mut data =
                     unsafe { Data::from_parts(data, n_samples, user_data.sample_format) };
-                user_data.publish_data_out(stream, frames, &mut data);
+                user_data.publish_data_out(stream, frames, &mut data, xrun);
                 let chunk = buf_data.chunk_mut();
                 *chunk.offset_mut() = 0;
                 *chunk.stride_mut() = stride as i32;
@@ -887,7 +904,7 @@ pub fn connect_input<D, E>(
     error_callback: E,
 ) -> Result<StreamData<D>, pw::Error>
 where
-    D: FnMut(&Data, &InputCallbackInfo) + Send + 'static,
+    D: FnMut(&Data, &CallbackInfo) + Send + 'static,
     E: FnMut(Error) + Send + 'static,
 {
     let ConnectParams {
@@ -1052,7 +1069,7 @@ where
             {
                 user_data.pending_device_changed.store(false, Ordering::Relaxed);
             }
-            user_data.check_xrun();
+            let xrun = user_data.check_xrun();
 
             let n_channels = user_data.format.channels();
             if n_channels == 0 {
@@ -1074,7 +1091,7 @@ where
                 let data = samples.as_mut_ptr() as *mut ();
                 let data =
                     unsafe { Data::from_parts(data, n_samples as usize, user_data.sample_format) };
-                user_data.publish_data_in(stream, frames as usize, &data);
+                user_data.publish_data_in(stream, frames as usize, &data, xrun);
             }
         })
         .register()?;

--- a/src/host/pulseaudio/mod.rs
+++ b/src/host/pulseaudio/mod.rs
@@ -94,7 +94,6 @@ impl From<pulseaudio::ClientError> for Error {
                 ConnectionTerminated | Killed | Protocol | BadState | Io => {
                     ErrorKind::StreamInvalidated
                 }
-                NoData => ErrorKind::Xrun,
                 _ => ErrorKind::BackendError,
             }
         }

--- a/src/host/pulseaudio/mod.rs
+++ b/src/host/pulseaudio/mod.rs
@@ -15,10 +15,9 @@ mod stream;
 pub use stream::Stream;
 
 use crate::{
-    BufferSize, Data, DeviceDescription, DeviceDescriptionBuilder, DeviceDirection, DeviceId,
-    Error, ErrorKind, FrameCount, HostId, InputCallbackInfo, OutputCallbackInfo, SampleFormat,
-    SampleRate, StreamConfig, SupportedBufferSize, SupportedStreamConfig,
-    SupportedStreamConfigRange,
+    BufferSize, CallbackInfo, Data, DeviceDescription, DeviceDescriptionBuilder, DeviceDirection,
+    DeviceId, Error, ErrorKind, FrameCount, HostId, SampleFormat, SampleRate, StreamConfig,
+    SupportedBufferSize, SupportedStreamConfig, SupportedStreamConfigRange,
     error::ResultExt,
     traits::{DeviceTrait, HostTrait},
 };
@@ -321,7 +320,7 @@ impl DeviceTrait for Device {
         timeout: Option<Duration>,
     ) -> Result<Self::Stream, Error>
     where
-        D: FnMut(&Data, &InputCallbackInfo) + Send + 'static,
+        D: FnMut(&Data, &CallbackInfo) + Send + 'static,
         E: FnMut(Error) + Send + 'static,
     {
         let Device::Source { client, info } = self else {
@@ -414,7 +413,7 @@ impl DeviceTrait for Device {
         timeout: Option<Duration>,
     ) -> Result<Self::Stream, Error>
     where
-        D: FnMut(&mut Data, &OutputCallbackInfo) + Send + 'static,
+        D: FnMut(&mut Data, &CallbackInfo) + Send + 'static,
         E: FnMut(Error) + Send + 'static,
     {
         let Device::Sink { client, info } = self else {

--- a/src/host/pulseaudio/stream.rs
+++ b/src/host/pulseaudio/stream.rs
@@ -11,8 +11,7 @@ use futures_util::FutureExt as _;
 use pulseaudio::{AsPlaybackSource, protocol};
 
 use crate::{
-    Data, Error, ErrorKind, FrameCount, InputCallbackInfo, InputStreamTimestamp,
-    OutputCallbackInfo, OutputStreamTimestamp, SampleFormat, StreamInstant,
+    CallbackInfo, Data, Error, ErrorKind, FrameCount, SampleFormat, StreamInstant, StreamTimestamp,
     host::{ErrorCallbackArc, emit_error, latch::Latch},
     traits::StreamTrait,
 };
@@ -200,7 +199,7 @@ impl Stream {
         error_callback: E,
     ) -> Result<Self, Error>
     where
-        D: FnMut(&mut Data, &OutputCallbackInfo) + Send + 'static,
+        D: FnMut(&mut Data, &CallbackInfo) + Send + 'static,
         E: FnMut(Error) + Send + 'static,
     {
         let start = Instant::now();
@@ -269,9 +268,9 @@ impl Stream {
                 let latency = stored_latency.saturating_sub(elapsed_since_poll);
 
                 let playback_time = elapsed + Duration::from_micros(latency);
-                let timestamp = OutputStreamTimestamp {
+                let timestamp = StreamTimestamp {
                     callback: StreamInstant::new(elapsed.as_secs(), elapsed.subsec_nanos()),
-                    playback: StreamInstant::new(
+                    device: StreamInstant::new(
                         playback_time.as_secs(),
                         playback_time.subsec_nanos(),
                     ),
@@ -286,7 +285,14 @@ impl Stream {
                 let mut data =
                     unsafe { Data::from_parts(buf.as_mut_ptr().cast(), n_samples, format) };
 
-                data_callback(&mut data, &OutputCallbackInfo { timestamp });
+                // TODO: real underrun status when https://github.com/colinmarc/pulseaudio-rs/pull/10 is merged.
+                data_callback(
+                    &mut data,
+                    &CallbackInfo {
+                        timestamp,
+                        xrun: false,
+                    },
+                );
 
                 // Notify the latency thread that audio was written, so it updates timing info.
                 let (lock, cvar) = &*update_callback;
@@ -396,7 +402,7 @@ impl Stream {
         mut error_callback: E,
     ) -> Result<Self, Error>
     where
-        D: FnMut(&Data, &InputCallbackInfo) + Send + 'static,
+        D: FnMut(&Data, &CallbackInfo) + Send + 'static,
         E: FnMut(Error) + Send + 'static,
     {
         let start = Instant::now();
@@ -441,9 +447,9 @@ impl Stream {
                 .checked_sub(Duration::from_micros(latency))
                 .unwrap_or_default();
 
-            let timestamp = InputStreamTimestamp {
+            let timestamp = StreamTimestamp {
                 callback: StreamInstant::new(elapsed.as_secs(), elapsed.subsec_nanos()),
-                capture: StreamInstant::new(capture_time.as_secs(), capture_time.subsec_nanos()),
+                device: StreamInstant::new(capture_time.as_secs(), capture_time.subsec_nanos()),
             };
 
             let bps = sample_spec.format.bytes_per_sample();
@@ -456,7 +462,14 @@ impl Stream {
             // exposes shared references (&[T]), so no mutation occurs.
             let data = unsafe { Data::from_parts(buf.as_ptr() as *mut _, n_samples, format) };
 
-            data_callback(&data, &InputCallbackInfo { timestamp });
+            // TODO: real overrun status when https://github.com/colinmarc/pulseaudio-rs/pull/10 is merged.
+            data_callback(
+                &data,
+                &CallbackInfo {
+                    timestamp,
+                    xrun: false,
+                },
+            );
 
             // Notify the latency thread that audio was read, so it updates timing info.
             let (lock, cvar) = &*update_callback;

--- a/src/host/wasapi/device.rs
+++ b/src/host/wasapi/device.rs
@@ -13,9 +13,9 @@ use std::{
 };
 
 use crate::{
-    BufferSize, COMMON_SAMPLE_RATES, Data, DeviceDescription, DeviceDescriptionBuilder,
-    DeviceDirection, DeviceId, DeviceType, Error, ErrorKind, FrameCount, InputCallbackInfo,
-    InterfaceType, OutputCallbackInfo, SampleFormat, SampleRate, StreamConfig, SupportedBufferSize,
+    BufferSize, COMMON_SAMPLE_RATES, CallbackInfo, Data, DeviceDescription,
+    DeviceDescriptionBuilder, DeviceDirection, DeviceId, DeviceType, Error, ErrorKind, FrameCount,
+    InterfaceType, SampleFormat, SampleRate, StreamConfig, SupportedBufferSize,
     SupportedStreamConfig, SupportedStreamConfigRange,
     error::ResultExt,
     host::{ErrorCallbackArc, com::ComString},
@@ -126,7 +126,7 @@ impl DeviceTrait for Device {
         timeout: Option<Duration>,
     ) -> Result<Self::Stream, Error>
     where
-        D: FnMut(&Data, &InputCallbackInfo) + Send + 'static,
+        D: FnMut(&Data, &CallbackInfo) + Send + 'static,
         E: FnMut(Error) + Send + 'static,
     {
         let stream_inner = self.build_input_stream_raw_inner(config, sample_format, timeout)?;
@@ -146,7 +146,7 @@ impl DeviceTrait for Device {
         timeout: Option<Duration>,
     ) -> Result<Self::Stream, Error>
     where
-        D: FnMut(&mut Data, &OutputCallbackInfo) + Send + 'static,
+        D: FnMut(&mut Data, &CallbackInfo) + Send + 'static,
         E: FnMut(Error) + Send + 'static,
     {
         // Keep `playback` monotonic: an underrun can saturate `buffered` to zero, pulling

--- a/src/host/wasapi/stream.rs
+++ b/src/host/wasapi/stream.rs
@@ -18,12 +18,9 @@ use windows::Win32::{
 };
 
 use crate::{
-    Data, Error, ErrorKind, FrameCount, InputCallbackInfo, InputStreamTimestamp,
-    OutputCallbackInfo, OutputStreamTimestamp, ResultExt, SampleFormat, SampleRate, StreamConfig,
-    StreamInstant,
-    host::{
-        ErrorCallbackArc, emit_error, equilibrium::fill_equilibrium, latch::Latch, try_emit_error,
-    },
+    CallbackInfo, Data, Error, ErrorKind, FrameCount, ResultExt, SampleFormat, SampleRate,
+    StreamConfig, StreamInstant, StreamTimestamp,
+    host::{ErrorCallbackArc, emit_error, equilibrium::fill_equilibrium, latch::Latch},
     traits::StreamTrait,
 };
 
@@ -321,7 +318,7 @@ impl Stream {
         default_device_monitor: Option<DefaultDeviceMonitor>,
     ) -> Result<Stream, Error>
     where
-        D: FnMut(&Data, &InputCallbackInfo) + Send + 'static,
+        D: FnMut(&Data, &CallbackInfo) + Send + 'static,
     {
         let pending_scheduled_event = unsafe {
             Threading::CreateEventA(None, false, false, windows::core::PCSTR(ptr::null()))
@@ -397,7 +394,7 @@ impl Stream {
         default_device_monitor: Option<DefaultDeviceMonitor>,
     ) -> Result<Stream, Error>
     where
-        D: FnMut(&mut Data, &OutputCallbackInfo) + Send + 'static,
+        D: FnMut(&mut Data, &CallbackInfo) + Send + 'static,
     {
         let pending_scheduled_event = unsafe {
             Threading::CreateEventA(None, false, false, windows::core::PCSTR(ptr::null()))
@@ -657,7 +654,7 @@ fn get_available_frames(stream: &StreamInner) -> Result<FrameCount, Error> {
 
 fn run_input(
     mut run_ctxt: RunContext,
-    data_callback: &mut dyn FnMut(&Data, &InputCallbackInfo),
+    data_callback: &mut dyn FnMut(&Data, &CallbackInfo),
     error_callback: &ErrorCallbackArc,
 ) {
     #[cfg(feature = "realtime")]
@@ -678,12 +675,7 @@ fn run_input(
             AudioClientFlow::Capture { ref capture_client } => capture_client.clone(),
             _ => unreachable!(),
         };
-        if let Err(err) = process_input(
-            &run_ctxt.stream,
-            capture_client,
-            data_callback,
-            error_callback,
-        ) {
+        if let Err(err) = process_input(&run_ctxt.stream, capture_client, data_callback) {
             emit_error(error_callback, err);
             break;
         }
@@ -692,7 +684,7 @@ fn run_input(
 
 fn run_output(
     mut run_ctxt: RunContext,
-    data_callback: &mut dyn FnMut(&mut Data, &OutputCallbackInfo),
+    data_callback: &mut dyn FnMut(&mut Data, &CallbackInfo),
     error_callback: &ErrorCallbackArc,
 ) {
     #[cfg(feature = "realtime")]
@@ -822,8 +814,7 @@ fn process_commands_and_await_signal(
 fn process_input(
     stream: &StreamInner,
     capture_client: Audio::IAudioCaptureClient,
-    data_callback: &mut dyn FnMut(&Data, &InputCallbackInfo),
-    error_callback: &ErrorCallbackArc,
+    data_callback: &mut dyn FnMut(&Data, &CallbackInfo),
 ) -> Result<(), Error> {
     unsafe {
         // Get the available data in the shared buffer.
@@ -852,9 +843,7 @@ fn process_input(
             }
 
             let flags = flags.assume_init();
-            if flags & Audio::AUDCLNT_BUFFERFLAGS_DATA_DISCONTINUITY.0 as u32 != 0 {
-                let _ = try_emit_error(error_callback, ErrorKind::Xrun.into());
-            }
+            let xrun = flags & Audio::AUDCLNT_BUFFERFLAGS_DATA_DISCONTINUITY.0 as u32 != 0;
 
             debug_assert!(!buffer.is_null());
 
@@ -866,7 +855,7 @@ fn process_input(
             if !stream.draining.load(Ordering::Relaxed) {
                 // The `qpc_position` is in 100 nanosecond units. Convert it to nanoseconds.
                 let timestamp = input_timestamp(stream, qpc_position)?;
-                data_callback(&data, &InputCallbackInfo { timestamp });
+                data_callback(&data, &CallbackInfo { timestamp, xrun });
             }
 
             // Release the buffer.
@@ -881,7 +870,7 @@ fn process_input(
 fn process_output(
     stream: &StreamInner,
     render_client: Audio::IAudioRenderClient,
-    data_callback: &mut dyn FnMut(&mut Data, &OutputCallbackInfo),
+    data_callback: &mut dyn FnMut(&mut Data, &CallbackInfo),
     clock_frequency: u64,
     frames_written: &mut u64,
 ) -> Result<(), Error> {
@@ -920,7 +909,14 @@ fn process_output(
             let sample_rate = stream.config.sample_rate;
             let timestamp =
                 output_timestamp(stream, sample_rate, clock_frequency, *frames_written)?;
-            data_callback(&mut data, &OutputCallbackInfo { timestamp });
+            // WASAPI exposes no render-side xrun signal.
+            data_callback(
+                &mut data,
+                &CallbackInfo {
+                    timestamp,
+                    xrun: false,
+                },
+            );
         }
 
         render_client.ReleaseBuffer(frames_available, 0)?;
@@ -961,7 +957,7 @@ fn clock_position(stream: &StreamInner) -> Result<(StreamInstant, u64), Error> {
 fn input_timestamp(
     stream: &StreamInner,
     buffer_qpc_position: u64,
-) -> Result<InputStreamTimestamp, Error> {
+) -> Result<StreamTimestamp, Error> {
     // The `qpc_position` is in 100-nanosecond units.
     let nanos = buffer_qpc_position as u128 * 100;
     let capture = StreamInstant::new(
@@ -969,7 +965,10 @@ fn input_timestamp(
         (nanos % 1_000_000_000) as u32,
     );
     let (callback, _position) = clock_position(stream)?;
-    Ok(InputStreamTimestamp { capture, callback })
+    Ok(StreamTimestamp {
+        device: capture,
+        callback,
+    })
 }
 
 /// Produce the output stream timestamp.
@@ -987,7 +986,7 @@ fn output_timestamp(
     sample_rate: SampleRate,
     clock_frequency: u64,
     frames_written: u64,
-) -> Result<OutputStreamTimestamp, Error> {
+) -> Result<StreamTimestamp, Error> {
     let (callback, position) = clock_position(stream)?;
     // `buffered` is the amount of audio we've already submitted that has not yet been consumed by
     // the device at this instant; it determines when the next written frame will be heard.
@@ -998,5 +997,8 @@ fn output_timestamp(
     let buffered = Duration::from_nanos(buffered_nanos);
 
     let playback = callback + (buffered + stream.stream_latency);
-    Ok(OutputStreamTimestamp { callback, playback })
+    Ok(StreamTimestamp {
+        callback,
+        device: playback,
+    })
 }

--- a/src/host/webaudio/mod.rs
+++ b/src/host/webaudio/mod.rs
@@ -23,17 +23,17 @@ use futures_channel::mpsc;
 #[cfg(target_feature = "atomics")]
 use futures_util::StreamExt as _;
 
-type OutputDataCallbackArc = Arc<Mutex<dyn FnMut(&mut Data, &OutputCallbackInfo) + Send>>;
+type OutputDataCallbackArc = Arc<Mutex<dyn FnMut(&mut Data, &CallbackInfo) + Send>>;
 
 use self::{
     wasm_bindgen::{JsCast, prelude::*},
     web_sys::{AudioContext, AudioContextOptions},
 };
 use crate::{
-    BufferSize, ChannelCount, Data, DeviceDescription, DeviceDescriptionBuilder, DeviceDirection,
-    DeviceId, Error, ErrorKind, FrameCount, InputCallbackInfo, OutputCallbackInfo,
-    OutputStreamTimestamp, SampleFormat, SampleRate, StreamConfig, StreamInstant,
-    SupportedBufferSize, SupportedStreamConfig, SupportedStreamConfigRange,
+    BufferSize, CallbackInfo, ChannelCount, Data, DeviceDescription, DeviceDescriptionBuilder,
+    DeviceDirection, DeviceId, Error, ErrorKind, FrameCount, SampleFormat, SampleRate,
+    StreamConfig, StreamInstant, StreamTimestamp, SupportedBufferSize, SupportedStreamConfig,
+    SupportedStreamConfigRange,
     host::ErrorCallbackArc,
     traits::{DeviceTrait, HostTrait, StreamTrait},
 };
@@ -251,7 +251,7 @@ impl DeviceTrait for Device {
         _timeout: Option<Duration>,
     ) -> Result<Self::Stream, Error>
     where
-        D: FnMut(&Data, &InputCallbackInfo) + Send + 'static,
+        D: FnMut(&Data, &CallbackInfo) + Send + 'static,
         E: FnMut(Error) + Send + 'static,
     {
         Err(Error::with_message(
@@ -270,7 +270,7 @@ impl DeviceTrait for Device {
         _timeout: Option<Duration>,
     ) -> Result<Self::Stream, Error>
     where
-        D: FnMut(&mut Data, &OutputCallbackInfo) + Send + 'static,
+        D: FnMut(&mut Data, &CallbackInfo) + Send + 'static,
         E: FnMut(Error) + Send + 'static,
     {
         crate::validate_stream_config(&config)?;
@@ -318,8 +318,8 @@ impl DeviceTrait for Device {
         })?;
         let buffer_time_step_secs = buffer_time_step_secs(buffer_size_frames, config.sample_rate);
 
-        // Keep `playback` monotonic: outputLatency can drop (e.g. the page calls `setSinkId()` to
-        // switch output devices), which would pull `playback` backward.
+        // Keep `device` monotonic: outputLatency can drop (e.g. the page calls `setSinkId()` to
+        // switch output devices), which would pull `device` backward.
         let data_callback = crate::host::monotonic_output_callback(data_callback);
         let data_callback: OutputDataCallbackArc = Arc::new(Mutex::new(data_callback));
         let error_callback: ErrorCallbackArc = Arc::new(Mutex::new(error_callback));
@@ -466,11 +466,14 @@ impl DeviceTrait for Device {
                                     if sum.is_finite() { sum.max(0.0) } else { 0.0 }
                                 };
                                 let callback = StreamInstant::from_secs_f64(now);
-                                let playback = StreamInstant::from_secs_f64(
+                                let device = StreamInstant::from_secs_f64(
                                     time_at_start_of_buffer + total_hw_latency_secs,
                                 );
-                                let timestamp = OutputStreamTimestamp { callback, playback };
-                                let info = OutputCallbackInfo { timestamp };
+                                let timestamp = StreamTimestamp { callback, device };
+                                let info = CallbackInfo {
+                                    timestamp,
+                                    xrun: false,
+                                };
                                 (data_callback.deref_mut())(&mut data, &info);
                             }
                             Err(_) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,7 @@
 //! # let config = device.default_output_config().unwrap().into();
 //! let stream = device.build_output_stream(
 //!     config,
-//!     move |data: &mut [f32], _: &cpal::OutputCallbackInfo| {
+//!     move |data: &mut [f32], _: &cpal::CallbackInfo| {
 //!         // react to stream events and read or write stream data here.
 //!     },
 //!     move |err| {
@@ -116,7 +116,7 @@
 //!     sample_format => panic!("Unsupported sample format '{sample_format}'")
 //! }.unwrap();
 //!
-//! fn write_silence<T: Sample>(data: &mut [T], _: &cpal::OutputCallbackInfo) {
+//! fn write_silence<T: Sample>(data: &mut [T], _: &cpal::CallbackInfo) {
 //!     for sample in data.iter_mut() {
 //!         *sample = Sample::EQUILIBRIUM;
 //!     }
@@ -133,7 +133,7 @@
 //! # let supported_config = device.default_output_config().unwrap();
 //! # let sample_format = supported_config.sample_format();
 //! # let config = supported_config.into();
-//! # let data_fn = move |_data: &mut cpal::Data, _: &cpal::OutputCallbackInfo| {};
+//! # let data_fn = move |_data: &mut cpal::Data, _: &cpal::CallbackInfo| {};
 //! # let err_fn = move |_err| {};
 //! # let stream = device.build_output_stream_raw(config, sample_format, data_fn, err_fn, None).unwrap();
 //! stream.start().unwrap();
@@ -156,7 +156,7 @@
 //! # let supported_config = device.default_output_config().unwrap();
 //! # let sample_format = supported_config.sample_format();
 //! # let config = supported_config.into();
-//! # let data_fn = move |_data: &mut cpal::Data, _: &cpal::OutputCallbackInfo| {};
+//! # let data_fn = move |_data: &mut cpal::Data, _: &cpal::CallbackInfo| {};
 //! # let err_fn = move |_err| {};
 //! # let stream = device.build_output_stream_raw(config, sample_format, data_fn, err_fn, None).unwrap();
 //! stream.start().unwrap();
@@ -172,7 +172,7 @@
 //! # let supported_config = device.default_output_config().unwrap();
 //! # let sample_format = supported_config.sample_format();
 //! # let config = supported_config.into();
-//! # let data_fn = move |_data: &mut cpal::Data, _: &cpal::OutputCallbackInfo| {};
+//! # let data_fn = move |_data: &mut cpal::Data, _: &cpal::CallbackInfo| {};
 //! # let err_fn = move |_err| {};
 //! # let stream = device.build_output_stream_raw(config, sample_format, data_fn, err_fn, None).unwrap();
 //! stream.start().unwrap();
@@ -551,10 +551,7 @@ pub struct Data {
 }
 
 pub use duplex::{DuplexCallbackInfo, DuplexStreamConfig};
-pub use timestamp::{
-    InputCallbackInfo, InputStreamTimestamp, OutputCallbackInfo, OutputStreamTimestamp,
-    StreamInstant,
-};
+pub use timestamp::{CallbackInfo, StreamInstant, StreamTimestamp};
 
 impl SupportedStreamConfig {
     pub fn new(

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -477,7 +477,7 @@ macro_rules! impl_platform_host {
                 timeout: Option<std::time::Duration>,
             ) -> Result<Self::Stream, crate::Error>
             where
-                D: FnMut(&crate::Data, &crate::InputCallbackInfo) + Send + 'static,
+                D: FnMut(&crate::Data, &crate::CallbackInfo) + Send + 'static,
                 E: FnMut(crate::Error) + Send + 'static,
             {
                 match self.0 {
@@ -506,7 +506,7 @@ macro_rules! impl_platform_host {
                 timeout: Option<std::time::Duration>,
             ) -> Result<Self::Stream, crate::Error>
             where
-                D: FnMut(&mut crate::Data, &crate::OutputCallbackInfo) + Send + 'static,
+                D: FnMut(&mut crate::Data, &crate::CallbackInfo) + Send + 'static,
                 E: FnMut(crate::Error) + Send + 'static,
             {
                 match self.0 {

--- a/src/timestamp.rs
+++ b/src/timestamp.rs
@@ -40,38 +40,31 @@ pub struct StreamInstant {
     nanos: u32,
 }
 
-/// A timestamp associated with a call to an input stream's data callback.
+/// A timestamp associated with a call to a stream's data callback.
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
-pub struct InputStreamTimestamp {
+pub struct StreamTimestamp {
     /// The instant the stream's data callback was invoked.
     pub callback: StreamInstant,
-    /// The instant that data was captured from the device.
-    ///
-    /// E.g. The instant data was read from an ADC.
-    pub capture: StreamInstant,
+    /// For an input stream, the instant data was captured from the device (e.g. read from an
+    /// ADC). For an output stream, the predicted instant data will be delivered to the device
+    /// (e.g. played by a DAC).
+    pub device: StreamInstant,
 }
 
-/// A timestamp associated with a call to an output stream's data callback.
+/// Information relevant to a single call to the user's stream data callback.
+///
+/// Whether [`xrun`][CallbackInfo::xrun] reflects a glitch from exactly this block of samples, or
+/// one detected up to a callback earlier, depends on the host:
+///
+/// | Guarantee | Hosts |
+/// | --------- | ----- |
+/// | Same-cycle | AAudio, ALSA, PipeWire, WASAPI (capture) |
+/// | Next-cycle | CoreAudio |
+/// | No ordering guarantee | ASIO, JACK |
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
-pub struct OutputStreamTimestamp {
-    /// The instant the stream's data callback was invoked.
-    pub callback: StreamInstant,
-    /// The predicted instant that data written will be delivered to the device for playback.
-    ///
-    /// E.g. The instant data will be played by a DAC.
-    pub playback: StreamInstant,
-}
-
-/// Information relevant to a single call to the user's input stream data callback.
-#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
-pub struct InputCallbackInfo {
-    pub(crate) timestamp: InputStreamTimestamp,
-}
-
-/// Information relevant to a single call to the user's output stream data callback.
-#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
-pub struct OutputCallbackInfo {
-    pub(crate) timestamp: OutputStreamTimestamp,
+pub struct CallbackInfo {
+    pub(crate) timestamp: StreamTimestamp,
+    pub(crate) xrun: bool,
 }
 
 impl StreamInstant {
@@ -244,25 +237,19 @@ impl std::ops::Sub<StreamInstant> for StreamInstant {
     }
 }
 
-impl InputCallbackInfo {
-    pub fn new(timestamp: InputStreamTimestamp) -> Self {
-        Self { timestamp }
+impl CallbackInfo {
+    pub fn new(timestamp: StreamTimestamp, xrun: bool) -> Self {
+        Self { timestamp, xrun }
     }
 
-    /// The timestamp associated with the call to an input stream's data callback.
-    pub fn timestamp(&self) -> InputStreamTimestamp {
+    /// The timestamp associated with the call to the stream's data callback.
+    pub fn timestamp(&self) -> StreamTimestamp {
         self.timestamp
     }
-}
 
-impl OutputCallbackInfo {
-    pub fn new(timestamp: OutputStreamTimestamp) -> Self {
-        Self { timestamp }
-    }
-
-    /// The timestamp associated with the call to an output stream's data callback.
-    pub fn timestamp(&self) -> OutputStreamTimestamp {
-        self.timestamp
+    /// Whether a buffer overrun/underrun occurred for this call to the data callback.
+    pub fn xrun(&self) -> bool {
+        self.xrun
     }
 }
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -12,9 +12,9 @@ use std::{
 };
 
 use crate::{
-    Data, DeviceDescription, DeviceId, DuplexCallbackInfo, DuplexStreamConfig, Error, ErrorKind,
-    InputCallbackInfo, InputDevices, OutputCallbackInfo, OutputDevices, SampleFormat, SizedSample,
-    StreamConfig, StreamInstant, SupportedStreamConfig, SupportedStreamConfigRange,
+    CallbackInfo, Data, DeviceDescription, DeviceId, DuplexCallbackInfo, DuplexStreamConfig, Error,
+    ErrorKind, InputDevices, OutputDevices, SampleFormat, SizedSample, StreamConfig, StreamInstant,
+    SupportedStreamConfig, SupportedStreamConfigRange,
 };
 
 /// A [`Host`] provides access to the available audio devices on the system.
@@ -275,7 +275,7 @@ pub trait DeviceTrait: PartialEq + Eq + Hash + Debug + Display + Send + Sync {
     ) -> Result<Self::Stream, Error>
     where
         T: SizedSample,
-        D: FnMut(&[T], &InputCallbackInfo) + Send + 'static,
+        D: FnMut(&[T], &CallbackInfo) + Send + 'static,
         E: FnMut(Error) + Send + 'static,
     {
         self.build_input_stream_raw(
@@ -331,7 +331,7 @@ pub trait DeviceTrait: PartialEq + Eq + Hash + Debug + Display + Send + Sync {
     ) -> Result<Self::Stream, Error>
     where
         T: SizedSample,
-        D: FnMut(&mut [T], &OutputCallbackInfo) + Send + 'static,
+        D: FnMut(&mut [T], &CallbackInfo) + Send + 'static,
         E: FnMut(Error) + Send + 'static,
     {
         self.build_output_stream_raw(
@@ -390,7 +390,7 @@ pub trait DeviceTrait: PartialEq + Eq + Hash + Debug + Display + Send + Sync {
         timeout: Option<Duration>,
     ) -> Result<Self::Stream, Error>
     where
-        D: FnMut(&Data, &InputCallbackInfo) + Send + 'static,
+        D: FnMut(&Data, &CallbackInfo) + Send + 'static,
         E: FnMut(Error) + Send + 'static;
 
     /// Create a dynamically typed output stream.
@@ -435,7 +435,7 @@ pub trait DeviceTrait: PartialEq + Eq + Hash + Debug + Display + Send + Sync {
         timeout: Option<Duration>,
     ) -> Result<Self::Stream, Error>
     where
-        D: FnMut(&mut Data, &OutputCallbackInfo) + Send + 'static,
+        D: FnMut(&mut Data, &CallbackInfo) + Send + 'static,
         E: FnMut(Error) + Send + 'static;
 
     /// Create a synchronized duplex stream whose input and output share the same clock
@@ -655,8 +655,8 @@ pub trait StreamTrait: Send + Sync {
     /// `capture`, or `playback` instant already delivered to the stream's data callback.
     ///
     /// The returned value shares the same time base as the [`StreamInstant`]s delivered to the
-    /// stream's data callback via [`crate::InputStreamTimestamp::callback`] and
-    /// [`crate::OutputStreamTimestamp::callback`], so durations between them are meaningful.
+    /// stream's data callback via [`crate::StreamTimestamp::callback`] and
+    /// [`crate::StreamTimestamp::callback`], so durations between them are meaningful.
     fn now(&self) -> StreamInstant;
 }
 


### PR DESCRIPTION
This PR came out of a [Discord discussion](https://discord.com/channels/590254806208217089/672897096826748948/1525258777949900810) with @BillyDM and @edwloef about where xrun status belongs.

Currently xruns are reported in the error callback, which have no ordering guarantee relative to the data callback. The issue with this is that for engines to skip forward to stay in sync with something else needs to know which data callback followed a glitch. That only works if the flag rides along with the data itself, not through a side channel.

RtAudio does the same thing.

With this PR:

- `ErrorKind::Xrun` is gone in favor of `CallbackInfo::xrun()`.
- `InputCallbackInfo`/`OutputCallbackInfo` are unified into `CallbackInfo`, `InputStreamTimestamp`/`OutputStreamTimestamp` into `StreamTimestamp`.
- `DuplexCallbackInfo` is now `{ input: CallbackInfo, output: CallbackInfo }`.
- PulseAudio's `NoData` is now more accurately mapped to `BackendError` instead of guessing it's an xrun.
