### PR TITLE
fix(jack): make DeviceId stable across restarts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **CoreAudio**: Fix stale audio output when a data callback wrote a partial buffer.
 - **JACK**: Streams with more channels than physical system ports no longer fail to build.
 - **JACK**: Channel enumeration is no longer capped at the physical system port count.
+- **JACK**: `Device::id` no longer embeds the process ID, so `DeviceId` is now stable across application restarts.
 - **PipeWire**: Fix streams starting audio before `play()` is called.
 - **PipeWire**: Streams for a specific device no longer auto-reroute if it disappears.
 - **PulseAudio**: `NoData` errors are no longer misreported as buffer xruns.

--- a/src/host/jack/device.rs
+++ b/src/host/jack/device.rs
@@ -64,7 +64,12 @@ impl Device {
     }
 
     fn id(&self) -> Result<DeviceId, Error> {
-        Ok(DeviceId::new(crate::platform::HostId::Jack, &self.name))
+        // `self.name` carries the process ID (see `Host::new`) so that concurrent cpal
+        // instances get distinct JACK client names. It must not leak into `DeviceId`,
+        // which callers persist across restarts (see #1279): a synthetic device's
+        // direction is the only part of its identity that's actually stable.
+        let id = if self.is_input() { "input" } else { "output" };
+        Ok(DeviceId::new(crate::platform::HostId::Jack, id))
     }
 
     pub fn default_output_device(
@@ -143,7 +148,14 @@ impl DeviceTrait for Device {
     type Stream = Stream;
 
     fn description(&self) -> Result<DeviceDescription, Error> {
-        Ok(DeviceDescriptionBuilder::new(self.name.clone())
+        // Not `self.name`: that's the JACK client name, which carries a process ID
+        // uniquifier (see `Host::new`) and isn't meant as a user-facing device label.
+        let name = if self.is_input() {
+            "JACK Input"
+        } else {
+            "JACK Output"
+        };
+        Ok(DeviceDescriptionBuilder::new(name)
             .direction(self.direction)
             .build())
     }


### PR DESCRIPTION
`Device::id()` and `description()` derived from the JACK client name, which embeds the process ID. That broke `DeviceId`'s documented restart-stability contract. Use direction (input/output) instead.

Fixes #1279