### PR TITLE
fix(alsa): use PCM state for suspend handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Timestamps now stay monotonic across device and graph changes.
 - **ALSA**: A nonzero but sub-millisecond stream timeout is no longer treated as a non-blocking poll.
+- **ALSA**: Fix compilation on FreeBSD, DragonFly, and NetBSD.
 - **AudioWorklet**: Fix `Stream` operations to work when called from any thread.
 - **AudioWorklet**: Fix stale audio output when a data callback wrote a partial buffer.
 - **CoreAudio**: Default-output streams now report xrun status.

--- a/src/host/alsa/mod.rs
+++ b/src/host/alsa/mod.rs
@@ -1121,13 +1121,16 @@ fn poll_for_period(
             "Device disconnected",
         ));
     }
-    // POLLERR signals an xrun or suspend; avail_delay() below returns EPIPE/ESTRPIPE accordingly.
+    // POLLERR signals an xrun or suspend; avail_delay() below returns an error accordingly.
     // POLLIN/POLLOUT: data is ready, fall through to process it.
     let (avail_frames, delay_frames) = match stream.handle.avail_delay() {
+        // Suspend: try hardware resume first; fall back to prepare() if unsupported.
+        // BSD compat: check via PCM state rather than the Linux-specific ESTRPIPE errno.
+        Err(_) if matches!(stream.handle.state(), alsa::pcm::State::Suspended) => {
+            return try_resume(&stream.handle);
+        }
         // Xrun: recover via prepare() (+ start() for capture, handled by the worker).
         Err(err) if err.errno() == libc::EPIPE => return Err(ErrorKind::Xrun.into()),
-        // Suspend: try hardware resume first; fall back to prepare() if unsupported.
-        Err(err) if err.errno() == libc::ESTRPIPE => return try_resume(&stream.handle),
         res => res,
     }?;
     // ALSA can have spurious wakeups where poll returns but avail < avail_min.
@@ -1186,9 +1189,10 @@ fn process_input(
             }
             // EPIPE = xrun: full underrun recovery (prepare + start) required.
             Err(err) if err.errno() == libc::EPIPE => return Err(ErrorKind::Xrun.into()),
-            // ESTRPIPE = hardware suspend: try soft resume first, falling back to underrun
-            // recovery if the hardware doesn't support it.
-            Err(err) if err.errno() == libc::ESTRPIPE => {
+            // Suspend: try soft resume first, falling back to underrun recovery if the
+            // hardware doesn't support it. BSD compat: check via PCM state rather than the
+            // Linux-specific ESTRPIPE errno.
+            Err(_) if matches!(stream.handle.state(), alsa::pcm::State::Suspended) => {
                 return try_resume(&stream.handle).map(|_| ());
             }
             Err(err) => return Err(err.into()),
@@ -1254,9 +1258,10 @@ fn process_output(
             }
             // EPIPE = xrun: full underrun recovery (prepare) required.
             Err(err) if err.errno() == libc::EPIPE => return Err(ErrorKind::Xrun.into()),
-            // ESTRPIPE = hardware suspend: try soft resume first, falling back to underrun
-            // recovery if the hardware doesn't support it.
-            Err(err) if err.errno() == libc::ESTRPIPE => {
+            // Suspend: try soft resume first, falling back to underrun recovery if the
+            // hardware doesn't support it. BSD compat: check via PCM state rather than the
+            // Linux-specific ESTRPIPE errno.
+            Err(_) if matches!(stream.handle.state(), alsa::pcm::State::Suspended) => {
                 return try_resume(&stream.handle).map(|_| ());
             }
             Err(err) => return Err(err.into()),


### PR DESCRIPTION
Compare state instead of `errno() == libc::ESTRPIPE` which is only a Linux thing.

Fixes #1290