### PR TITLE
fix(pipewire): enumerate nodes with internal media classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **JACK**: Channel enumeration is no longer capped at the physical system port count.
 - **JACK**: `Device::id` no longer embeds the process ID, so `DeviceId` is now stable across application restarts.
 - **PipeWire**: Fix streams starting audio before `play()` is called.
+- **PipeWire**: Nodes with an `/Internal` media class are now enumerated as devices.
 - **PipeWire**: Streams for a specific device no longer auto-reroute if it disappears.
 - **PulseAudio**: `NoData` errors are no longer misreported as buffer xruns.
 - **visionOS**: The CoreAudio backend now builds.

--- a/src/host/pipewire/device.rs
+++ b/src/host/pipewire/device.rs
@@ -868,6 +868,9 @@ pub fn init_devices(connect_automatically: Arc<AtomicBool>) -> Option<Vec<Device
                         audio::SINK
                             | audio::SOURCE
                             | audio::DUPLEX
+                            | audio::SINK_INTERNAL
+                            | audio::SOURCE_INTERNAL
+                            | audio::DUPLEX_INTERNAL
                             | audio::STREAM_INPUT
                             | audio::STREAM_OUTPUT
                     ) {
@@ -895,9 +898,9 @@ pub fn init_devices(connect_automatically: Arc<AtomicBool>) -> Option<Vec<Device
                                 return;
                             };
                             let role = match media_class {
-                                audio::SINK => Role::Sink,
-                                audio::SOURCE => Role::Source,
-                                audio::DUPLEX => Role::Duplex,
+                                audio::SINK | audio::SINK_INTERNAL => Role::Sink,
+                                audio::SOURCE | audio::SOURCE_INTERNAL => Role::Source,
+                                audio::DUPLEX | audio::DUPLEX_INTERNAL => Role::Duplex,
                                 audio::STREAM_OUTPUT => Role::StreamOutput,
                                 audio::STREAM_INPUT => Role::StreamInput,
                                 _ => {

--- a/src/host/pipewire/utils.rs
+++ b/src/host/pipewire/utils.rs
@@ -37,6 +37,11 @@ pub mod audio {
     pub const DUPLEX: &str = "Audio/Duplex";
     pub const STREAM_OUTPUT: &str = "Stream/Output/Audio";
     pub const STREAM_INPUT: &str = "Stream/Input/Audio";
+
+    // Hidden from "default device" pickers but still directly connectable.
+    pub const SINK_INTERNAL: &str = "Audio/Sink/Internal";
+    pub const SOURCE_INTERNAL: &str = "Audio/Source/Internal";
+    pub const DUPLEX_INTERNAL: &str = "Audio/Duplex/Internal";
 }
 
 /// Returns the path of the PipeWire socket, checking the standard locations


### PR DESCRIPTION
Fixes @edwloef's [Discord report](https://discord.com/channels/590254806208217089/672897096826748948/1529489292068651058).