### PR TITLE
Re-export volume-related `alsa` types for better control and avoiding version discrepancies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,7 +94,7 @@ dasp_sample = "0.11"
 [dev-dependencies]
 anyhow = "1.0"
 hound = "3.5"
-ringbuf = "0.4"
+ringbuf = "0.5.1"
 clap = { version = ">=4.6, <5", features = ["derive"] }
 
 # `windows` and `windows-core` must be the same minor version.
@@ -121,8 +121,8 @@ num-traits = { version = "0.2", optional = true }
 jack = { version = "0.13.5", optional = true }
 
 [target.'cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "netbsd"))'.dependencies]
-alsa = "0.11"
-alsa-sys = { version = "0.4", optional = true }
+alsa = "0.12"
+alsa-sys = { version = "0.6", optional = true }
 libc = "0.2"
 audio_thread_priority = { version = "0.35", optional = true, default-features = false }
 jack = { version = "0.13.5", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -524,6 +524,14 @@ pub struct Data {
     sample_format: SampleFormat,
 }
 
+#[cfg(any(
+    target_os = "linux",
+    target_os = "dragonfly",
+    target_os = "freebsd",
+    target_os = "netbsd",
+))]
+pub use alsa::mixer::{Mixer, Selem, SelemChannelId, SelemId};
+
 pub use timestamp::{
     InputCallbackInfo, InputStreamTimestamp, OutputCallbackInfo, OutputStreamTimestamp,
     StreamInstant,


### PR DESCRIPTION
On an application I'm working in, I would like to have better control of the system volume to allow users to choose between bit-perfect (system-wide) and resampled (application only) output modes. Right now, I need to add `alsa` as a separate dependency, which leads to version discrepancies between `cpal` (which currently uses "0.11") and the latest `alsa` version ("0.12").

That's why I though re-exporting the volume-related types would avoid this issue. What do you think about it? :)