### PR TITLE
fix(pipewire): prevent bursty real-time promotion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **JACK**: `Device::id` no longer embeds the process ID, so `DeviceId` is now stable across application restarts.
 - **PipeWire**: Fix streams starting audio before `play()` is called.
 - **PipeWire**: Fix rtkit burst limit errors from repeated real-time promotion on quantum jitter.
+- **PipeWire**: Fix real-time promotion blocking the audio callback thread on Linux.
 - **PipeWire**: Nodes with an `/Internal` media class are now enumerated as devices.
 - **PipeWire**: Streams for a specific device no longer auto-reroute if it disappears.
 - **PipeWire**: Build on 32-bit targets without native 64-bit atomics.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **JACK**: Channel enumeration is no longer capped at the physical system port count.
 - **JACK**: `Device::id` no longer embeds the process ID, so `DeviceId` is now stable across application restarts.
 - **PipeWire**: Fix streams starting audio before `play()` is called.
+- **PipeWire**: Fix rtkit burst limit errors from repeated real-time promotion on quantum jitter.
 - **PipeWire**: Nodes with an `/Internal` media class are now enumerated as devices.
 - **PipeWire**: Streams for a specific device no longer auto-reroute if it disappears.
 - **PipeWire**: Build on 32-bit targets without native 64-bit atomics.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **CoreAudio**: Bump `objc2-core-foundation` dependency lower bound to 0.3.1.
+- **Linux**: Clarify that `realtime` alone is a no-op without `realtime-dbus`.
 - **iOS**: Timestamps now include hardware latency and update when the audio route changes.
 - **JACK**: Timestamps now include port latency.
 - **PipeWire**: Devices with multiple ports now get distinct, localized, per-port names.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,14 +17,12 @@ default = []
 
 # Real-time audio thread scheduling
 # Applies platform-specific real-time scheduling and performance modes to audio threads.
-# Requires: (Linux/BSD) `rtprio` granted in `limits.conf` (e.g. `@audio - rtprio 95`)
-# Platform: Linux, DragonFly BSD, FreeBSD, NetBSD, Windows, Android
+# Platform: Android, Windows (see `realtime-dbus` for Linux/BSD)
 realtime = ["dep:audio_thread_priority", "dep:alsa-sys"]
 
-# D-Bus/rtkit support on top of `realtime` for RT scheduling on Linux/BSD desktop systems
+# Enables `realtime` and adds D-Bus/rtkit support, for RT scheduling on Linux/BSD desktop systems
 # Requires: D-Bus development libraries (libdbus-1-dev or equivalent)
-# Platform: Linux, DragonFly BSD, FreeBSD, NetBSD (D-Bus/rtkit is a no-op elsewhere;
-#           `realtime` still applies on Windows and Android)
+# Platform: Linux, DragonFly BSD, FreeBSD, NetBSD
 realtime-dbus = ["realtime", "audio_thread_priority/with_dbus"]
 
 # ASIO backend for Windows

--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ The `audioworklet` backend additionally requires `-Zbuild-std` with atomics supp
 | `jack` | Linux, BSD, macOS, Windows | JACK Audio Connection Kit backend for pro-audio routing and inter-application connectivity. Requires `libjack-jackd2-dev` (Debian/Ubuntu) or `jack-devel` (Fedora). |
 | `pipewire` | Linux, BSD | PipeWire media server backend. Requires `libpipewire-0.3-dev` (Debian/Ubuntu) or `pipewire-devel` (Fedora). |
 | `pulseaudio` | Linux, BSD | PulseAudio sound server backend. Requires `libpulse-dev` (Debian/Ubuntu) or `pulseaudio-libs-devel` (Fedora). |
-| `realtime` | Linux, BSD, Windows, Android | Raises the audio callback thread to real-time or high-priority scheduling for lower latency. On Linux/BSD, requires `rtprio` granted in `limits.conf` (e.g. `@audio - rtprio 95`) unless `realtime-dbus` is also enabled. |
-| `realtime-dbus` | Linux, BSD | Uses `rtkit` via D-Bus for RT scheduling on Linux/BSD desktop systems, removing the need for manual `limits.conf` setup. Implies `realtime` on all platforms. Requires `libdbus-1-dev` on Linux/BSD. |
+| `realtime` | Android, Windows | Raises the audio callback thread to real-time or high-priority scheduling for lower latency. |
+| `realtime-dbus` | Linux, BSD | Uses `rtkit` via D-Bus for RT scheduling on Linux/BSD desktop systems. Implies `realtime` on all platforms. Requires `libdbus-1-dev` on Linux/BSD. |
 | `wasm-bindgen` | WebAssembly (`wasm32-unknown-unknown`) | Web Audio API backend for browser-based audio; required for any WebAssembly audio support. See the `wasm-beep` example. |
 
 See the [beep example](examples/beep.rs) for selecting the backend at runtime.
@@ -186,13 +186,9 @@ RT promotion is only attempted for a whitelist of PCM types: direct hardware PCM
 
 `RealtimeDenied` is emitted on the error callback only when promotion is attempted but fails, which happens when the process lacks the resource limits to acquire `SCHED_FIFO`. While RT priority is desirable for low latency, the stream will continue to play at the default scheduling priority.
 
-With the `realtime-dbus` feature, `rtkit` arranges the necessary limits over D-Bus on typical desktop systems. With the plain `realtime` feature, you must ensure that `rtprio` is granted yourself. Add to `/etc/security/limits.d/audio.conf` and ensure the user is member of the `audio` group:
+On Linux/BSD, use `realtime-dbus`: `rtkit` arranges the necessary limits over D-Bus.
 
-```text
-@audio - rtprio 95
-```
-
-then add the user to the `audio` group (`usermod -aG audio "$USER"`) and re-login. The same group may anyway be needed to grant access to ALSA device files via `udev` on systems that do not arrange this automatically via `logind`.
+Independently of RT scheduling, some systems need the user added to the `audio` group for ALSA device access via `udev` (`usermod -aG audio "$USER"`, then re-login).
 
 ### Build Errors
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -217,16 +217,17 @@ let config = device
 
 ## 6. `audio_thread_priority` feature renamed to `realtime-dbus`
 
-**What changed:** The `audio_thread_priority` feature has been renamed to `realtime-dbus`. A new `realtime` feature was also added, providing the same scheduling promotion without a D-Bus build dependency (suitable for headless or embedded targets).
+**What changed:** The `audio_thread_priority` feature has been renamed to `realtime-dbus`. A new `realtime` feature was also added, without a D-Bus build dependency. It's functional on Windows and Android; on Linux/BSD it's currently a no-op, so use `realtime-dbus` there.
 
 ```toml
 # Before (v0.17)
 cpal = { version = "0.17", features = ["audio_thread_priority"] }
 
 # After (v0.18): rename the feature
+# Android/Windows plus Linux/BSD with D-Bus
 cpal = { version = "0.18", features = ["realtime-dbus"] }
 
-# For systems without D-Bus (embedded, headless, containers):
+# Android/Windows only (no D-Bus dependency)
 cpal = { version = "0.18", features = ["realtime"] }
 ```
 

--- a/src/host/pipewire/mod.rs
+++ b/src/host/pipewire/mod.rs
@@ -9,6 +9,8 @@ use stream::PwInitGuard;
 use crate::{traits::HostTrait, Error, ErrorKind};
 
 mod device;
+#[cfg(all(target_os = "linux", feature = "realtime"))]
+mod rt_promote;
 mod stream;
 mod utils;
 

--- a/src/host/pipewire/rt_promote.rs
+++ b/src/host/pipewire/rt_promote.rs
@@ -1,0 +1,104 @@
+//! Background real-time thread promotion.
+//!
+//! Defers `audio_thread_priority::promote_thread_to_real_time` to a background thread so the
+//! audio callback thread that requests it never blocks -- whether the call ends up going over
+//! D-Bus or making a syscall directly, since either could block.
+//!
+//! Only usable where the crate exposes a cross-thread promotion API at all, i.e. accepts a
+//! thread identity rather than always promoting the caller.
+
+use std::{
+    sync::{
+        atomic::{AtomicBool, AtomicU32, Ordering},
+        Arc,
+    },
+    thread::{self, JoinHandle, Thread},
+};
+
+use crate::{
+    host::{emit_error, ErrorCallbackArc},
+    Error, ErrorKind, FrameCount, SampleRate,
+};
+
+pub(crate) struct RtPromoter {
+    pending_frames: Arc<AtomicU32>,
+    shutdown: Arc<AtomicBool>,
+    handle: Thread,
+    join: Option<JoinHandle<()>>,
+}
+
+impl RtPromoter {
+    /// Must be called on the thread that will run the audio callbacks: `get_current_thread_info`
+    /// captures the calling thread's identity, to promote later from the background thread.
+    pub(crate) fn spawn(error_callback: ErrorCallbackArc, rate: SampleRate) -> Option<Self> {
+        let thread_info = match audio_thread_priority::get_current_thread_info() {
+            Ok(info) => info,
+            Err(e) => {
+                emit_error(&error_callback, Error::from(e));
+                return None;
+            }
+        };
+
+        let pending_frames = Arc::new(AtomicU32::new(0));
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let pending_frames_bg = pending_frames.clone();
+        let shutdown_bg = shutdown.clone();
+        let error_callback_bg = error_callback.clone();
+
+        let join = thread::Builder::new()
+            .name("cpal_rt_promote".to_owned())
+            .spawn(move || loop {
+                if shutdown_bg.load(Ordering::Relaxed) {
+                    return;
+                }
+                let frames = pending_frames_bg.swap(0, Ordering::Relaxed);
+                if frames != 0 {
+                    if let Err(e) = audio_thread_priority::promote_thread_to_real_time(
+                        thread_info,
+                        frames,
+                        rate,
+                    ) {
+                        emit_error(&error_callback_bg, Error::from(e));
+                    }
+                    continue;
+                }
+                thread::park();
+            });
+        let join = match join {
+            Ok(j) => j,
+            Err(e) => {
+                emit_error(
+                    &error_callback,
+                    Error::with_message(
+                        ErrorKind::ResourceExhausted,
+                        format!("failed to create real-time promotion thread: {e}"),
+                    ),
+                );
+                return None;
+            }
+        };
+
+        Some(Self {
+            pending_frames,
+            shutdown,
+            handle: join.thread().clone(),
+            join: Some(join),
+        })
+    }
+
+    /// Hands a promotion request to the background thread; never blocks.
+    pub(crate) fn request(&self, frames: FrameCount) {
+        self.pending_frames.store(frames, Ordering::Relaxed);
+        self.handle.unpark();
+    }
+}
+
+impl Drop for RtPromoter {
+    fn drop(&mut self) {
+        self.shutdown.store(true, Ordering::Relaxed);
+        self.handle.unpark();
+        if let Some(join) = self.join.take() {
+            let _ = join.join();
+        }
+    }
+}

--- a/src/host/pipewire/rt_promote.rs
+++ b/src/host/pipewire/rt_promote.rs
@@ -1,11 +1,4 @@
 //! Background real-time thread promotion.
-//!
-//! Defers `audio_thread_priority::promote_thread_to_real_time` to a background thread so the
-//! audio callback thread that requests it never blocks -- whether the call ends up going over
-//! D-Bus or making a syscall directly, since either could block.
-//!
-//! Only usable where the crate exposes a cross-thread promotion API at all, i.e. accepts a
-//! thread identity rather than always promoting the caller.
 
 use std::{
     sync::{

--- a/src/host/pipewire/stream.rs
+++ b/src/host/pipewire/stream.rs
@@ -233,16 +233,14 @@ pub struct UserData<D> {
     spa_io_clock: *const spa_io_clock,
     xrun_recovering: bool,
     #[cfg(feature = "realtime")]
-    rt_promoted: bool,
+    rt_promoted_frames: FrameCount,
 }
 
 impl<D> UserData<D> {
-    // `#[cold]` because it only runs on the first cycle and whenever PipeWire renegotiates the graph quantum.
     #[cfg(feature = "realtime")]
-    #[cold]
     fn promote_realtime(&mut self, frames: FrameCount) {
-        // Set regardless of success, so a failed promotion isn't retried until the quantum changes.
-        self.rt_promoted = true;
+        // Set regardless of success, so a failed promotion isn't retried until the quantum grows.
+        self.rt_promoted_frames = frames;
         if let Err(e) =
             audio_thread_priority::promote_current_thread_to_real_time(frames, self.format.rate())
         {
@@ -308,17 +306,13 @@ impl<D> UserData<D>
 where
     D: FnMut(&Data, &InputCallbackInfo) + Send + 'static,
 {
-    fn publish_data_in(&mut self, stream: &pw::stream::Stream, frames: usize, data: &Data) {
-        #[cfg(feature = "realtime")]
-        {
-            let prev = self.last_quantum.swap(frames as u32, Ordering::Relaxed);
-            if !self.rt_promoted || frames as u32 != prev {
-                self.promote_realtime(frames as FrameCount);
-            }
-        }
+    fn publish_data_in(&mut self, stream: &pw::stream::Stream, frames: FrameCount, data: &Data) {
+        self.last_quantum.store(frames, Ordering::Relaxed);
 
-        #[cfg(not(feature = "realtime"))]
-        self.last_quantum.store(frames as u32, Ordering::Relaxed);
+        #[cfg(feature = "realtime")]
+        if frames > self.rt_promoted_frames {
+            self.promote_realtime(frames);
+        }
 
         let (callback, capture) = match pw_stream_time(stream) {
             Some(t) => {
@@ -334,7 +328,7 @@ where
                 let cb = monotonic_stream_instant()
                     .unwrap_or_else(|| stream_instant_from_start(self.start));
                 let capture = cb
-                    .checked_sub(frames_to_duration(frames as FrameCount, self.format.rate()))
+                    .checked_sub(frames_to_duration(frames, self.format.rate()))
                     .unwrap_or(StreamInstant::ZERO);
                 (cb, capture)
             }
@@ -349,17 +343,18 @@ impl<D> UserData<D>
 where
     D: FnMut(&mut Data, &OutputCallbackInfo) + Send + 'static,
 {
-    fn publish_data_out(&mut self, stream: &pw::stream::Stream, frames: usize, data: &mut Data) {
-        #[cfg(feature = "realtime")]
-        {
-            let prev = self.last_quantum.swap(frames as u32, Ordering::Relaxed);
-            if !self.rt_promoted || frames as u32 != prev {
-                self.promote_realtime(frames as FrameCount);
-            }
-        }
+    fn publish_data_out(
+        &mut self,
+        stream: &pw::stream::Stream,
+        frames: FrameCount,
+        data: &mut Data,
+    ) {
+        self.last_quantum.store(frames, Ordering::Relaxed);
 
-        #[cfg(not(feature = "realtime"))]
-        self.last_quantum.store(frames as u32, Ordering::Relaxed);
+        #[cfg(feature = "realtime")]
+        if frames > self.rt_promoted_frames {
+            self.promote_realtime(frames);
+        }
 
         let (callback, playback) = match pw_stream_time(stream) {
             Some(t) => {
@@ -374,7 +369,7 @@ where
             None => {
                 let cb = monotonic_stream_instant()
                     .unwrap_or_else(|| stream_instant_from_start(self.start));
-                let pl = cb + frames_to_duration(frames as FrameCount, self.format.rate());
+                let pl = cb + frames_to_duration(frames, self.format.rate());
                 (cb, pl)
             }
         };
@@ -606,7 +601,7 @@ where
         spa_io_clock: std::ptr::null(),
         xrun_recovering: false,
         #[cfg(feature = "realtime")]
-        rt_promoted: false,
+        rt_promoted_frames: 0,
     };
     let channels = config.channels as _;
     let rate = config.sample_rate as _;
@@ -748,7 +743,7 @@ where
                 let data = active.as_mut_ptr() as *mut ();
                 let mut data =
                     unsafe { Data::from_parts(data, n_samples, user_data.sample_format) };
-                user_data.publish_data_out(stream, frames, &mut data);
+                user_data.publish_data_out(stream, frames as FrameCount, &mut data);
                 let chunk = buf_data.chunk_mut();
                 *chunk.offset_mut() = 0;
                 *chunk.stride_mut() = stride as i32;
@@ -777,7 +772,7 @@ where
     // RT_PROCESS is intentionally absent: with add_local_listener the process callback always
     // runs on this mainloop thread, not the separate data-loop thread RT_PROCESS creates.
     // That thread promotes itself to RT from the process callback, once when the negotiated
-    // quantum is known and again whenever PipeWire renegotiates it.
+    // quantum is known and again whenever it grows.
     let mut flags = StreamFlags::MAP_BUFFERS | StreamFlags::INACTIVE;
     if connect_automatically {
         flags |= StreamFlags::AUTOCONNECT;
@@ -862,7 +857,7 @@ where
         spa_io_clock: std::ptr::null(),
         xrun_recovering: false,
         #[cfg(feature = "realtime")]
-        rt_promoted: false,
+        rt_promoted_frames: 0,
     };
 
     let channels = config.channels as _;
@@ -991,7 +986,7 @@ where
                 let data = samples.as_mut_ptr() as *mut ();
                 let data =
                     unsafe { Data::from_parts(data, n_samples as usize, user_data.sample_format) };
-                user_data.publish_data_in(stream, frames as usize, &data);
+                user_data.publish_data_in(stream, frames, &data);
             }
         })
         .register()?;
@@ -1016,7 +1011,7 @@ where
     // RT_PROCESS is intentionally absent: with add_local_listener the process callback always
     // runs on this mainloop thread, not the separate data-loop thread RT_PROCESS creates.
     // That thread promotes itself to RT from the process callback, once when the negotiated
-    // quantum is known and again whenever PipeWire renegotiates it.
+    // quantum is known and again whenever it grows.
     let mut flags = StreamFlags::MAP_BUFFERS | StreamFlags::INACTIVE;
     if connect_automatically {
         flags |= StreamFlags::AUTOCONNECT;

--- a/src/host/pipewire/stream.rs
+++ b/src/host/pipewire/stream.rs
@@ -5,7 +5,7 @@ use std::{
         atomic::{AtomicBool, AtomicU32, Ordering},
         Arc, Mutex,
     },
-    thread::JoinHandle,
+    thread::{self, JoinHandle},
     time::Instant,
 };
 
@@ -31,6 +31,8 @@ use pipewire::{
     types::ObjectType,
 };
 
+#[cfg(all(target_os = "linux", feature = "realtime"))]
+use super::rt_promote::RtPromoter;
 use crate::{
     host::{
         emit_error, equilibrium::fill_equilibrium, frames_to_duration, latch::Latch,
@@ -234,6 +236,8 @@ pub struct UserData<D> {
     xrun_recovering: bool,
     #[cfg(feature = "realtime")]
     rt_promoted_frames: FrameCount,
+    #[cfg(all(target_os = "linux", feature = "realtime"))]
+    rt_promoter: Option<RtPromoter>,
 }
 
 impl<D> UserData<D> {
@@ -241,6 +245,14 @@ impl<D> UserData<D> {
     fn promote_realtime(&mut self, frames: FrameCount) {
         // Set regardless of success, so a failed promotion isn't retried until the quantum grows.
         self.rt_promoted_frames = frames;
+
+        #[cfg(target_os = "linux")]
+        if let Some(promoter) = &self.rt_promoter {
+            promoter.request(frames);
+        }
+
+        #[cfg(not(target_os = "linux"))]
+        // audio_thread_priority has no cross-thread promotion API on this target.
         if let Err(e) =
             audio_thread_priority::promote_current_thread_to_real_time(frames, self.format.rate())
         {
@@ -587,6 +599,8 @@ where
     };
 
     let error_callback_out = error_callback.clone();
+    #[cfg(all(target_os = "linux", feature = "realtime"))]
+    let rt_promoter = RtPromoter::spawn(error_callback.clone(), config.sample_rate);
     let data = UserData {
         data_callback,
         error_callback,
@@ -602,6 +616,8 @@ where
         xrun_recovering: false,
         #[cfg(feature = "realtime")]
         rt_promoted_frames: 0,
+        #[cfg(all(target_os = "linux", feature = "realtime"))]
+        rt_promoter,
     };
     let channels = config.channels as _;
     let rate = config.sample_rate as _;
@@ -843,6 +859,8 @@ where
     };
 
     let error_callback_out = error_callback.clone();
+    #[cfg(all(target_os = "linux", feature = "realtime"))]
+    let rt_promoter = RtPromoter::spawn(error_callback.clone(), config.sample_rate);
     let data = UserData {
         data_callback,
         error_callback,
@@ -858,6 +876,8 @@ where
         xrun_recovering: false,
         #[cfg(feature = "realtime")]
         rt_promoted_frames: 0,
+        #[cfg(all(target_os = "linux", feature = "realtime"))]
+        rt_promoter,
     };
 
     let channels = config.channels as _;

--- a/src/host/pipewire/stream.rs
+++ b/src/host/pipewire/stream.rs
@@ -5,7 +5,7 @@ use std::{
         atomic::{AtomicBool, AtomicU32, Ordering},
         Arc, Mutex,
     },
-    thread::{self, JoinHandle},
+    thread::JoinHandle,
     time::Instant,
 };
 


### PR DESCRIPTION
A user on Discord reported getting 'Failed to promote audio thread to real-time priority: AudioThreadPriorityError: Thread promotion error ("Device or resource busy"): "Device or resource bus"' errors, noticing his quantum size changed on every callback.

This PR fixes that by using a growth-only strategy when the quantum size is jittery (e.g. for non-integer resampling ratios, or to compensate for clock drift, ...)