### PR TITLE
fix(alsa): timespec segfault with 64-bit time_t on 32-bit systems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Breaking: `ErrorKind::Xrun` (see UPGRADING.md).
 
+### Fixed
+
+- **ALSA**: Fix a remaining timestamp segfault on 32-bit platforms with a 64-bit kernel `time_t`.
+
 ## [Unreleased] (v0.18.2)
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,8 +123,8 @@ num-traits = { version = "0.2", optional = true }
 jack = { version = "0.13.5", optional = true }
 
 [target.'cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "netbsd"))'.dependencies]
-alsa = "0.12"
-alsa-sys = { version = "0.6", optional = true }
+alsa = "0.12.1"
+alsa-sys = { version = "0.6.1", optional = true }
 libc = "0.2"
 audio_thread_priority = { version = "0.35", optional = true, default-features = false }
 jack = { version = "0.13.5", optional = true }

--- a/src/host/alsa/mod.rs
+++ b/src/host/alsa/mod.rs
@@ -762,7 +762,7 @@ struct StreamInner {
 
     // htstamp value from the status query at prepare() time.
     // Used as the creation-time anchor for SystemClock and AudioLink calculations.
-    creation_ts: libc::timespec,
+    creation_ts: alsa::timespec,
 
     // Monotonic instant captured at stream creation. Timestamp origin for CreationInstant
     // mode and last-resort fallback if the status query in now() fails.
@@ -1366,21 +1366,21 @@ fn process_output(
 // https://fossies.org/linux/alsa-lib/test/audio_time.c
 #[inline]
 #[expect(clippy::unnecessary_cast)]
-fn timespec_to_nanos(ts: libc::timespec) -> i64 {
+fn timespec_to_nanos(ts: alsa::timespec) -> i64 {
     ts.tv_sec as i64 * 1_000_000_000 + ts.tv_nsec as i64
 }
 
 // Adapted from `timediff` here:
 // https://fossies.org/linux/alsa-lib/test/audio_time.c
 #[inline]
-fn timespec_diff_nanos(a: libc::timespec, b: libc::timespec) -> i64 {
+fn timespec_diff_nanos(a: alsa::timespec, b: alsa::timespec) -> i64 {
     timespec_to_nanos(a) - timespec_to_nanos(b)
 }
 
 // StreamInstant representing how long htstamp is ahead of origin, clamped to zero.
 // Used as the creation-relative timestamp source for SystemClock and AudioLink fallback paths.
 #[inline]
-fn htstamp_elapsed(status: &alsa::pcm::Status, origin: libc::timespec) -> StreamInstant {
+fn htstamp_elapsed(status: &alsa::pcm::Status, origin: alsa::timespec) -> StreamInstant {
     let nanos = timespec_diff_nanos(status.get_htstamp(), origin);
     StreamInstant::from_nanos(nanos.max(0) as u64)
 }


### PR DESCRIPTION
This stacks with https://github.com/diwic/alsa-rs/pull/158.

@d3d9