### PR TITLE
Remove `is_format_supported` calls in wasapi `build_*_stream_inner`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **WASAPI**: Default device changes no longer report `DeviceChanged`, which wrongly implied the stream had rerouted automatically.
 - **WASAPI**: Reported buffer sizes are no longer off by one frame.
 - **WASAPI**: `Stream::drop`, `play`, and `pause` no longer panic when the device is lost.
+- **WASAPI**: Output streams no longer reject formats that the built-in resampler can convert.
 - **WebAudio**: Fix stale audio output when a data callback wrote a partial buffer.
 - **WebAudio**: Fix unsound `Send + Sync` on `Stream` when compiled with `+atomics`.
 - **WebAudio**: Fix `Host::is_available()` always returning `true`, even in non-window contexts.

--- a/src/host/wasapi/device.rs
+++ b/src/host/wasapi/device.rs
@@ -866,18 +866,6 @@ impl Device {
                     })?;
                 let share_mode = Audio::AUDCLNT_SHAREMODE_SHARED;
 
-                // Ensure the format is supported.
-                match super::device::is_format_supported(&audio_client, &format_attempt.Format) {
-                    Ok(false) => {
-                        return Err(Error::with_message(
-                            ErrorKind::UnsupportedConfig,
-                            "Stream configuration is not supported in shared mode",
-                        ))
-                    }
-                    Err(e) => return Err(e),
-                    _ => (),
-                }
-
                 // Finally, initializing the audio client
                 audio_client
                     .Initialize(
@@ -978,18 +966,6 @@ impl Device {
                         )
                     })?;
                 let share_mode = Audio::AUDCLNT_SHAREMODE_SHARED;
-
-                // Ensure the format is supported.
-                match super::device::is_format_supported(&audio_client, &format_attempt.Format) {
-                    Ok(false) => {
-                        return Err(Error::with_message(
-                            ErrorKind::UnsupportedConfig,
-                            "Stream configuration is not supported in shared mode",
-                        ))
-                    }
-                    Err(e) => return Err(e),
-                    _ => (),
-                }
 
                 // Finally, initializing the audio client
                 audio_client


### PR DESCRIPTION
"During stream creation we’re gating on `is_format_supported` when we shouldn’t. This is inconsistent with enumeration. The resampler would handle it."

I finally got the opportunity to verify this works.